### PR TITLE
change: replace unnecessary streaming responses

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -260,6 +260,12 @@ tasks.register('runServer', JavaExec) {
     mainClass = 'org.eclipse.openvsx.RegistryApplication'
 }
 
+testlogger {
+    // By default only frames of the test class itself are shown, which hides where a failure
+    // actually originated - useless for diagnosing failures that only reproduce on CI.
+    showFullStackTraces true
+}
+
 test {
     jvmArgs = ['--enable-native-access=ALL-UNNAMED', '-Xmx4096m'] // due to https://github.com/netty/netty/issues/15161
     useJUnitPlatform()

--- a/server/src/main/java/org/eclipse/openvsx/IExtensionRegistry.java
+++ b/server/src/main/java/org/eclipse/openvsx/IExtensionRegistry.java
@@ -9,8 +9,8 @@
  ********************************************************************************/
 package org.eclipse.openvsx;
 
+import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import org.eclipse.openvsx.json.*;
 import org.eclipse.openvsx.search.ISearchService;
@@ -36,7 +36,7 @@ public interface IExtensionRegistry {
             int offset
     );
 
-    ResponseEntity<StreamingResponseBody> getFile(
+    ResponseEntity<Resource> getFile(
             String namespace,
             String extensionName,
             String targetPlatform,
@@ -54,7 +54,7 @@ public interface IExtensionRegistry {
 
     NamespaceDetailsJson getNamespaceDetails(String namespace);
 
-    ResponseEntity<StreamingResponseBody> getNamespaceLogo(String namespaceName, String fileName);
+    ResponseEntity<Resource> getNamespaceLogo(String namespaceName, String fileName);
 
     String getPublicKey(String publicId);
 

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -23,12 +23,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.io.Resource;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import org.eclipse.openvsx.accesstoken.AccessTokenService;
 import org.eclipse.openvsx.cache.CacheService;
@@ -271,7 +271,7 @@ public class LocalRegistryService implements IExtensionRegistry {
     }
 
     @Override
-    public ResponseEntity<StreamingResponseBody> getFile(
+    public ResponseEntity<Resource> getFile(
             String namespace,
             String extensionName,
             String targetPlatform,
@@ -606,7 +606,7 @@ public class LocalRegistryService implements IExtensionRegistry {
     }
 
     @Override
-    public ResponseEntity<StreamingResponseBody> getNamespaceLogo(String namespaceName, String fileName) {
+    public ResponseEntity<Resource> getNamespaceLogo(String namespaceName, String fileName) {
         if (fileName == null) {
             fileName = "";
         }

--- a/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
@@ -33,11 +33,11 @@ import jakarta.validation.constraints.Min;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import org.eclipse.openvsx.entities.SemanticVersion;
 import org.eclipse.openvsx.json.*;
@@ -208,7 +208,7 @@ public class RegistryAPI {
         responseCode = "404",
         description = "The specified namespace could not be found"
     )
-    public ResponseEntity<StreamingResponseBody> getNamespaceLogo(
+    public ResponseEntity<Resource> getNamespaceLogo(
             @PathVariable
             @Parameter(description = "Namespace name", example = "Codeium") String namespace,
             @PathVariable
@@ -688,7 +688,7 @@ public class RegistryAPI {
         description = "The specified file could not be found",
         content = @Content()
     )
-    public ResponseEntity<StreamingResponseBody> getFile(
+    public ResponseEntity<Resource> getFile(
             HttpServletRequest request,
             @PathVariable
             @Parameter(description = "Extension namespace", example = "astro-build") String namespace,
@@ -734,7 +734,7 @@ public class RegistryAPI {
         description = "The specified file could not be found",
         content = @Content()
     )
-    public ResponseEntity<StreamingResponseBody> getFile(
+    public ResponseEntity<Resource> getFile(
             HttpServletRequest request,
             @PathVariable
             @Parameter(description = "Extension namespace", example = "AdaCore") String namespace,

--- a/server/src/main/java/org/eclipse/openvsx/UpstreamRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/UpstreamRegistryService.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +29,6 @@ import org.springframework.web.client.ResponseExtractor;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import org.eclipse.openvsx.json.*;
@@ -97,7 +97,7 @@ public class UpstreamRegistryService implements IExtensionRegistry {
     }
 
     @Override
-    public ResponseEntity<StreamingResponseBody> getNamespaceLogo(String namespaceName, String fileName) {
+    public ResponseEntity<Resource> getNamespaceLogo(String namespaceName, String fileName) {
         var urlTemplate = urlConfigService.getUpstreamUrl() + "/api/{namespace}/logo/{file}";
         var uriVariables = Map.of(VAR_NAMESPACE, namespaceName, "file", fileName);
         return getFile(urlTemplate, uriVariables);
@@ -228,7 +228,7 @@ public class UpstreamRegistryService implements IExtensionRegistry {
     }
 
     @Override
-    public ResponseEntity<StreamingResponseBody> getFile(
+    public ResponseEntity<Resource> getFile(
             String namespace,
             String extension,
             String targetPlatform,
@@ -253,10 +253,10 @@ public class UpstreamRegistryService implements IExtensionRegistry {
         return getFile(urlTemplate, uriVariables);
     }
 
-    private ResponseEntity<StreamingResponseBody> getFile(String urlTemplate, Map<String, ?> uriVariables) {
-        var responseHandler = new ResponseExtractor<ResponseEntity<StreamingResponseBody>>() {
+    private ResponseEntity<Resource> getFile(String urlTemplate, Map<String, ?> uriVariables) {
+        var responseHandler = new ResponseExtractor<ResponseEntity<Resource>>() {
             @Override
-            public ResponseEntity<StreamingResponseBody> extractData(ClientHttpResponse response) throws IOException {
+            public ResponseEntity<Resource> extractData(ClientHttpResponse response) throws IOException {
                 var statusCode = response.getStatusCode();
                 if (statusCode.is2xxSuccessful()) {
                     return ResponseEntity.status(HttpStatus.FOUND)

--- a/server/src/main/java/org/eclipse/openvsx/adapter/IVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/IVSCodeService.java
@@ -9,15 +9,15 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.adapter;
 
+import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 public interface IVSCodeService {
     ExtensionQueryResult extensionQuery(ExtensionQueryParam param, int defaultPageSize);
 
     ExtensionQueryResult.Extension latest(String namespaceName, String extensionName);
 
-    ResponseEntity<StreamingResponseBody> browse(
+    ResponseEntity<Resource> browse(
             String namespaceName,
             String extensionName,
             String version,
@@ -28,7 +28,7 @@ public interface IVSCodeService {
 
     String getItemUrl(String namespace, String extension);
 
-    ResponseEntity<StreamingResponseBody> getAsset(
+    ResponseEntity<Resource> getAsset(
             String namespace,
             String extensionName,
             String version,

--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -24,11 +24,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import org.eclipse.openvsx.cache.CacheService;
 import org.eclipse.openvsx.entities.Extension;
@@ -366,7 +367,7 @@ public class LocalVSCodeService implements IVSCodeService {
 
     @Observed
     @Override
-    public ResponseEntity<StreamingResponseBody> getAsset(
+    public ResponseEntity<Resource> getAsset(
             String namespace,
             String extensionName,
             String version,
@@ -443,8 +444,8 @@ public class LocalVSCodeService implements IVSCodeService {
         return "Built-in extension namespace '" + BuiltInExtensionUtil.getBuiltInNamespace() + "' not allowed";
     }
 
-    private StreamingResponseBody builtinExtensionResponse() {
-        return out -> out.write(builtinExtensionMessage().getBytes(StandardCharsets.UTF_8));
+    private Resource builtinExtensionResponse() {
+        return new ByteArrayResource(builtinExtensionMessage().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
@@ -498,7 +499,7 @@ public class LocalVSCodeService implements IVSCodeService {
 
     @Observed
     @Override
-    public ResponseEntity<StreamingResponseBody> browse(
+    public ResponseEntity<Resource> browse(
             String namespaceName,
             String extensionName,
             String version,

--- a/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
@@ -21,6 +21,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Service;
@@ -28,7 +30,6 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResponseExtractor;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import org.springframework.web.util.UriComponentsBuilder;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -38,6 +39,7 @@ import org.eclipse.openvsx.UrlConfigService;
 import org.eclipse.openvsx.util.HttpHeadersUtil;
 import org.eclipse.openvsx.util.NotFoundException;
 import org.eclipse.openvsx.util.TempFile;
+import org.eclipse.openvsx.util.TempFileResource;
 
 @Service
 public class UpstreamVSCodeService implements IVSCodeService {
@@ -144,7 +146,7 @@ public class UpstreamVSCodeService implements IVSCodeService {
     }
 
     @Override
-    public ResponseEntity<StreamingResponseBody> browse(
+    public ResponseEntity<Resource> browse(
             String namespaceName,
             String extensionName,
             String version,
@@ -172,9 +174,9 @@ public class UpstreamVSCodeService implements IVSCodeService {
 
         var method = HttpMethod.GET;
         var urlTemplate = urlBuilder.toString();
-        var responseHandler = new ResponseExtractor<ResponseEntity<StreamingResponseBody>>() {
+        var responseHandler = new ResponseExtractor<ResponseEntity<Resource>>() {
             @Override
-            public ResponseEntity<StreamingResponseBody> extractData(ClientHttpResponse response) throws IOException {
+            public ResponseEntity<Resource> extractData(ClientHttpResponse response) throws IOException {
                 var statusCode = response.getStatusCode();
                 if (statusCode.isError() && statusCode != HttpStatus.NOT_FOUND) {
                     handleResponseError(urlTemplate, uriVariables, response);
@@ -189,7 +191,7 @@ public class UpstreamVSCodeService implements IVSCodeService {
                     var json = proxy.rewriteUrls(jsonMapper.readTree(response.getBody()));
                     return ResponseEntity.status(statusCode)
                             .headers(HttpHeadersUtil.createJsonFileResponseHeaders())
-                            .body(outputStream -> jsonMapper.writeValue(outputStream, json));
+                            .body(new ByteArrayResource(jsonMapper.writeValueAsBytes(json)));
                 } else {
                     return streamResponse(response, org.springframework.util.StringUtils.getFilename(path), "browse");
                 }
@@ -276,7 +278,7 @@ public class UpstreamVSCodeService implements IVSCodeService {
     }
 
     @Override
-    public ResponseEntity<StreamingResponseBody> getAsset(
+    public ResponseEntity<Resource> getAsset(
             String namespace,
             String extensionName,
             String version,
@@ -312,9 +314,9 @@ public class UpstreamVSCodeService implements IVSCodeService {
         urlBuilder.append("?targetPlatform={targetPlatform}");
         var urlTemplate = urlBuilder.toString();
         var method = HttpMethod.GET;
-        var responseHandler = new ResponseExtractor<ResponseEntity<StreamingResponseBody>>() {
+        var responseHandler = new ResponseExtractor<ResponseEntity<Resource>>() {
             @Override
-            public ResponseEntity<StreamingResponseBody> extractData(ClientHttpResponse response) throws IOException {
+            public ResponseEntity<Resource> extractData(ClientHttpResponse response) throws IOException {
                 var statusCode = response.getStatusCode();
                 if (statusCode.is3xxRedirection()) {
                     var location = response.getHeaders().getLocation();
@@ -376,7 +378,7 @@ public class UpstreamVSCodeService implements IVSCodeService {
         return new NotFoundException();
     }
 
-    private ResponseEntity<StreamingResponseBody> streamResponse(
+    private ResponseEntity<Resource> streamResponse(
             ClientHttpResponse response,
             @Nullable String fileName,
             String prefix
@@ -389,15 +391,10 @@ public class UpstreamVSCodeService implements IVSCodeService {
 
             var headers = HttpHeadersUtil.createFileResponseHeaders(tempFile.getPath(), fileName);
 
+            // TempFileResource deletes the temp file once the message converter has written the body.
             return ResponseEntity.status(response.getStatusCode())
                     .headers(headers)
-                    .body(outputStream -> {
-                        try (var in = Files.newInputStream(tempFile.getPath())) {
-                            in.transferTo(outputStream);
-                        }
-
-                        IOUtils.closeQuietly(tempFile);
-                    });
+                    .body(new TempFileResource(tempFile));
         } catch (IOException e) {
             IOUtils.closeQuietly(tempFile);
             throw e;

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
@@ -24,13 +24,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -169,7 +169,7 @@ public class VSCodeAPI {
         description = "The specified asset could not be found",
         content = @Content()
     )
-    public ResponseEntity<StreamingResponseBody> getAsset(
+    public ResponseEntity<Resource> getAsset(
             HttpServletRequest request,
             @PathVariable
             @Parameter(description = "Extension namespace", example = "vitest") String namespaceName,
@@ -394,7 +394,7 @@ public class VSCodeAPI {
         description = "The specified file or directory could not be found",
         content = @Content()
     )
-    public ResponseEntity<StreamingResponseBody> browse(
+    public ResponseEntity<Resource> browse(
             HttpServletRequest request,
             @PathVariable
             @Parameter(description = "Extension namespace", example = "malloydata") String namespaceName,

--- a/server/src/main/java/org/eclipse/openvsx/storage/LocalStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/LocalStorageService.java
@@ -20,11 +20,12 @@ import java.util.List;
 import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
 import org.springframework.data.util.Pair;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerErrorException;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 import org.eclipse.openvsx.entities.FileResource;
 import org.eclipse.openvsx.entities.Namespace;
@@ -86,15 +87,11 @@ public class LocalStorageService implements IStorageService {
         }
     }
 
-    public ResponseEntity<StreamingResponseBody> getFile(FileResource resource) {
+    public ResponseEntity<Resource> getFile(FileResource resource) {
         var path = getPath(resource);
         return ResponseEntity.ok()
                 .headers(HttpHeadersUtil.createFileResponseHeaders(path))
-                .body(outputStream -> {
-                    try (var in = Files.newInputStream(path)) {
-                        in.transferTo(outputStream);
-                    }
-                });
+                .body(new FileSystemResource(path));
     }
 
     @Override
@@ -102,7 +99,7 @@ public class LocalStorageService implements IStorageService {
         return URI.create(UrlUtil.createApiFileUrl(UrlUtil.getBaseUrl(), resource.getExtension(), resource.getName()));
     }
 
-    public ResponseEntity<StreamingResponseBody> getNamespaceLogo(Namespace namespace) {
+    public ResponseEntity<Resource> getNamespaceLogo(Namespace namespace) {
         if (!isEnabled()) {
             throw new IllegalStateException(
                     "Cannot determine location of logo. Configure the 'ovsx.storage.local.directory' property.");
@@ -112,11 +109,7 @@ public class LocalStorageService implements IStorageService {
 
         return ResponseEntity.ok()
                 .headers(HttpHeadersUtil.createFileResponseHeaders(path))
-                .body(outputStream -> {
-                    try (var in = Files.newInputStream(path)) {
-                        in.transferTo(outputStream);
-                    }
-                });
+                .body(new FileSystemResource(path));
     }
     public URI getNamespaceLogoLocation(Namespace namespace) {
         return URI.create(

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -21,10 +21,12 @@ import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
 import org.springframework.data.util.Pair;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ArrayNode;
 
@@ -319,7 +321,7 @@ public class StorageUtilService implements IStorageService {
         }
     }
 
-    public ResponseEntity<StreamingResponseBody> getFileResponse(FileResource resource) {
+    public ResponseEntity<Resource> getFileResponse(FileResource resource) {
         if (resource.getStorageType().equals(STORAGE_LOCAL)) {
             return localStorage.getFile(resource);
         } else {
@@ -330,32 +332,27 @@ public class StorageUtilService implements IStorageService {
         }
     }
 
-    public ResponseEntity<StreamingResponseBody> getFileResponse(Path path) {
+    public ResponseEntity<Resource> getFileResponse(Path path) {
         var headers = HttpHeadersUtil.createFileResponseHeaders(path);
         return ResponseEntity.ok()
                 .headers(headers)
-                .body(outputStream -> {
-                    try (var in = Files.newInputStream(path)) {
-                        in.transferTo(outputStream);
-                    }
-                });
+                .body(new FileSystemResource(path));
     }
 
-    public ResponseEntity<StreamingResponseBody> getFileResponse(ArrayNode node) {
+    public ResponseEntity<Resource> getFileResponse(ArrayNode node) {
         var baseUrl = UrlUtil.getBaseUrl();
         var headers = HttpHeadersUtil.createJsonFileResponseHeaders();
+        var value = jsonMapper.createArrayNode();
+        for (var item : node) {
+            value.add(baseUrl + item.asString());
+        }
+
         return ResponseEntity.ok()
                 .headers(headers)
-                .body(outputStream -> {
-                    var value = jsonMapper.createArrayNode();
-                    for (var item : node) {
-                        value.add(baseUrl + item.asString());
-                    }
-                    jsonMapper.writeValue(outputStream, value);
-                });
+                .body(new ByteArrayResource(jsonMapper.writeValueAsBytes(value)));
     }
 
-    public ResponseEntity<StreamingResponseBody> getNamespaceLogo(Namespace namespace) {
+    public ResponseEntity<Resource> getNamespaceLogo(Namespace namespace) {
         if (namespace.getLogoStorageType().equals(STORAGE_LOCAL)) {
             return localStorage.getNamespaceLogo(namespace);
         } else {

--- a/server/src/main/java/org/eclipse/openvsx/util/TempFileResource.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/TempFileResource.java
@@ -1,0 +1,45 @@
+/** ******************************************************************************
+ * Copyright (c) 2026 Precies. Software Ltd and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.util;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.springframework.core.io.FileSystemResource;
+
+/**
+ * A {@link FileSystemResource} backed by a {@link TempFile} that deletes the temp file once the
+ * response body has been written, i.e. when the message converter closes the input stream.
+ */
+public class TempFileResource extends FileSystemResource {
+
+    private final TempFile tempFile;
+
+    public TempFileResource(TempFile tempFile) {
+        super(tempFile.getPath());
+        this.tempFile = tempFile;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return new FilterInputStream(super.getInputStream()) {
+            @Override
+            public void close() throws IOException {
+                try {
+                    super.close();
+                } finally {
+                    IOUtils.closeQuietly(TempFileResource.this.tempFile);
+                }
+            }
+        };
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -47,7 +47,6 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.support.TransactionTemplate;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.json.JsonMapper;
@@ -524,8 +523,6 @@ class RegistryAPITest {
     void testReadmeUniversalTarget() throws Exception {
         var filePath = mockReadme();
         mockMvc.perform(get("/api/{namespace}/{extension}/{version}/file/{fileName}", "foo", "bar", "1.0.0", "README"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("Please read me"))
                 .andExpect(header().string("X-Content-Type-Options", "nosniff"))
@@ -546,8 +543,6 @@ class RegistryAPITest {
         var filePath = mockReadme(TargetPlatform.NAME_UNIVERSAL, "readme.html", "<script>alert(1)</script>");
         mockMvc.perform(
                 get("/api/{namespace}/{extension}/{version}/file/{fileName}", "foo", "bar", "1.0.0", "readme.html"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(header().string("X-Content-Type-Options", "nosniff"))
                 .andExpect(header().string("X-Frame-Options", "DENY"))
@@ -571,8 +566,6 @@ class RegistryAPITest {
                         "win32-x64",
                         "1.0.0",
                         "README"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("Please read me"))
                 .andDo(_ -> Files.delete(filePath));
@@ -598,8 +591,6 @@ class RegistryAPITest {
         var filePath = mockChangelog();
         mockMvc.perform(
                 get("/api/{namespace}/{extension}/{version}/file/{fileName}", "foo", "bar", "1.0.0", "CHANGELOG"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("All notable changes is documented here"))
                 .andDo(_ -> Files.delete(filePath));
@@ -609,8 +600,6 @@ class RegistryAPITest {
     void testLicense() throws Exception {
         var filePath = mockLicense();
         mockMvc.perform(get("/api/{namespace}/{extension}/{version}/file/{fileName}", "foo", "bar", "1.0.0", "LICENSE"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("I never broke the Law! I am the law!"))
                 .andDo(_ -> Files.delete(filePath));
@@ -638,8 +627,6 @@ class RegistryAPITest {
         var filePath = mockLatest();
         mockMvc.perform(
                 get("/api/{namespace}/{extension}/{version}/file/{fileName}", "foo", "bar", "latest", "DOWNLOAD"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("latest download"))
                 .andDo(_ -> Files.delete(filePath));

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -35,7 +35,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import org.eclipse.openvsx.ExtensionValidator;
@@ -404,8 +403,6 @@ class VSCodeAPITest {
                         "vscode-yaml",
                         "0.5.2",
                         "Microsoft.VisualStudio.Code.Manifest"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("{\"foo\":\"bar\"}"))
                 .andDo(result -> Files.delete(path));
@@ -428,8 +425,6 @@ class VSCodeAPITest {
                         "0.5.2",
                         "Microsoft.VisualStudio.Code.Manifest",
                         target))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().string("{\"foo\":\"bar\",\"target\":\"darwin-arm64\"}"))
                 .andDo(result -> Files.delete(path));
@@ -470,8 +465,6 @@ class VSCodeAPITest {
                         extensionName,
                         version,
                         "Microsoft.VisualStudio.Code.WebResources/extension/EditorConfig_icon.png"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().bytes(bytes))
                 .andDo(result -> Files.delete(path));
@@ -499,8 +492,6 @@ class VSCodeAPITest {
                         "vscode-yaml",
                         "0.5.2",
                         "Microsoft.VisualStudio.Code.Manifest"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string("Built-in extension namespace 'vscode' not allowed"));
     }
@@ -590,8 +581,6 @@ class VSCodeAPITest {
                         "bar",
                         "1.3.4",
                         "extension/img"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isBadRequest())
                 .andExpect(content().string("Built-in extension namespace 'vscode' not allowed"));
     }
@@ -604,8 +593,6 @@ class VSCodeAPITest {
         var path = mockExtensionBrowse(namespaceName, extensionName, version);
         mockMvc.perform(
                 get("/vscode/unpkg/{namespaceName}/{extensionName}/{version}", namespaceName, extensionName, version))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(
@@ -634,8 +621,6 @@ class VSCodeAPITest {
                         extensionName,
                         version,
                         "extension.vsixmanifest"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(
                         content().string(
@@ -657,8 +642,6 @@ class VSCodeAPITest {
                         extensionName,
                         version,
                         "extension.vsixmanifest"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(
                         content().string(
@@ -680,8 +663,6 @@ class VSCodeAPITest {
                         extensionName,
                         version,
                         "extension.vsixmanifest"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(
                         content().string(
@@ -703,8 +684,6 @@ class VSCodeAPITest {
                         extensionName,
                         version,
                         "extension/"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(
@@ -747,8 +726,6 @@ class VSCodeAPITest {
                         extensionName,
                         version,
                         "extension/package.json"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(
                         content().json(
@@ -770,8 +747,6 @@ class VSCodeAPITest {
                         extensionName,
                         version,
                         "extension/syntaxes/"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(
@@ -800,8 +775,6 @@ class VSCodeAPITest {
                         extensionName,
                         version,
                         "extension/EditorConfig_icon.png"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().bytes(bytes))
                 .andDo(result -> Files.delete(path));
@@ -827,8 +800,6 @@ class VSCodeAPITest {
                         extensionName,
                         version,
                         "extension/EditorConfig icon.png"))
-                .andExpect(request().asyncStarted())
-                .andDo(MvcResult::getAsyncResult)
                 .andExpect(status().isOk())
                 .andExpect(content().bytes(bytes))
                 .andDo(result -> Files.delete(path));


### PR DESCRIPTION
The fixes in #2028 solve the failures with streaming response bodies in a test environment, however, Claude pointed out that the same problem could still be present in a production setup.

This PR replaces the existing endpoints returning `StreamingResponseBody` with regular ones as all the content is eagerly loaded anyway and returning a streaming response seems unnecessary.

Maybe this was due to a refactoring and early on the streaming response made sense.

Needs more investigation, open as draft for now.