### PR TITLE
Improve docker deployment configuration and add documentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     environment:
       - POSTGRES_USER=openvsx
       - POSTGRES_PASSWORD=openvsx
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
     logging:
       options:
         max-size: 10m
@@ -14,6 +16,7 @@ services:
     profiles:
       - db
       - debug
+      - openvsx
 
   elasticsearch:
     image: elasticsearch:8.7.1
@@ -23,21 +26,31 @@ services:
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - cluster.routing.allocation.disk.threshold_enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
     ports:
       - 9200:9200
       - 9300:9300
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
     healthcheck:
-      test: curl -s http://elasticsearch01:9200 >/dev/null || exit 1
-      interval: 10s
-      timeout: 5s
-      retries: 50
-      start_period: 5s
+      test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
     profiles:
       - es
       - debug
+      - openvsx
 
   kibana:
     image: kibana:8.7.1
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
     ports:
       - "5601:5601"
     environment:
@@ -48,22 +61,35 @@ services:
       - kibana
 
   server:
-    image: openjdk:17
+    image: openjdk:17-bullseye
     working_dir: /app
-    command: sh -c 'scripts/generate-properties.sh --docker && ./gradlew assemble && ./gradlew runServer'
     volumes:
       - ./server:/app
+      - /etc/localtime:/etc/localtime:ro
+    command: >
+      bash -c '
+        apt-get update && 
+        apt-get install -y curl findutils &&
+        scripts/generate-properties.sh --docker && 
+        ./gradlew assemble && 
+        ./gradlew runServer'
     ports:
-      - 8080:8080
+      - "0.0.0.0:8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+      - ELASTICSEARCH_HOST=elasticsearch
+      - POSTGRES_HOST=postgres
     depends_on:
-      - postgres
-      - elasticsearch
+      elasticsearch:
+        condition: service_healthy
+      postgres:
+        condition: service_started
     healthcheck:
       test: "curl --fail --silent localhost:8081/actuator/health | grep UP || exit 1"
-      interval: 10s
-      timeout: 5s
-      retries: 50
-      start_period: 5s
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
     profiles:
       - openvsx
       - backend
@@ -71,27 +97,14 @@ services:
   webui:
     image: node:18
     working_dir: /app
-    command: sh -c 'yarn && yarn build && yarn build:default && yarn start:default'
     volumes:
       - ./webui:/app
+      - /etc/localtime:/etc/localtime:ro
+    command: sh -c 'yarn && yarn build && yarn build:default && yarn start:default'
     ports:
-      - 3000:3000
+      - "0.0.0.0:3000:3000"
     depends_on:
       - server
     profiles:
       - openvsx
       - frontend
-
-  cli:
-    image: node:18
-    working_dir: /app
-    command: sh -c 'yarn && yarn watch'
-    volumes:
-      - ./cli:/app
-    depends_on:
-      - server
-    environment:
-      - OVSX_REGISTRY_URL=http://server:8080
-    profiles:
-      - openvsx
-      - commandline

