### PR TITLE
Just enable forks for tests

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -267,8 +267,9 @@ testlogger {
 }
 
 test {
-    jvmArgs = ['--enable-native-access=ALL-UNNAMED', '-Xmx4096m'] // due to https://github.com/netty/netty/issues/15161
+    jvmArgs = ['--enable-native-access=ALL-UNNAMED', '-Xmx4096m', '-Xshare:off'] // due to https://github.com/netty/netty/issues/15161
     useJUnitPlatform()
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 tasks.register('unitTests', Test) {


### PR DESCRIPTION
Also, use `share:off` to lessen JVM nags.