### PR TITLE
fix: use jackson 2 compatible mapper for extensionquery

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
@@ -56,13 +56,14 @@ public class VSCodeAPI {
     public VSCodeAPI(
             LocalVSCodeService local,
             UpstreamVSCodeService upstream,
-            IExtensionQueryRequestHandler extensionQueryRequestHandler
+            IExtensionQueryRequestHandler extensionQueryRequestHandler,
+            JsonMapper jsonMapper
     ) {
         this.local = local;
         this.upstream = upstream;
         this.registries = setupRegistries();
         this.extensionQueryRequestHandler = extensionQueryRequestHandler;
-        this.jsonMapper = JsonMapper.builder().build();
+        this.jsonMapper = jsonMapper;
     }
 
     private List<IVSCodeService> setupRegistries() {
@@ -119,7 +120,9 @@ public class VSCodeAPI {
         try {
             param = jsonMapper.readValue(query, ExtensionQueryParam.class);
         } catch (JacksonException ex) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid extension query");
+            // include the parser's message: it is what actually gets logged when Spring resolves
+            // this exception, and it is often the only clue that e.g. a proxy double-encoded `q`
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid extension query: " + ex.getMessage());
         }
 
         var size = 0;

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.CacheControl;
@@ -121,8 +122,10 @@ public class VSCodeAPI {
             param = jsonMapper.readValue(query, ExtensionQueryParam.class);
         } catch (JacksonException ex) {
             // include the parser's message: it is what actually gets logged when Spring resolves
-            // this exception, and it is often the only clue that e.g. a proxy double-encoded `q`
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid extension query: " + ex.getMessage());
+            // this exception, and it is often the only clue that e.g. a proxy double-encoded `q`.
+            // Sanitized/bounded since it can echo back attacker-controlled input and Jackson
+            // messages can be long.
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid extension query" + describe(ex));
         }
 
         var size = 0;
@@ -141,6 +144,21 @@ public class VSCodeAPI {
                 // from caching the same queries
                 .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES).cachePublic().mustRevalidate())
                 .body(result);
+    }
+
+    /**
+     * A short, control-character-free description of a JacksonException suitable for a
+     * ResponseStatusException reason: the raw message can be arbitrarily long and may echo back
+     * parts of the (attacker-controlled) query string.
+     */
+    private static String describe(JacksonException ex) {
+        var message = ex.getMessage();
+        if (message == null) {
+            return "";
+        }
+
+        var singleLine = message.replaceAll("[\\r\\n\\p{Cntrl}]+", " ").trim();
+        return singleLine.isEmpty() ? "" : ": " + StringUtils.abbreviate(singleLine, 200);
     }
 
     @Observed

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -10,6 +10,8 @@
 package org.eclipse.openvsx.adapter;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -59,6 +61,7 @@ import org.eclipse.openvsx.storage.*;
 import org.eclipse.openvsx.storage.log.DownloadCountService;
 import org.eclipse.openvsx.util.TargetPlatform;
 import org.eclipse.openvsx.util.VersionService;
+import org.eclipse.openvsx.web.JacksonConfig;
 
 import static org.eclipse.openvsx.entities.FileResource.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -114,6 +117,46 @@ class VSCodeAPITest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().json(file("search-yaml-response.json")));