--- a/docs/docker-deployment-fix.md
+++ b/docs/docker-deployment-fix.md
@@ -1,0 +1,151 @@
+# Docker 部署问题修复文档
+
+## 问题描述
+
+在使用 Docker Compose 部署 OpenVSX 服务时遇到以下问题：
+1. Server 服务启动失败（Exit 127）
+2. Elasticsearch 健康检查不通过
+3. 服务间依赖关系不正确
+
+## 解决方案
+
+### 1. 修改 docker-compose.yml 配置
+
+主要修改包括：
+
+```yaml
+# 1. 更改 server 服务配置
+server:
+  image: openjdk:17-bullseye  # 使用完整版本的基础镜像
+  working_dir: /app
+  volumes:
+    - ./server:/app
+    - /etc/localtime:/etc/localtime:ro
+  command: >
+    bash -c '
+      apt-get update && 
+      apt-get install -y curl findutils &&
+      scripts/generate-properties.sh --docker && 
+      ./gradlew assemble && 
+      ./gradlew runServer'
+  ports:
+    - "0.0.0.0:8080:8080"
+  environment:
+    - SPRING_PROFILES_ACTIVE=docker
+    - ELASTICSEARCH_HOST=elasticsearch
+    - POSTGRES_HOST=postgres
+  depends_on:
+    elasticsearch:
+      condition: service_healthy
+    postgres:
+      condition: service_started
+  healthcheck:
+    test: "curl --fail --silent localhost:8081/actuator/health | grep UP || exit 1"
+    interval: 30s
+    timeout: 10s
+    retries: 5
+    start_period: 40s
+
+# 2. 优化 elasticsearch 服务配置
+elasticsearch:
+  image: elasticsearch:8.7.1
+  environment:
+    - xpack.security.enabled=false
+    - xpack.ml.enabled=false
+    - discovery.type=single-node
+    - bootstrap.memory_lock=true
+    - cluster.routing.allocation.disk.threshold_enabled=false
+    - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+  volumes:
+    - /etc/localtime:/etc/localtime:ro
+  ports:
+    - 9200:9200
+    - 9300:9300
+  ulimits:
+    memlock:
+      soft: -1
+      hard: -1
+  healthcheck:
+    test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health"]
+    interval: 30s
+    timeout: 10s
+    retries: 5
+    start_period: 40s
+```
+
+### 2. 主要改进点
+
+1. Server 服务：
+   - 使用 `openjdk:17-bullseye` 替代 `openjdk:17`，确保基础工具可用
+   - 添加必要的工具安装（curl, findutils）
+   - 添加环境变量配置
+   - 优化健康检查参数
+   - 改进服务依赖配置
+
+2. Elasticsearch 服务：
+   - 添加内存限制配置
+   - 优化健康检查配置
+   - 添加 ulimits 配置解决内存锁定问题
+
+## 验证步骤
+
+1. 检查服务状态：
+```bash
+docker-compose ps
+```
+确保所有服务状态正常：
+- elasticsearch: Up (healthy)
+- postgres: Up
+- server: Up
+- webui: Up
+
+2. 验证 Elasticsearch：
+```bash
+curl http://localhost:9200/_cluster/health
+```
+应返回集群健康状态信息。
+
+3. 验证 Server API：
+```bash
+curl http://localhost:8080/user
+```
+应返回 `{"error":"Not logged in."}` 表示服务正常。
+
+4. 验证 Web UI：
+访问 `http://YOUR_SERVER_IP:3000` 确保界面可以正常加载。
+
+## 访问服务
+
+服务启动后可通过以下地址访问：
+
+1. Web UI 界面：
+```
+http://YOUR_SERVER_IP:3000
+```
+
+2. API 服务：
+```
+http://YOUR_SERVER_IP:8080
+```
+
+## 故障排查
+
+如果服务未正常启动，可以通过以下命令查看日志：
+
+```bash
+# 查看所有服务状态
+docker-compose ps
+
+# 查看特定服务日志
+docker-compose logs server
+docker-compose logs elasticsearch
+
+# 实时查看日志
+docker-compose logs -f server
+```
+
+## 注意事项
+
+1. 首次启动时，服务可能需要几分钟时间完成初始化
+2. Elasticsearch 需要足够的内存来运行，建议至少 2GB 可用内存
+3. 确保服务器防火墙允许访问相应端口（3000, 8080, 9200） 


### PR DESCRIPTION
## fix 类型
## 问题描述
当前 OpenVSX 的 Docker 部署存在以下问题：
1. Server 服务启动失败 (Exit 127)
2. Elasticsearch 健康检查失败
3. 服务依赖关系配置不合理

## 修复内容

### Docker 配置优化
1. 修改 server 镜像
   - 从 `openjdk:17` 更改为 `openjdk:17-bullseye`
   - 添加必要工具: curl, findutils 等

