### PR TITLE
fix: make revoking of publisher contributions more resilient

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
@@ -476,21 +476,24 @@ public class AdminService {
             throw new ErrorResultException(userNotFoundMessage(loginName), HttpStatus.NOT_FOUND);
         }
 
-        // Only send a DELETE request to the publisher agreement API when we have
-        // reliably determined that one exists ('signed' or 'outdated') - not when the status
-        // is 'none' or could not be determined at all, since in that case there is nothing
-        // confirmed to revoke and calling the Eclipse API would be a guess. Whatever the DELETE
-        // call itself throws must still not abort the rest of the revoke below - tokens,
-        // extensions and namespace memberships are unrelated to Eclipse and should still be
-        // revoked; that failure is reported back as part of the result instead.
         String revokeFailure = null;
-        var agreementStatus = eclipse.determinePublisherAgreementStatus(user);
-        if ("signed".equals(agreementStatus) || "outdated".equals(agreementStatus)) {
-            try {
-                eclipse.revokePublisherAgreement(user, admin);
-            } catch (RuntimeException exc) {
-                logger.error("Failed to revoke publisher agreement for user {}/{}", provider, loginName, exc);
-                revokeFailure = exc.getMessage();
+        if (eclipse.isActive()) {
+            // Only send a DELETE request to the publisher agreement API when we have
+            // reliably determined that one exists ('signed' or 'outdated') - not when the status
+            // is 'none' or could not be determined at all, since in that case there is nothing
+            // confirmed to revoke and calling the Eclipse API would be a guess. Whatever the DELETE
+            // call itself throws must still not abort the rest of the revoke below - tokens,
+            // extensions and namespace memberships are unrelated to Eclipse and should still be
+            // revoked; that failure is reported back as part of the result instead.
+
+            var agreementStatus = eclipse.determinePublisherAgreementStatus(user);
+            if ("signed".equals(agreementStatus) || "outdated".equals(agreementStatus)) {
+                try {
+                    eclipse.revokePublisherAgreement(user, admin);
+                } catch (RuntimeException exc) {
+                    logger.error("Failed to revoke publisher agreement for user {}/{}", provider, loginName, exc);
+                    revokeFailure = exc.getMessage();
+                }
             }
         }
 

--- a/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/AdminService.java
@@ -23,6 +23,8 @@ import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
 import org.jobrunr.scheduling.JobRequestScheduler;
 import org.jobrunr.scheduling.cron.Cron;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Page;
@@ -40,7 +42,6 @@ import org.eclipse.openvsx.entities.AdminStatistics;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionReview;
 import org.eclipse.openvsx.entities.ExtensionVersion;
-import org.eclipse.openvsx.entities.ExtensionVersionChange;
 import org.eclipse.openvsx.entities.ExtensionVersionState;
 import org.eclipse.openvsx.entities.Namespace;
 import org.eclipse.openvsx.entities.PersonalAccessToken;
@@ -68,6 +69,8 @@ import static org.eclipse.openvsx.entities.FileResource.VSIXMANIFEST;
 
 @Component
 public class AdminService {
+
+    private static final Logger logger = LoggerFactory.getLogger(AdminService.class);
 
     private final RepositoryService repositories;
     private final ExtensionService extensions;
@@ -473,9 +476,22 @@ public class AdminService {
             throw new ErrorResultException(userNotFoundMessage(loginName), HttpStatus.NOT_FOUND);
         }
 
-        // Send a DELETE request to the Eclipse publisher agreement API
-        if (eclipse.isActive() && user.getEclipsePersonId() != null) {
-            eclipse.revokePublisherAgreement(user, admin);
+        // Only send a DELETE request to the publisher agreement API when we have
+        // reliably determined that one exists ('signed' or 'outdated') - not when the status
+        // is 'none' or could not be determined at all, since in that case there is nothing
+        // confirmed to revoke and calling the Eclipse API would be a guess. Whatever the DELETE
+        // call itself throws must still not abort the rest of the revoke below - tokens,
+        // extensions and namespace memberships are unrelated to Eclipse and should still be
+        // revoked; that failure is reported back as part of the result instead.
+        String revokeFailure = null;
+        var agreementStatus = eclipse.determinePublisherAgreementStatus(user);
+        if ("signed".equals(agreementStatus) || "outdated".equals(agreementStatus)) {
+            try {
+                eclipse.revokePublisherAgreement(user, admin);
+            } catch (RuntimeException exc) {
+                logger.error("Failed to revoke publisher agreement for user {}/{}", provider, loginName, exc);
+                revokeFailure = exc.getMessage();
+            }
         }
 
         var accessTokens = repositories.findAccessTokens(user);
@@ -524,7 +540,14 @@ public class AdminService {
         if (reason != null) {
             message += " Reason: " + reason;
         }
-        var result = ResultJson.success(message);
+
+        ResultJson result;
+        if (revokeFailure != null) {
+            message += " Failed to revoke the publisher agreement: " + revokeFailure;
+            result = ResultJson.warning(message);
+        } else {
+            result = ResultJson.success(message);
+        }
         logs.logAction(admin, result);
         return result;
     }

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -174,6 +175,10 @@ public class EclipseService {
     }
 
     public void enrichUserJsonWithPublisherAgreement(UserJson json, UserData user) {
+        if (!isActive()) {
+            return;
+        }
+
         var usableToken = true;
         PublisherAgreement agreement = null;
         try {
@@ -256,16 +261,20 @@ public class EclipseService {
         }
     }
 
-    public void adminEnrichUserJson(UserJson json, UserData user) {
+    /**
+     * Determine the given user's publisher agreement status for admin purposes: one of
+     * 'none', 'signed', 'outdated', or null if the status could not be reliably determined
+     * (e.g. the Eclipse profile lookup failed, or is blocked). Callers must treat null as
+     * "undetermined" and not fall back to guessing 'none' or any other value.
+     */
+    public @Nullable String determinePublisherAgreementStatus(UserData user) {
         if (!isActive()) {
-            return;
+            return null;
         }
 
-        var publisherAgreement = new UserJson.PublisherAgreement();
         var personId = user.getEclipsePersonId();
         if (personId == null) {
-            publisherAgreement.setStatus("none");
-            return;
+            return "none";
         }
 
         try {
@@ -273,17 +282,31 @@ public class EclipseService {
             var openVsxPublisherAgreement = profile.getOpenVsxPublisherAgreement();
             if (openVsxPublisherAgreement.isEmpty()
                     || StringUtils.isEmpty(openVsxPublisherAgreement.get().getVersion())) {
-                publisherAgreement.setStatus("none");
-            } else if (publisherAgreementAllowedVersions.contains(openVsxPublisherAgreement.get().getVersion())) {
-                publisherAgreement.setStatus("signed");
-            } else {
-                publisherAgreement.setStatus("outdated");
+                return "none";
             }
-
-            json.setPublisherAgreement(publisherAgreement);
-        } catch (ErrorResultException e) {
+            return publisherAgreementAllowedVersions.contains(openVsxPublisherAgreement.get().getVersion())
+                    ? "signed"
+                    : "outdated";
+        } catch (RuntimeException e) {
+            // Profile could not be retrieved (e.g. the user is blocked on Eclipse's side) or
+            // something else unexpected went wrong - the status is genuinely unknown, so it
+            // must not be reported as any of the determined values above.
             logger.error("Failed to get public profile", e);
+            return null;
         }
+    }
+
+    public void adminEnrichUserJson(UserJson json, UserData user) {
+        var status = determinePublisherAgreementStatus(user);
+        if (status == null) {
+            // Leave json.publisherAgreement unset (null) rather than guessing - the frontend
+            // must treat a missing agreement the same as an undetermined one, not as 'none'.
+            return;
+        }
+
+        var publisherAgreement = new UserJson.PublisherAgreement();
+        publisherAgreement.setStatus(status);
+        json.setPublisherAgreement(publisherAgreement);
     }
 
     /**
@@ -496,6 +519,13 @@ public class EclipseService {
             var requestCallback = restTemplate.httpEntityCallback(request);
             restTemplate.execute(urlTemplate, HttpMethod.DELETE, requestCallback, null, uriVariables);
         } catch (RestClientException exc) {
+            if (exc instanceof HttpStatusCodeException
+                    && ((HttpStatusCodeException) exc).getStatusCode() == HttpStatus.NOT_FOUND) {
+                // Same convention as getPublisherAgreement(): 404 means the user never signed
+                // one, so there is nothing to revoke - not an error worth failing the caller for.
+                return;
+            }
+
             var url = UriComponentsBuilder.fromUriString(urlTemplate).build(uriVariables);
             logger.error("Delete request failed with URL: {}", url, exc);
             throw new ErrorResultException(

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
@@ -274,8 +274,10 @@ public class EclipseService {
 
         var personId = user.getEclipsePersonId();
         if (personId == null) {
-            // no eclipse user is linked to no point in setting a publisher agreement status
-            return null;
+            // No Eclipse account is linked at all - that's a definite, known fact (not signed),
+            // unlike the isActive()/lookup-failure cases below where the status genuinely can't
+            // be determined. Report it as "none" rather than null.
+            return "none";
         }
 
         try {

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
@@ -274,7 +274,8 @@ public class EclipseService {
 
         var personId = user.getEclipsePersonId();
         if (personId == null) {
-            return "none";
+            // no eclipse user is linked to no point in setting a publisher agreement status
+            return null;
         }
 
         try {

--- a/server/src/test/java/org/eclipse/openvsx/admin/AdminServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/admin/AdminServiceTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -114,6 +115,56 @@ class AdminServiceTest {
                 eq(extVersion),
                 eq(ExtensionVersionState.INACTIVE),
                 any());
+    }
+
+    // Regression: revokePublisherAgreement used to be called unguarded, so any exception it threw
+    // (Eclipse API down, unexpected runtime error, ...) rolled back the whole revoke, including the
+    // token/extension/membership cleanup that has nothing to do with Eclipse.
+    @Test
+    void revokingPublisherContributionsStillDeactivatesEverythingElseWhenTheEclipseRevokeFails() {
+        var user = new UserData();
+        user.setLoginName("amy");
+        user.setEclipsePersonId("12345");
+        var extVersion = version(extension("ext"));
+        extVersion.setActive(true);
+
+        when(repositories.findUserByLoginName("github", "amy")).thenReturn(user);
+        when(repositories.findAccessTokens(user)).thenReturn(Streamable.empty());
+        when(repositories.findVersionsByUser(user, true)).thenReturn(Streamable.of(extVersion));
+        when(eclipse.determinePublisherAgreementStatus(user)).thenReturn("signed");
+        doThrow(new RuntimeException("Eclipse API is down")).when(eclipse).revokePublisherAgreement(user, admin);
+
+        var result = adminService.revokePublisherContributions("github", "amy", admin);
+
+        assertThat(extVersion.isActive()).isFalse();
+        verify(repositories).recordExtensionVersionChange(
+                eq(extVersion),
+                eq(ExtensionVersionState.INACTIVE),
+                any());
+        // The failure is reported back rather than silently dropped or failing the whole call.
+        assertThat(result.getError()).isNull();
+        assertThat(result.getWarning()).contains("Eclipse API is down");
+    }
+
+    // Regression: the revoke used to be attempted whenever an Eclipse person ID was present,
+    // even if the agreement status was 'none' or could not be determined at all - calling the
+    // Eclipse API on a guess rather than a confirmed agreement.
+    @Test
+    void revokingPublisherContributionsDoesNotCallEclipseWhenTheAgreementStatusIsNotConfirmed() {
+        var user = new UserData();
+        user.setLoginName("amy");
+        user.setEclipsePersonId("12345");
+
+        when(repositories.findUserByLoginName("github", "amy")).thenReturn(user);
+        when(repositories.findAccessTokens(user)).thenReturn(Streamable.empty());
+        when(repositories.findVersionsByUser(user, true)).thenReturn(Streamable.empty());
+        when(eclipse.determinePublisherAgreementStatus(user)).thenReturn(null);
+
+        var result = adminService.revokePublisherContributions("github", "amy", admin);
+
+        verify(eclipse, never()).revokePublisherAgreement(any(), any());
+        assertThat(result.getError()).isNull();
+        assertThat(result.getWarning()).isNull();
     }
 
     @Test

--- a/server/src/test/java/org/eclipse/openvsx/admin/AdminServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/admin/AdminServiceTest.java
@@ -131,6 +131,7 @@ class AdminServiceTest {
         when(repositories.findUserByLoginName("github", "amy")).thenReturn(user);
         when(repositories.findAccessTokens(user)).thenReturn(Streamable.empty());
         when(repositories.findVersionsByUser(user, true)).thenReturn(Streamable.of(extVersion));
+        when(eclipse.isActive()).thenReturn(true);
         when(eclipse.determinePublisherAgreementStatus(user)).thenReturn("signed");
         doThrow(new RuntimeException("Eclipse API is down")).when(eclipse).revokePublisherAgreement(user, admin);
 
@@ -158,6 +159,7 @@ class AdminServiceTest {
         when(repositories.findUserByLoginName("github", "amy")).thenReturn(user);
         when(repositories.findAccessTokens(user)).thenReturn(Streamable.empty());
         when(repositories.findVersionsByUser(user, true)).thenReturn(Streamable.empty());
+        when(eclipse.isActive()).thenReturn(true);
         when(eclipse.determinePublisherAgreementStatus(user)).thenReturn(null);
 
         var result = adminService.revokePublisherContributions("github", "amy", admin);

--- a/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/eclipse/EclipseServiceTest.java
@@ -41,6 +41,7 @@ import org.eclipse.openvsx.adapter.VSCodeIdService;
 import org.eclipse.openvsx.cache.CacheService;
 import org.eclipse.openvsx.cache.LatestExtensionVersionCacheKeyGenerator;
 import org.eclipse.openvsx.entities.*;
+import org.eclipse.openvsx.json.UserJson;
 import org.eclipse.openvsx.metrics.ExtensionDownloadMetrics;
 import org.eclipse.openvsx.publish.PublishExtensionVersionHandler;
 import org.eclipse.openvsx.publish.PublishingConfig;
@@ -58,6 +59,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 
 @ExtendWith(SpringExtension.class)
 @MockitoBean(
@@ -332,10 +334,124 @@ class EclipseServiceTest {
         }
     }
 
+    // Regression: enrichUserJsonWithPublisherAgreement is called from the "who am I" endpoint on
+    // essentially every page load, but used to skip the isActive() guard that every other method
+    // in this class applies - so it kept round-tripping to the Eclipse API (publisher agreement
+    // lookup, and potentially the public profile as a fallback) even when the feature is disabled,
+    // discarding the result anyway once it reached enrichUserJson()'s own isActive() check.
+    @Test
+    void testEnrichUserJsonWithPublisherAgreementSkipsEclipseCallsWhenNotActive() {
+        eclipse.publisherAgreementVersion = "";
+        eclipse.publisherAgreementAllowedVersions = List.of();
+
+        var user = new UserData();
+        user.setLoginName("test");
+        user.setProvider("github");
+        user.setEclipsePersonId("test");
+        var json = new UserJson();
+
+        eclipse.enrichUserJsonWithPublisherAgreement(json, user);
+
+        assertThat(json.getPublisherAgreement()).isNull();
+        Mockito.verifyNoInteractions(tokens);
+        Mockito.verifyNoInteractions(restTemplate);
+    }
+
+    @Test
+    void testAdminEnrichUserJsonNoEclipsePersonId() {
+        var user = mockUser();
+        var json = new UserJson();
+
+        eclipse.adminEnrichUserJson(json, user);
+
+        assertThat(json.getPublisherAgreement()).isNotNull();
+        assertThat(json.getPublisherAgreement().getStatus()).isEqualTo("none");
+    }
+
+    @Test
+    void testAdminEnrichUserJson() throws Exception {
+        var user = mockUser();
+        user.setEclipsePersonId("test");
+        var json = new UserJson();
+
+        Mockito.when(
+                restTemplate.exchange(
+                        eq(PUBLIC_PROFILE_URL),
+                        eq(HttpMethod.GET),
+                        any(HttpEntity.class),
+                        eq(String.class),
+                        eq(Map.of("personId", "test"))))
+                .thenReturn(mockProfileResponse());
+
+        eclipse.adminEnrichUserJson(json, user);
+
+        assertThat(json.getPublisherAgreement()).isNotNull();
+        assertThat(json.getPublisherAgreement().getStatus()).isEqualTo("signed");
+    }
+
+    @Test
+    void testAdminEnrichUserJsonProfileUnavailable() {
+        var user = mockUser();
+        user.setEclipsePersonId("test");
+        var json = new UserJson();
+
+        Mockito.when(
+                restTemplate.exchange(
+                        eq(PUBLIC_PROFILE_URL),
+                        eq(HttpMethod.GET),
+                        any(HttpEntity.class),
+                        eq(String.class),
+                        eq(Map.of("personId", "test"))))
+                .thenThrow(new HttpClientErrorException(HttpStatus.FORBIDDEN));
+
+        eclipse.adminEnrichUserJson(json, user);
+
+        // The status genuinely could not be determined - it must be left null rather than
+        // guessed as "none" (which would wrongly read as "no agreement exists").
+        assertThat(json.getPublisherAgreement()).isNull();
+    }
+
+    @Test
+    void testDeterminePublisherAgreementStatusProfileUnavailable() {
+        var user = mockUser();
+        user.setEclipsePersonId("test");
+
+        Mockito.when(
+                restTemplate.exchange(
+                        eq(PUBLIC_PROFILE_URL),
+                        eq(HttpMethod.GET),
+                        any(HttpEntity.class),
+                        eq(String.class),
+                        eq(Map.of("personId", "test"))))
+                .thenThrow(new HttpClientErrorException(HttpStatus.FORBIDDEN));
+
+        assertThat(eclipse.determinePublisherAgreementStatus(user)).isNull();
+    }
+
     @Test
     void testRevokePublisherAgreement() {
         var user = mockUser();
         user.setEclipsePersonId("test");
+
+        eclipse.revokePublisherAgreement(user, null);
+    }
+
+    // Regression: a user with no (or unconfirmed) publisher agreement still reaches this
+    // call, since AdminService only checks for an Eclipse person ID. The Eclipse API answers
+    // the DELETE with 404 in that case, which must not fail the whole revoke action.
+    @Test
+    void testRevokePublisherAgreementNotFound() {
+        var user = mockUser();
+        user.setEclipsePersonId("test");
+
+        Mockito.when(
+                restTemplate.execute(
+                        eq(PUBLISHER_AGREEMENT_URL),
+                        eq(HttpMethod.DELETE),
+                        any(),
+                        isNull(),
+                        eq(Map.of("personId", "test"))))
+                .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 
         eclipse.revokePublisherAgreement(user, null);
     }

--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -4,6 +4,10 @@ This change log covers only the frontend library (webui) of Open VSX.
 
 ## [next] (unreleased)
 
+### Fixed
+
+- Fix the admin publisher revoke dialog prompting for an Eclipse login even when the target publisher's agreement status is `none` or could not be determined (nothing confirmed to revoke)
+
 ### Dependencies
 
 - Bump socks from `2.8.3` to `2.8.9`

--- a/webui/src/pages/admin-dashboard/publisher-revoke-dialog.tsx
+++ b/webui/src/pages/admin-dashboard/publisher-revoke-dialog.tsx
@@ -38,10 +38,13 @@ export const PublisherRevokeContributionsButton: FunctionComponent<PublisherRevo
 
     const [dialogOpen, setDialogOpen] = useState(false);
 
-    if (
-        props.publisherInfo.user.publisherAgreement &&
-        !user?.additionalLogins?.find(login => login.provider === 'eclipse')
-    ) {
+    // A missing publisherAgreement means the backend could not reliably determine the status
+    // (see EclipseService#determinePublisherAgreementStatus) - treat that the same as 'none':
+    // only a confirmed 'signed' or 'outdated' agreement needs an Eclipse login to revoke.
+    const agreementStatus = props.publisherInfo.user.publisherAgreement?.status;
+    const hasAgreement = agreementStatus === 'signed' || agreementStatus === 'outdated';
+
+    if (hasAgreement && !user?.additionalLogins?.find(login => login.provider === 'eclipse')) {
         // If a publisher agreement is required, the admin must be logged in with Eclipse to revoke it
         return (
             <Link href={createAbsoluteURL([service.serverUrl, 'oauth2', 'authorization', 'eclipse'])}>
@@ -65,7 +68,6 @@ export const PublisherRevokeContributionsButton: FunctionComponent<PublisherRevo
 
     const tokenCount = props.publisherInfo.activeAccessTokenNum;
     const extensionCount = props.publisherInfo.extensions.filter(e => e.active).length;
-    const hasAgreement = props.publisherInfo.user.publisherAgreement?.status !== 'none';
 
     return (
         <>

--- a/webui/test/unit/pages/admin-dashboard/publisher-details.spec.tsx
+++ b/webui/test/unit/pages/admin-dashboard/publisher-details.spec.tsx
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../support/test-providers';
+import { PublisherDetails } from '../../../../src/pages/admin-dashboard/publisher-details';
+import { ExtensionRegistryService, AdminService } from '../../../../src/extension-registry-service';
+import { PublisherInfo, UserData, UserRelationships } from '../../../../src/extension-registry-types';
+
+function entry(): UserRelationships {
+    return {
+        user: { loginName: 'octocat', tokensUrl: '', createTokenUrl: '', provider: 'github' },
+        namespaces: []
+    };
+}
+
+function serviceReturning(publisherAgreement?: UserData['publisherAgreement']): ExtensionRegistryService {
+    const publisherInfo: PublisherInfo = {
+        user: { loginName: 'octocat', tokensUrl: '', createTokenUrl: '', provider: 'github', publisherAgreement },
+        extensions: [],
+        activeAccessTokenNum: 0
+    };
+    return {
+        serverUrl: 'https://open-vsx.org',
+        admin: { getPublisherInfo: () => Promise.resolve(publisherInfo) } as unknown as AdminService
+    } as ExtensionRegistryService;
+}
+
+describe('PublisherDetails — publisher agreement chip', () => {
+    // Regression: the backend falls back to 'none' whenever it cannot confirm the agreement
+    // status (e.g. a blocked Eclipse profile) rather than reporting a status the frontend has
+    // no rendering for, so 'none' is the only "nothing to show" state this chip needs to cover.
+    it('renders the "Not signed" chip when the agreement status is "none"', async () => {
+        renderWithProviders(<PublisherDetails entry={entry()} />, {
+            mainContext: { service: serviceReturning({ status: 'none' }) }
+        });
+
+        expect(await screen.findByText('Publisher agreement: Not signed')).toBeInTheDocument();
+    });
+});

--- a/webui/test/unit/pages/admin-dashboard/publisher-revoke-dialog.spec.tsx
+++ b/webui/test/unit/pages/admin-dashboard/publisher-revoke-dialog.spec.tsx
@@ -1,0 +1,90 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../support/test-providers';
+import { PublisherRevokeContributionsButton } from '../../../../src/pages/admin-dashboard/publisher-revoke-dialog';
+import { ExtensionRegistryService, AdminService } from '../../../../src/extension-registry-service';
+import { PublisherInfo, UserData } from '../../../../src/extension-registry-types';
+
+const service = { serverUrl: 'https://open-vsx.org', admin: {} as AdminService } as ExtensionRegistryService;
+
+function publisherInfo(publisherAgreement?: UserData['publisherAgreement']): PublisherInfo {
+    return {
+        user: { loginName: 'octocat', tokensUrl: '', createTokenUrl: '', provider: 'github', publisherAgreement },
+        extensions: [],
+        activeAccessTokenNum: 0
+    };
+}
+
+const eclipseLoginButton = () => screen.queryByRole('link', { name: /log in with eclipse/i });
+const revokeButton = () => screen.getByRole('button', { name: /revoke publisher contributions/i });
+
+describe('PublisherRevokeContributionsButton', () => {
+    it('prompts the admin to log in with Eclipse when the publisher has an agreement to revoke', () => {
+        renderWithProviders(
+            <PublisherRevokeContributionsButton publisherInfo={publisherInfo({ status: 'signed' })} />,
+            { mainContext: { service } }
+        );
+
+        expect(eclipseLoginButton()).toBeInTheDocument();
+    });
+
+    // Regression test: the gate used to check for the mere presence of a
+    // publisherAgreement object, which the backend also sends with status
+    // 'none' — forcing an unneeded Eclipse login even though there is nothing
+    // to revoke on the agreement side.
+    it('does not require an Eclipse login when the publisher agreement status is "none"', () => {
+        renderWithProviders(<PublisherRevokeContributionsButton publisherInfo={publisherInfo({ status: 'none' })} />, {
+            mainContext: { service }
+        });
+
+        expect(eclipseLoginButton()).not.toBeInTheDocument();
+        expect(revokeButton()).toBeInTheDocument();
+    });
+
+    // Regression: a missing publisherAgreement (the backend could not reliably determine the
+    // status) used to read as "has an agreement" - `undefined !== 'none'` is true - forcing an
+    // unneeded Eclipse login even though there is nothing confirmed to revoke.
+    it('does not require an Eclipse login when the publisher agreement status could not be determined', () => {
+        renderWithProviders(<PublisherRevokeContributionsButton publisherInfo={publisherInfo(undefined)} />, {
+            mainContext: { service }
+        });
+
+        expect(eclipseLoginButton()).not.toBeInTheDocument();
+        expect(revokeButton()).toBeInTheDocument();
+    });
+
+    it('does not prompt for an Eclipse login once the admin is already logged in with Eclipse', () => {
+        renderWithProviders(
+            <PublisherRevokeContributionsButton publisherInfo={publisherInfo({ status: 'signed' })} />,
+            {
+                mainContext: {
+                    service,
+                    user: {
+                        loginName: 'admin',
+                        tokensUrl: '',
+                        createTokenUrl: '',
+                        additionalLogins: [
+                            { loginName: 'admin', tokensUrl: '', createTokenUrl: '', provider: 'eclipse' }
+                        ]
+                    }
+                }
+            }
+        );
+
+        expect(eclipseLoginButton()).not.toBeInTheDocument();
+        expect(revokeButton()).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Currently, revoking publisher contributions does not handle certain error situations gracefully, which leads to situations where the whole method can not be used anymore to e.g. revoke access tokens as the first step is to unconditionally revoke the publisher agreement. If that fails for some reason, the whole thing fails.

This PR fixes various things:

 - the UI properly checks for an available eclipse login when a publisher agreement is available
 - gracefully handle error results when calling eclipse api services (handle blocked users which return 404)
 - in the AdminService.revokePublisherContributions only revoke the publisher agreement if it could be determined that one was signed
 - catch any other exception while calling revoke and report it in the result instead of rolling back everything
 - in the `/user` endpoint do not unconditionally check for publisher agreement, only when the service is active

The starting point of this PR was the case where a user account was already blocked before revoking his contributions, but Open VSX could not handle that case anymore as it was calling unconditionally the revoke API and failing if that resulted in an error.