+    }
+
+    @Test
+    void testSearchAsGet() throws Exception {
+        var extension = mockSearch(true);
+        mockExtensionVersions(extension, null, "universal");
+
+        // URLEncoder targets application/x-www-form-urlencoded (space -> '+'); a URI query
+        // component needs '%20' instead, since '+' there is a literal character, not a space
+        var query = URLEncoder.encode(file("search-yaml-query.json"), StandardCharsets.UTF_8).replace("+", "%20");
+        mockMvc.perform(get(URI.create("/vscode/gallery/extensionquery?q=" + query)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(file("search-yaml-response.json")));
+    }
+
+    @Test
+    void testExtensionQueryAsGetInvalidJson() throws Exception {
+        var query = URLEncoder.encode("not json", StandardCharsets.UTF_8);
+        mockMvc.perform(get(URI.create("/vscode/gallery/extensionquery?q=" + query)))
+                .andExpect(status().isBadRequest())
+                .andExpect(status().reason(Matchers.startsWith("Invalid extension query:")));
+    }
+
+    @Test
+    void testExtensionQueryAsGetMissingSortFields() throws Exception {
+        // a real request seen in production: a lean single-extension lookup (pageSize 1) that
+        // omits sortBy/sortOrder entirely, since they don't matter for a one-result query. Jackson
+        // 3 treats the missing primitive int fields as null and rejects them unless
+        // FAIL_ON_NULL_FOR_PRIMITIVES is disabled - which JacksonConfig does, but only for the
+        // JsonMapper bean actually wired into the app (see testConfig's @Import above)
+        var query = URLEncoder
+                .encode(
+                        "{\"filters\":[{\"criteria\":[{\"filterType\":7,"
+                                + "\"value\":\"test.extension\"}],"
+                                + "\"pageSize\":1,\"pageNumber\":1}],\"flags\":147}",
+                        StandardCharsets.UTF_8)
+                .replace("+", "%20");
+
+        mockMvc.perform(get(URI.create("/vscode/gallery/extensionquery?q=" + query)))
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -1334,7 +1377,7 @@ class VSCodeAPITest {
     }
 
     @TestConfiguration
-    @Import({ SecurityConfig.class, MockMvcAsyncConfig.class })
+    @Import({ SecurityConfig.class, MockMvcAsyncConfig.class, JacksonConfig.class })
     static class TestConfig {
         @Bean
         IExtensionQueryRequestHandler extensionQueryRequestHandler(

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -39,6 +39,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.server.ResponseStatusException;
 
 import org.eclipse.openvsx.ExtensionValidator;
 import org.eclipse.openvsx.MockMvcAsyncConfig;
@@ -63,6 +64,7 @@ import org.eclipse.openvsx.util.TargetPlatform;
 import org.eclipse.openvsx.util.VersionService;
 import org.eclipse.openvsx.web.JacksonConfig;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.openvsx.entities.FileResource.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
@@ -120,6 +122,17 @@ class VSCodeAPITest {
     }
 
     @Test
+    void testSearchPostMissingSortFields() throws Exception {
+        // reproduces eclipse-openvsx/openvsx#2059 exactly: POST body omits pageNumber's siblings
+        // sortBy/sortOrder entirely. Confirms the @RequestBody path (fixed by #2052 / JacksonConfig)
+        // still works end-to-end, as a counterpart to the GET-focused regression tests below.
+        var body = "{\"filters\":[{\"criteria\":[{\"filterType\":8,\"value\":\"Microsoft.VisualStudio.Code\"}],"
+                + "\"pageSize\":10,\"pageNumber\":1}],\"flags\":914}";
+        mockMvc.perform(post("/vscode/gallery/extensionquery").content(body).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     void testSearchAsGet() throws Exception {
         var extension = mockSearch(true);
         mockExtensionVersions(extension, null, "universal");
@@ -138,6 +151,22 @@ class VSCodeAPITest {
         mockMvc.perform(get(URI.create("/vscode/gallery/extensionquery?q=" + query)))
                 .andExpect(status().isBadRequest())
                 .andExpect(status().reason(Matchers.startsWith("Invalid extension query:")));
+    }
+
+    @Test
+    void testExtensionQueryAsGetInvalidJsonMessageIsBounded() throws Exception {
+        // the parser message is attacker-influenced (derived from `q`) and could in principle be
+        // long or contain control characters; it must stay short and single-line since it ends up
+        // in the response status line
+        var query = URLEncoder.encode("not json\nwith a newline " + "a".repeat(500), StandardCharsets.UTF_8);
+        var result = mockMvc.perform(get(URI.create("/vscode/gallery/extensionquery?q=" + query)))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        var reason = ((ResponseStatusException) result.getResolvedException()).getReason();
+        assertThat(reason).startsWith("Invalid extension query:");
+        assertThat(reason).doesNotContainPattern("[\\r\\n]");
+        assertThat(reason.length()).isLessThanOrEqualTo(250);
     }
 
     @Test


### PR DESCRIPTION
This fixes #2059.

The GET variant for the extensionquery endpoint uses its own `JsonMapper` instead of an injected one. The default `JsonMapper` has now backwards compatible settings for Jackson 2, use that mapper also for the `VSCodeAPI`.