2. 优化 Elasticsearch 配置
   - 调整内存设置
   - 改进健康检查机制
   - 优化启动顺序

3. 服务依赖关系
   - 移除不必要的 cli 服务
   - 保留并优化 webui 服务
   - 完善服务间的依赖关系配置

### 文档改进
1. 新增 `docs/docker-deployment-fix.md`
   - 详细的部署步骤说明
   - 配置示例和最佳实践
   - 常见问题排查指南

## 验证方法
1. 清理现有容器和卷:
```bash
docker-compose down -v
```

2. 使用新配置启动服务:
```bash
docker-compose --profile openvsx up -d
```

3. 验证服务状态:
```bash
docker-compose ps
docker-compose logs
```

>hongbo@coduora openvsx (fix/docker-deployment) $ docker-compose ps -a
         Name                        Command                       State                                             Ports                                  
------------------------------------------------------------------------------------------------------------------------------------------------------------
openvsx_elasticsearch_1   /bin/tini -- /usr/local/bi ...   Up (healthy)            0.0.0.0:9200->9200/tcp,:::9200->9200/tcp,                                
                                                                                   0.0.0.0:9300->9300/tcp,:::9300->9300/tcp                                 
openvsx_postgres_1        docker-entrypoint.sh postgres    Up                      0.0.0.0:5432->5432/tcp,:::5432->5432/tcp                                 
openvsx_server_1          bash -c                          Up (health: starting)   0.0.0.0:8080->8080/tcp                                                   
                            apt-get update  ...                                                                                                             
openvsx_webui_1           docker-entrypoint.sh sh -c ...   Up                      0.0.0.0:3000->3000/tcp  


例如 docker-compose logs -f server

> server_1         | Downloading https://services.gradle.org/distributions/gradle-8.1.1-bin.zip
server_1         | ...........10%............20%............30%............40%............50%............60%............70%............80%...........90%............100%
server_1         | 
server_1         | Welcome to Gradle 8.1.1!
server_1         | 
server_1         | Here are the highlights of this release:
server_1         |  - Stable configuration cache
server_1         |  - Experimental Kotlin DSL assignment syntax
server_1         |  - Building with Java 20
server_1         | 
server_1         | For more details see https://docs.gradle.org/8.1.1/release-notes.html
server_1         | 
server_1         | Starting a Gradle Daemon (subsequent builds will be faster)
server_1         | 2025-06-10T05:24:21.496Z  INFO [openvsx-server,,] 680 --- [openvsx-server] [  restartedMain] [                                                 ] o.eclipse.openvsx.RegistryApplication    : Started RegistryApplication in 15.715 seconds (process running for 16.369)



4. 检查3000 是否curl 通：
```bash
curl -I localhost:3000
HTTP/1.1 200 OK
X-Powered-By: Express
Accept-Ranges: bytes
Cache-Control: public, max-age=0
Last-Modified: Tue, 10 Jun 2025 01:45:47 GMT
ETag: W/"160-1975783d7e1"
Content-Type: text/html; charset=UTF-8
Content-Length: 352
Date: Tue, 10 Jun 2025 05:25:07 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```

5. 检查 PostgreSQL: 5432 

```bash
telnet localhost 5432
```
> Trying 127.0.0.1...              # 正在尝试连接到本地主机的 IP 地址
Connected to localhost.          # 成功连接到本地主机
Escape character is '^]'.        # 退出 telnet 的快捷键是 Ctrl + ]

6. 检查 8080 是否 healthy:
```bash
curl http://localhost:8080/actuator/health
```
> curl http://localhost:8080/actuator/health
{"status":"UP","groups":["liveness","readiness"]}

## 注意事项
- 首次启动时 Elasticsearch 可能需要 1-2 分钟完成初始化
- 我这里的 compose 是 v1 版本的 ， 用的是 docker-compose 命令
