### PR TITLE
feat: Configure active providers

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/trustedpublishing/TrustedPublishingConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/trustedpublishing/TrustedPublishingConfig.java
@@ -12,7 +12,6 @@
  *****************************************************************************/
 package org.eclipse.openvsx.trustedpublishing;
 
-import java.time.Duration;
 import java.util.List;
 
 import jakarta.annotation.PostConstruct;
@@ -41,6 +40,13 @@ public class TrustedPublishingConfig {
     @Value("${ovsx.trusted-publishing.forbidden-jwt-headers:x5u,x5c,jku,jwk}")
     private List<String> forbiddenJwtHeaders;
 
+    /**
+     * The comma separated list of active trusted published providers.
+     * Default: @{code "github"}.
+     */
+    @Value("${ovsx.trusted-publishing.active-providers:github}")
+    private List<String> activeProviders;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -55,6 +61,11 @@ public class TrustedPublishingConfig {
         return forbiddenJwtHeaders;
     }
 
+    @NonNull
+    public List<String> getActiveProviders() {
+        return activeProviders;
+    }
+
     @PostConstruct
     public void validate() {
         if (enabled) {
@@ -64,6 +75,10 @@ public class TrustedPublishingConfig {
             if (forbiddenJwtHeaders == null || forbiddenJwtHeaders.isEmpty()) {
                 throw new IllegalStateException(
                         "Trusted publishing is enabled, but forbidden JWT headers are not configured");
+            }
+            if (activeProviders == null || activeProviders.isEmpty()) {
+                throw new IllegalStateException(
+                        "Trusted publishing is enabled, but there are no active providers configured");
             }
         }
     }

--- a/server/src/main/java/org/eclipse/openvsx/trustedpublishing/TrustedPublishingProviderSupport.java
+++ b/server/src/main/java/org/eclipse/openvsx/trustedpublishing/TrustedPublishingProviderSupport.java
@@ -122,6 +122,13 @@ public abstract class TrustedPublishingProviderSupport {
     }
 
     /**
+     * Is provider active.
+     */
+    public boolean isActive() {
+        return config.getActiveProviders().contains(getProviderId());
+    }
+
+    /**
      * The provider name, for human consumption.
      */
     public String getProviderName() {
@@ -155,7 +162,7 @@ public abstract class TrustedPublishingProviderSupport {
      */
     public Optional<Map<String, String>> extract(String oidcId) {
         requireNonNull(oidcId);
-        if (!config.isEnabled()) {
+        if (!config.isEnabled() || !isActive()) {
             return Optional.empty();
         }
         try {

--- a/server/src/main/java/org/eclipse/openvsx/trustedpublishing/TrustedPublishingService.java
+++ b/server/src/main/java/org/eclipse/openvsx/trustedpublishing/TrustedPublishingService.java
@@ -14,6 +14,7 @@ package org.eclipse.openvsx.trustedpublishing;
 
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -39,6 +40,7 @@ import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.trustedpublishing.github.GitHubTrustedPublishingProvider;
 import org.eclipse.openvsx.trustedpublishing.gitlab.EclipseGitLabTrustedPublishingProvider;
 import org.eclipse.openvsx.trustedpublishing.gitlab.GitLabTrustedPublishingProvider;
+import org.eclipse.openvsx.trustedpublishing.gitlab.GitLabTrustedPublishingProviderSupport;
 import org.eclipse.openvsx.util.ErrorResultException;
 import org.eclipse.openvsx.util.NotFoundException;
 import org.eclipse.openvsx.util.TimeUtil;
@@ -91,6 +93,11 @@ public class TrustedPublishingService {
         }
     }
 
+    private boolean providerIsActive(String providerId) {
+        TrustedPublishingProviderSupport provider = providers.get(providerId);
+        return provider != null && provider.isActive();
+    }
+
     /**
      * Client initiated registration of trusted publishing. The user must be an owner of the namespace.
      */
@@ -121,7 +128,7 @@ public class TrustedPublishingService {
         }
 
         TrustedPublishingProviderSupport provider = providers.get(providerId);
-        if (provider == null) {
+        if (provider == null || !provider.isActive()) {
             throw new ErrorResultException("Unknown trusted publishing provider: " + providerId);
         }
 
@@ -171,7 +178,8 @@ public class TrustedPublishingService {
                     registrableExtensions.add(extensionName);
                 }
             } else {
-                publishers.addAll(extensionPublishers);
+                // filter by active providers; if registration exists for non-active provider, filter it out
+                publishers.addAll(extensionPublishers.stream().filter(p -> providerIsActive(p.getProvider())).toList());
             }
         }
         return new TrustedPublishers(publishers, registrableExtensions);
@@ -203,9 +211,19 @@ public class TrustedPublishingService {
     }
 
     /**
-     * Lists trusted publisher providers.
+     * Lists active trusted publisher providers.
      */
     public Map<String, TrustedPublishingProviderSupport> getTrustedPublisherProviders() {
+        ensureEnabled();
+        return providers.entrySet().stream()
+                .filter(e -> e.getValue().isActive())
+                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll);
+    }
+
+    /**
+     * Lists all trusted publisher providers.
+     */
+    public Map<String, TrustedPublishingProviderSupport> getAllTrustedPublisherProviders() {
         ensureEnabled();
         return providers;
     }
@@ -236,6 +254,7 @@ public class TrustedPublishingService {
 
         // select provider based on "iss"
         TrustedPublishingProviderSupport provider = providers.values().stream()
+                .filter(TrustedPublishingProviderSupport::isActive)
                 .filter(p -> Objects.equals(issuer, p.getOidcIssuer()))
                 .findFirst()
                 .orElseThrow(() -> new ErrorResultException("Unsupported token issuer."));

--- a/server/src/test/java/org/eclipse/openvsx/trustedpublishing/TrustedPublishingServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/trustedpublishing/TrustedPublishingServiceTest.java
@@ -53,9 +53,6 @@ class TrustedPublishingServiceTest {
     @Mock
     EntityManager entityManager;
 
-    @InjectMocks
-    TrustedPublishingService service;
-
     private final UserData user = new UserData();
 
     private final Namespace namespace = new Namespace();
@@ -63,6 +60,7 @@ class TrustedPublishingServiceTest {
     @Test
     void listsEveryRegistrationButOffersOnlyUntakenActiveExtensions() {
         when(config.isEnabled()).thenReturn(true);
+        when(config.getActiveProviders()).thenReturn(List.of("github"));
         namespace.setId(1L);
         namespace.setName(NAMESPACE);
         when(repositories.findNamespace(NAMESPACE)).thenReturn(namespace);
@@ -85,6 +83,8 @@ class TrustedPublishingServiceTest {
         when(repositories.findTrustedPublishersByExtension(free)).thenReturn(Streamable.empty());
         when(repositories.findTrustedPublishersByExtension(gone)).thenReturn(Streamable.of(gonePublisher));
 
+        // config is used in ctor, so we must set up fixture and then create the service
+        TrustedPublishingService service = new TrustedPublishingService(config, repositories, tokens, entityManager);
         var result = service.getTrustedPublishers(user, NAMESPACE);
 
         assertThat(result.publishers()).containsExactlyInAnyOrder(registeredPublisher, gonePublisher);


### PR DESCRIPTION
For now keep only "github" as active, but it is now matter of configuration (providerIds as comma separated list).