### PR TITLE
fix: restore custom error handling

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -94,7 +94,13 @@ dependencies {
     implementation "org.springframework.security:spring-security-oauth2-client"
     implementation "org.springframework.security:spring-security-oauth2-jose"
 
-    implementation "org.springframework.boot:spring-boot-thymeleaf"
+    // Depend directly on Thymeleaf rather than org.springframework.boot:spring-boot-thymeleaf
+    // (the autoconfiguration module - see JacksonConfig-adjacent notes in MailConfig): the app
+    // only uses Thymeleaf for rendering mail templates and builds its own SpringTemplateEngine
+    // bean for that, so ThymeleafAutoConfiguration's ThymeleafViewResolver (which would resolve
+    // Spring MVC view names, e.g. the "error" view, through the same mail template resolver)
+    // never needs to exist in the first place. No spring.autoconfigure.exclude required.
+    implementation "org.thymeleaf:thymeleaf-spring6"
 
     implementation "org.apache.httpcomponents.client5:httpclient5"
     implementation "com.github.ben-manes.caffeine:caffeine"

--- a/server/src/main/java/org/eclipse/openvsx/mail/MailConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/mail/MailConfig.java
@@ -12,9 +12,15 @@ package org.eclipse.openvsx.mail;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
 import org.thymeleaf.templatemode.TemplateMode;
 
+// Depends directly on org.thymeleaf:thymeleaf-spring6 rather than the Spring Boot
+// spring-boot-thymeleaf autoconfiguration module (see build.gradle), and builds the
+// SpringTemplateEngine bean SendMailJobRequestHandler needs by hand below, so there is no
+// ThymeleafAutoConfiguration on the classpath at all to register a ThymeleafViewResolver for
+// Spring MVC - e.g. resolving the "error" view against this same mail-only template resolver.
 @Configuration
 public class MailConfig {
 
@@ -26,5 +32,12 @@ public class MailConfig {
         templateResolver.setSuffix(".html");
         templateResolver.setTemplateMode(TemplateMode.HTML);
         return templateResolver;
+    }
+
+    @Bean
+    public SpringTemplateEngine templateEngine(SpringResourceTemplateResolver templateResolver) {
+        var templateEngine = new SpringTemplateEngine();
+        templateEngine.setTemplateResolver(templateResolver);
+        return templateEngine;
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/web/ServerErrorController.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/ServerErrorController.java
@@ -9,19 +9,23 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.web;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.boot.webmvc.autoconfigure.error.BasicErrorController;
 import org.springframework.boot.webmvc.error.ErrorAttributes;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
 
 import org.eclipse.openvsx.util.UrlUtil;
 
 @Controller
-@ConditionalOnProperty(value = "server.error.path", havingValue = "/server-error")
+// server.error.path was renamed to spring.web.error.path in Spring Boot 4 - it's what both
+// BasicErrorController's class-level @RequestMapping and the servlet container's actual
+// error-page-forward target (ErrorMvcAutoConfiguration.ErrorPageCustomizer) resolve from now.
+@ConditionalOnProperty(value = "spring.web.error.path", havingValue = "/server-error")
 public class ServerErrorController extends BasicErrorController {
 
     @Value("${ovsx.webui.url:}")
@@ -31,8 +35,14 @@ public class ServerErrorController extends BasicErrorController {
         super(errorAttributes, webProperties.getError());
     }
 
-    @RequestMapping(value = "/server-error", produces = { MediaType.TEXT_HTML_VALUE })
-    public String handleError() {
-        return "redirect:" + UrlUtil.createApiUrl(webuiUrl, "error");
+    // Override errorHtml() itself rather than adding a new method with its own explicit
+    // "/server-error" @RequestMapping: the class-level mapping above already resolves to
+    // "/server-error", and Spring concatenates class-level + method-level paths, so an
+    // explicit method-level "/server-error" would only ever match "/server-error/server-error".
+    // Overriding this exact method (no path of its own, just like the superclass's) inherits
+    // the correct, property-driven path with no combination/doubling.
+    @Override
+    public ModelAndView errorHtml(HttpServletRequest request, HttpServletResponse response) {
+        return new ModelAndView("redirect:" + UrlUtil.createApiUrl(webuiUrl, "error"));
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/web/ServerExceptionResolver.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/ServerExceptionResolver.java
@@ -12,12 +12,18 @@
  *****************************************************************************/
 package org.eclipse.openvsx.web;
 
+import java.io.IOException;
+
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.jspecify.annotations.NonNull;
 import org.springframework.core.Ordered;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolver;
+import org.springframework.web.util.DisconnectedClientHelper;
 
 @RestControllerAdvice
 public class ServerExceptionResolver extends DefaultHandlerExceptionResolver {
@@ -34,5 +40,36 @@ public class ServerExceptionResolver extends DefaultHandlerExceptionResolver {
         if (!(ex instanceof HttpMediaTypeNotSupportedException)) {
             super.logException(ex, request);
         }
+    }
+
+    @Override
+    protected ModelAndView handleHttpMessageNotWritable(
+            @NonNull HttpMessageNotWritableException ex,
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            Object handler
+    ) throws IOException {
+        if (!response.isCommitted()) {
+            return super.handleHttpMessageNotWritable(ex, request, response, handler);
+        }
+
+        // The response is already committed, so - same as the superclass - there is nothing
+        // left to send back. Most of these are simply a client that disconnected mid-response
+        // (closed browser tab, VS Code request timeout, ...), surfaced as a broken-pipe/
+        // connection-reset IOException while writing the JSON body. Jackson 3 wraps that
+        // IOException into its own (unchecked) exception hierarchy, unlike Jackson 2, so
+        // Spring's message converter now wraps it into HttpMessageNotWritableException too -
+        // which this resolver recognizes and, same as the superclass, logs at WARN. That means
+        // the exact same, ordinary client-disconnect traffic this app always had now produces
+        // a WARN per occurrence where it used to be silent. Downgrade the recognized cases to
+        // DEBUG; anything else stays at WARN, since it may be a genuine bug.
+        if (DisconnectedClientHelper.isClientDisconnectedException(ex)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Ignoring exception, client disconnected: " + ex);
+            }
+        } else if (logger.isWarnEnabled()) {
+            logger.warn("Ignoring exception, response committed already: " + ex);
+        }
+        return new ModelAndView();
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/mail/MailConfigTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/mail/MailConfigTest.java
@@ -1,0 +1,64 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.mail;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.GenericApplicationContext;
+import org.thymeleaf.context.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MailConfigTest {
+
+    // Regression: MailConfig used to rely on Spring Boot's ThymeleafAutoConfiguration to turn
+    // its SpringResourceTemplateResolver bean into an actual TemplateEngine - which is also
+    // what registered a ThymeleafViewResolver for Spring MVC, resolving arbitrary view names
+    // (e.g. the default "error" view) through this same mail-only resolver. Building the
+    // engine here directly proves mail rendering still works without any Spring Boot
+    // autoconfiguration involved at all - not even a Spring Boot ApplicationContext, just the
+    // plain Spring ApplicationContext SpringResourceTemplateResolver needs for classpath
+    // resource loading.
+    @Test
+    void rendersARealMailTemplateWithoutAnySpringBootAutoconfiguration() {
+        var mailConfig = new MailConfig();
+        var applicationContext = new GenericApplicationContext();
+        applicationContext.refresh();
+
+        var resolver = mailConfig.templateResolver(applicationContext);
+        var engine = mailConfig.templateEngine(resolver);
+
+        var context = new Context();
+        context.setVariable("name", "Jane Doe");
+        context.setVariable("tokenName", "My Token");
+        context.setVariable("expiryDate", LocalDate.of(2026, 6, 15));
+
+        var html = engine.process("access-token-expired", context);
+
+        assertThat(html).contains("Jane Doe");
+        assertThat(html).contains("My Token");
+        assertThat(html).contains("15-06-2026");
+    }
+
+    // Regression: spring-boot-thymeleaf (the autoconfiguration module) must not be reachable
+    // from the classpath at all - if it were, ThymeleafAutoConfiguration would register a
+    // ThymeleafViewResolver for Spring MVC regardless of what MailConfig itself does.
+    @Test
+    void thymeleafAutoConfigurationIsNotOnTheClasspath() {
+        assertThatThrownBy(
+                () -> Class.forName("org.springframework.boot.thymeleaf.autoconfigure.ThymeleafAutoConfiguration"))
+                .isInstanceOf(ClassNotFoundException.class);
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/web/ServerErrorControllerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/ServerErrorControllerTest.java
@@ -1,0 +1,59 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.webmvc.error.ErrorAttributes;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServerErrorControllerTest {
+
+    // Regression: BasicErrorController carries a class-level @RequestMapping resolving to
+    // spring.web.error.path (Spring Boot 4; server.error.path under Boot 3), e.g. "/server-error".
+    // Spring concatenates class-level and method-level @RequestMapping paths, so an overriding
+    // method with its OWN explicit "/server-error" path would only ever match the doubled-up
+    // "/server-error/server-error" - never the actual "/server-error" the servlet container
+    // forwards errors to. errorHtml() must stay a bare override (no method-level path of its
+    // own, exactly like the superclass's) to inherit the class-level path unmodified.
+    @Test
+    void errorHtmlOverrideHasNoOwnRequestMappingPath() throws Exception {
+        var method = ServerErrorController.class.getMethod(
+                "errorHtml",
+                HttpServletRequest.class,
+                HttpServletResponse.class);
+
+        var mapping = method.getAnnotation(RequestMapping.class);
+
+        assertThat(mapping).isNull();
+    }
+
+    @Test
+    void errorHtmlRedirectsToTheWebuiErrorPage() throws Exception {
+        var controller = new ServerErrorController(
+                Mockito.mock(ErrorAttributes.class),
+                new WebProperties());
+        controller.webuiUrl = "https://open-vsx.org";
+
+        var modelAndView = controller.errorHtml(
+                Mockito.mock(HttpServletRequest.class),
+                Mockito.mock(HttpServletResponse.class));
+
+        assertThat(modelAndView.getViewName()).isEqualTo("redirect:https://open-vsx.org/error");
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/web/ServerExceptionResolverTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/ServerExceptionResolverTest.java
@@ -1,0 +1,133 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.web;
+
+import java.io.IOException;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression: Jackson 3 (Spring Boot 4) wraps a raw IOException from a broken client
+ * connection into its own (unchecked) exception hierarchy while writing a response, unlike
+ * Jackson 2. Spring's message converter then wraps that into HttpMessageNotWritableException -
+ * which DefaultHandlerExceptionResolver#handleHttpMessageNotWritable logs at WARN when the
+ * response is already committed. Under Spring Boot 3 (Jackson 2), the same client-disconnect
+ * event surfaced as a plain, unwrapped IOException that this resolver never saw at all, so it
+ * went unlogged. The rate of clients disconnecting mid-response hasn't changed - only Jackson 3
+ * made that same, ordinary event newly visible as a per-occurrence WARN.
+ */
+class ServerExceptionResolverTest {
+
+    private final ServerExceptionResolver resolver = new ServerExceptionResolver();
+    private final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+    private final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+    private Logger logbackLogger;
+    private Level originalLevel;
+    private ListAppender<ILoggingEvent> logAppender;
+
+    @BeforeEach
+    void setUp() {
+        logbackLogger = (Logger) LoggerFactory.getLogger(ServerExceptionResolver.class);
+        originalLevel = logbackLogger.getLevel();
+        logbackLogger.setLevel(Level.DEBUG);
+
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        logbackLogger.addAppender(logAppender);
+
+        when(response.isCommitted()).thenReturn(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logbackLogger.detachAppender(logAppender);
+        logbackLogger.setLevel(originalLevel);
+    }
+
+    @Test
+    void downgradesAClientDisconnectToDebugInsteadOfWarn() throws IOException {
+        var ex = new HttpMessageNotWritableException(
+                "Could not write JSON",
+                new IOException("Connection reset by peer"));
+
+        var modelAndView = resolver.handleHttpMessageNotWritable(ex, request, response, new Object());
+
+        assertThat(modelAndView.isEmpty()).isTrue();
+        assertThat(logAppender.list).noneMatch(event -> event.getLevel() == Level.WARN);
+        assertThat(logAppender.list)
+                .anyMatch(
+                        event -> event.getLevel() == Level.DEBUG
+                                && event.getFormattedMessage().contains("client disconnected"));
+    }
+
+    // Same regression, the other likely-common phrasing/exception type for the same event.
+    @Test
+    void downgradesABrokenPipeToDebugInsteadOfWarn() throws IOException {
+        var ex = new HttpMessageNotWritableException(
+                "Could not write JSON",
+                new IOException("Broken pipe"));
+
+        resolver.handleHttpMessageNotWritable(ex, request, response, new Object());
+
+        assertThat(logAppender.list).noneMatch(event -> event.getLevel() == Level.WARN);
+    }
+
+    // A write failure with no sign of being a disconnected client keeps its original WARN -
+    // the point is to stop logging expected, benign traffic loudly, not to hide real bugs.
+    @Test
+    void keepsWarnForAWriteFailureThatIsNotARecognizedClientDisconnect() throws IOException {
+        var ex = new HttpMessageNotWritableException(
+                "Could not write JSON",
+                new RuntimeException("something genuinely broke"));
+
+        var modelAndView = resolver.handleHttpMessageNotWritable(ex, request, response, new Object());
+
+        assertThat(modelAndView.isEmpty()).isTrue();
+        assertThat(logAppender.list)
+                .anyMatch(
+                        event -> event.getLevel() == Level.WARN
+                                && event.getFormattedMessage().contains("response committed already"));
+    }
+
+    // When the response has NOT been committed yet, the superclass's normal behavior (try to
+    // send a proper 500) must still apply unchanged - this override only ever changes the
+    // logging for the already-committed case.
+    @Test
+    void stillDelegatesToTheSuperclassWhenTheResponseIsNotCommittedYet() throws IOException {
+        when(response.isCommitted()).thenReturn(false);
+        var ex = new HttpMessageNotWritableException(
+                "Could not write JSON",
+                new IOException("Connection reset by peer"));
+
+        resolver.handleHttpMessageNotWritable(ex, request, response, new Object());
+
+        Mockito.verify(request).setAttribute(Mockito.eq("jakarta.servlet.error.exception"), Mockito.eq(ex));
+        Mockito.verify(response).sendError(500);
+        assertThat(logAppender.list).isEmpty();
+    }
+}


### PR DESCRIPTION
This PR fixes the custom error handler which redirects any encountered server error to the frontend page `/error`.

It also disables thymeleaf autoconfiguration which registers the thymeleaf template resolver as view resolver which results in unnecessary log messages.