### PR TITLE
fix: cap pre-release versions returned by extensionQuery

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -93,8 +93,9 @@ public class LocalVSCodeService implements IVSCodeService {
     // See RepositoryService.findActiveExtensionVersions / ExtensionVersionJooqRepository -
     // caps how many of an extension's active pre-release versions the version listing below
     // fetches per extensionQuery request; regular releases are never capped. A negative value
-    // (e.g. -1) disables the cap entirely.
-    @Value("${ovsx.extension-query.max-pre-release-versions:100}")
+    // (e.g. the -1 default) disables the cap entirely, preserving the pre-existing unbounded
+    // behaviour unless an operator opts into capping.
+    @Value("${ovsx.extension-query.max-pre-release-versions:-1}")
     int maxPreReleaseVersions;
 
     public LocalVSCodeService(

--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -90,6 +90,13 @@ public class LocalVSCodeService implements IVSCodeService {
     @Value("${ovsx.webui.url:}")
     String webuiUrl;
 
+    // See RepositoryService.findActiveExtensionVersions / ExtensionVersionJooqRepository -
+    // caps how many of an extension's active pre-release versions the version listing below
+    // fetches per extensionQuery request; regular releases are never capped. A negative value
+    // (e.g. -1) disables the cap entirely.
+    @Value("${ovsx.extension-query.max-pre-release-versions:100}")
+    int maxPreReleaseVersions;
+
     public LocalVSCodeService(
             RepositoryService repositories,
             VersionService versions,
@@ -206,7 +213,7 @@ public class LocalVSCodeService implements IVSCodeService {
         var extensionsMap = extensionsList.stream()
                 .collect(Collectors.toMap(Extension::getId, Function.identity(), (a, b) -> a));
         List<ExtensionVersion> allActiveExtensionVersions = repositories
-                .findActiveExtensionVersions(extensionsMap.keySet(), targetPlatform);
+                .findActiveExtensionVersions(extensionsMap.keySet(), targetPlatform, maxPreReleaseVersions);
 
         List<ExtensionVersion> extensionVersions;
         if (test(flags, FLAG_INCLUDE_LATEST_VERSION_ONLY)) {

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
@@ -109,7 +109,18 @@ public class ExtensionVersionJooqRepository {
 
     /**
      * True for an active pre-release version if fewer than {@code limit} other active pre-releases
-     * of the same extension - regardless of target platform - outrank it by semver.
+     * of the same extension - regardless of target platform - outrank it.
+     * <p>
+     * Ranking is (major, minor, patch) first, same as everywhere else, but that triple alone ties
+     * for any two rows that don't happen to differ in it - which is the common case, not an edge
+     * case: the same version published across several target platforms shares one (major, minor,
+     * patch) by construction, and a pre-release channel that republishes without bumping semver
+     * (relying on timestamp/build metadata to distinguish builds) produces the same tie. Neither of
+     * two tied rows outranks the other, so on a (major, minor, patch)-only comparison *neither*
+     * counts against the cap - ties can grow without bound and the cap stops capping. Falling back
+     * to {@code timestamp} (as {@code ExtensionVersion.SORT_COMPARATOR} and every DB sort index in
+     * this class already do) breaks most ties; the final {@code id} tiebreaker guarantees a strict
+     * total order so the cap always keeps exactly {@code min(limit, total)} rows, never more.
      */
     private Condition isAmongLatestPreReleases(int limit) {
         var rank = EXTENSION_VERSION.as("ev_pre_release_rank");
@@ -120,12 +131,19 @@ public class ExtensionVersionJooqRepository {
                         .and(rank.ACTIVE.isTrue())
                         .and(rank.PRE_RELEASE.isTrue())
                         .and(
-                                DSL.row(rank.SEMVER_MAJOR, rank.SEMVER_MINOR, rank.SEMVER_PATCH)
+                                DSL.row(
+                                        rank.SEMVER_MAJOR,
+                                        rank.SEMVER_MINOR,
+                                        rank.SEMVER_PATCH,
+                                        rank.TIMESTAMP,
+                                        rank.ID)
                                         .gt(
                                                 DSL.row(
                                                         EXTENSION_VERSION.SEMVER_MAJOR,
                                                         EXTENSION_VERSION.SEMVER_MINOR,
-                                                        EXTENSION_VERSION.SEMVER_PATCH))))
+                                                        EXTENSION_VERSION.SEMVER_PATCH,
+                                                        EXTENSION_VERSION.TIMESTAMP,
+                                                        EXTENSION_VERSION.ID))))
                 .lt(limit);
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
@@ -45,9 +45,20 @@ public class ExtensionVersionJooqRepository {
         this.dsl = dsl;
     }
 
+    /**
+     * An extension's stable release history stays bounded on its own, but a pre-release channel
+     * can publish one build per commit and accumulate thousands of entries - {@code
+     * maxPreReleaseVersions} keeps only that many of the most recent ones per extension (across all
+     * of its target platforms combined), ranked by the same semver-based ordering {@code
+     * ExtensionVersion.SORT_COMPARATOR} uses for "latest", so the true latest pre-release - rank #1 -
+     * is never dropped by the cap. The caller decides the limit rather than it being fixed here; a
+     * negative value (e.g. {@code -1}) disables the cap entirely, matching the "negative means
+     * unlimited" convention already used for {@code ovsx.data.mirror.requests-per-second}.
+     */
     public List<ExtensionVersion> findAllActiveByExtensionIdAndTargetPlatform(
             Collection<Long> extensionIds,
-            String targetPlatform
+            String targetPlatform,
+            int maxPreReleaseVersions
     ) {
         var query = dsl.select(
                 NAMESPACE.ID,
@@ -83,11 +94,39 @@ public class ExtensionVersionJooqRepository {
                 .where(EXTENSION_VERSION.ACTIVE.eq(true))
                 .and(EXTENSION_VERSION.EXTENSION_ID.in(extensionIds));
 
+        if (maxPreReleaseVersions >= 0) {
+            query = query.and(
+                    EXTENSION_VERSION.PRE_RELEASE.isFalse()
+                            .or(isAmongLatestPreReleases(maxPreReleaseVersions)));
+        }
+
         if (targetPlatform != null) {
             query = query.and(EXTENSION_VERSION.TARGET_PLATFORM.eq(targetPlatform));
         }
 
         return query.fetch().map(this::toExtensionVersion);
+    }
+
+    /**
+     * True for an active pre-release version if fewer than {@code limit} other active pre-releases
+     * of the same extension - regardless of target platform - outrank it by semver.
+     */
+    private Condition isAmongLatestPreReleases(int limit) {
+        var rank = EXTENSION_VERSION.as("ev_pre_release_rank");
+        return DSL.field(
+                dsl.selectCount()
+                        .from(rank)
+                        .where(rank.EXTENSION_ID.eq(EXTENSION_VERSION.EXTENSION_ID))
+                        .and(rank.ACTIVE.isTrue())
+                        .and(rank.PRE_RELEASE.isTrue())
+                        .and(
+                                DSL.row(rank.SEMVER_MAJOR, rank.SEMVER_MINOR, rank.SEMVER_PATCH)
+                                        .gt(
+                                                DSL.row(
+                                                        EXTENSION_VERSION.SEMVER_MAJOR,
+                                                        EXTENSION_VERSION.SEMVER_MINOR,
+                                                        EXTENSION_VERSION.SEMVER_PATCH))))
+                .lt(limit);
     }
 
     public Page<String> findActiveVersionStringsSorted(

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -649,8 +649,13 @@ public class RepositoryService {
         return extensionVersionChangeRepo.findFirstByExtensionVersionOrderByChangedAtDescIdDesc(extVersion);
     }
 
-    public List<ExtensionVersion> findActiveExtensionVersions(Collection<Long> extensionIds, String targetPlatform) {
-        return extensionVersionJooqRepo.findAllActiveByExtensionIdAndTargetPlatform(extensionIds, targetPlatform);
+    public List<ExtensionVersion> findActiveExtensionVersions(
+            Collection<Long> extensionIds,
+            String targetPlatform,
+            int maxPreReleaseVersions
+    ) {
+        return extensionVersionJooqRepo
+                .findAllActiveByExtensionIdAndTargetPlatform(extensionIds, targetPlatform, maxPreReleaseVersions);
     }
 
     public List<FileResource> findFileResourcesByExtensionVersionIdAndType(

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -93,6 +93,9 @@ import static org.eclipse.openvsx.entities.FileResource.*;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
@@ -2673,7 +2676,10 @@ class RegistryAPITest {
             versions.add(extVersion);
         }
 
-        Mockito.when(repositories.findActiveExtensionVersions(Set.of(extension.getId()), null))
+        Mockito
+                .when(
+                        repositories
+                                .findActiveExtensionVersions(eq(Set.of(extension.getId())), isNull(), anyInt()))
                 .thenReturn(versions);
         Mockito.when(repositories.findLatestVersionsIsPreview(Set.of(extension.getId())))
                 .thenReturn(Map.of(extension.getId(), versions.getFirst().isPreview()));
@@ -2715,7 +2721,10 @@ class RegistryAPITest {
         extVersion.setDisplayName("Foo Bar");
         extVersion.setExtension(extension);
 
-        Mockito.when(repositories.findActiveExtensionVersions(Set.of(extension.getId()), null))
+        Mockito
+                .when(
+                        repositories
+                                .findActiveExtensionVersions(eq(Set.of(extension.getId())), isNull(), anyInt()))
                 .thenReturn(List.of(extVersion));
 
         Mockito.when(repositories.findLatestVersionsIsPreview(Set.of(extension.getId())))

--- a/server/src/test/java/org/eclipse/openvsx/adapter/LocalVSCodeServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/LocalVSCodeServiceTest.java
@@ -72,7 +72,8 @@ public class LocalVSCodeServiceTest {
 
         Mockito.when(repositories.findActiveExtensionsByPublicId(any(), any()))
                 .thenReturn(List.of(extension, extension));
-        Mockito.when(repositories.findActiveExtensionVersions(any(), any())).thenReturn(List.of(extensionVersion));
+        Mockito.when(repositories.findActiveExtensionVersions(any(), any(), anyInt()))
+                .thenReturn(List.of(extensionVersion));
         Mockito.when(versions.getLatest(anyList(), anyBoolean())).thenReturn(extensionVersion);
 
         var result = vsCodeService.extensionQuery(param, 10);

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -68,6 +68,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.openvsx.entities.FileResource.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -1087,7 +1089,12 @@ class VSCodeAPITest {
             }
         }
 
-        Mockito.when(repositories.findActiveExtensionVersions(Set.of(extension.getId()), queryTargetPlatform))
+        Mockito
+                .when(
+                        repositories.findActiveExtensionVersions(
+                                eq(Set.of(extension.getId())),
+                                eq(queryTargetPlatform),
+                                anyInt()))
                 .thenReturn(extVersions);
 
         mockFileResources(extVersions);

--- a/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryTest.java
@@ -13,6 +13,8 @@
 package org.eclipse.openvsx.repositories;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
@@ -162,6 +164,102 @@ class ExtensionVersionJooqRepositoryTest extends AbstractPostgresContainerTest {
         assertThat(repo.isDeleteAllActiveVersions("ns6", "ext6")).isFalse();
     }
 
+    @Test
+    void capsPreReleaseVersionsButKeepsAllStableVersions() {
+        var extension = persistExtension("ns7", "ext7");
+        persistVersion(extension, "1.0.0", TargetPlatform.NAME_UNIVERSAL, true);
+        persistVersion(extension, "2.0.0", TargetPlatform.NAME_UNIVERSAL, true);
+        persistPreReleaseVersions(extension, TargetPlatform.NAME_UNIVERSAL, 1, 105);
+
+        var result = repo.findAllActiveByExtensionIdAndTargetPlatform(List.of(extension.getId()), null, 100);
+
+        var stable = result.stream()
+                .filter(ev -> !ev.isPreRelease())
+                .map(ExtensionVersion::getVersion)
+                .toList();
+        var preRelease = result.stream()
+                .filter(ExtensionVersion::isPreRelease)
+                .map(ExtensionVersion::getVersion)
+                .toList();
+
+        assertThat(stable)
+                .as("stable releases must never be affected by the pre-release cap")
+                .containsExactlyInAnyOrder("1.0.0", "2.0.0");
+        assertThat(preRelease).as("pre-releases must be capped at 100").hasSize(100);
+        assertThat(preRelease)
+                .as("the highest-semver pre-release ('latest') must survive the cap")
+                .contains("0.0.105");
+        assertThat(preRelease)
+                .as("the 5 lowest-semver pre-releases must be dropped by the cap")
+                .doesNotContain("0.0.1", "0.0.2", "0.0.3", "0.0.4", "0.0.5");
+    }
+
+    @Test
+    void capsPreReleaseVersionsAcrossTargetPlatformsCombinedRatherThanPerPlatform() {
+        var extension = persistExtension("ns8", "ext8");
+        persistPreReleaseVersions(extension, TargetPlatform.NAME_LINUX_X64, 1, 60);
+        persistPreReleaseVersions(extension, TargetPlatform.NAME_WIN32_X64, 61, 105);
+
+        var result = repo.findAllActiveByExtensionIdAndTargetPlatform(List.of(extension.getId()), null, 100);
+        var versions = result.stream().map(ExtensionVersion::getVersion).collect(Collectors.toSet());
+
+        assertThat(result)
+                .as("the cap counts pre-releases across all target platforms of the extension combined")
+                .hasSize(100);
+        for (var patch = 6; patch <= 105; patch++) {
+            assertThat(versions).contains("0.0." + patch);
+        }
+        for (var patch = 1; patch <= 5; patch++) {
+            assertThat(versions).doesNotContain("0.0." + patch);
+        }
+    }
+
+    @Test
+    void targetPlatformFilterIsAppliedAfterTheCrossPlatformPreReleaseCap() {
+        // 99 higher-semver win32 pre-releases crowd out all but the newest of the 2 linux
+        // pre-releases from the cross-platform top-100 cap, before the win32-x64 filter below is
+        // even applied - so requesting linux-x64 only can see fewer than 100 versions even though
+        // more than 100 exist for the extension overall.
+        var extension = persistExtension("ns9", "ext9");
+        persistPreReleaseVersions(extension, TargetPlatform.NAME_WIN32_X64, 1, 99, "1.0.");
+        persistPreReleaseVersions(extension, TargetPlatform.NAME_LINUX_X64, 1, 2);
+
+        var linuxOnly = repo.findAllActiveByExtensionIdAndTargetPlatform(
+                List.of(extension.getId()),
+                TargetPlatform.NAME_LINUX_X64,
+                100);
+
+        assertThat(linuxOnly).extracting(ExtensionVersion::getVersion).containsExactly("0.0.2");
+    }
+
+    @Test
+    void honoursTheCallerSuppliedPreReleaseCapInsteadOfAFixedOne() {
+        var extension = persistExtension("ns10", "ext10");
+        persistPreReleaseVersions(extension, TargetPlatform.NAME_UNIVERSAL, 1, 5);
+
+        var result = repo.findAllActiveByExtensionIdAndTargetPlatform(List.of(extension.getId()), null, 3);
+
+        assertThat(result)
+                .as("the cap is whatever the caller passes in, not a value fixed inside the repository")
+                .extracting(ExtensionVersion::getVersion)
+                .containsExactlyInAnyOrder("0.0.3", "0.0.4", "0.0.5");
+    }
+
+    @Test
+    void negativeMaxPreReleaseVersionsDisablesTheCapEntirely() {
+        // A negative "count < limit" can never hold, so a naive reading of the cap would exclude
+        // *every* pre-release rather than none - the opposite of "unlimited". This pins down that
+        // -1 (and negative values generally) instead skip the cap condition altogether, matching
+        // the "negative means unlimited" convention already used elsewhere in this codebase (e.g.
+        // ovsx.data.mirror.requests-per-second).
+        var extension = persistExtension("ns11", "ext11");
+        persistPreReleaseVersions(extension, TargetPlatform.NAME_UNIVERSAL, 1, 105);
+
+        var result = repo.findAllActiveByExtensionIdAndTargetPlatform(List.of(extension.getId()), null, -1);
+
+        assertThat(result).as("a negative cap must return every active pre-release, uncapped").hasSize(105);
+    }
+
     private Namespace persistNamespace(String namespaceName) {
         var namespace = new Namespace();
         namespace.setName(namespaceName);
@@ -198,5 +296,33 @@ class ExtensionVersionJooqRepositoryTest extends AbstractPostgresContainerTest {
         // bypassing the persistence context, so pending inserts must be flushed before they become
         // visible to it.
         em.flush();
+    }
+
+    /**
+     * Persists active pre-release versions {@code <versionPrefix><fromPatch>} .. {@code
+     * <versionPrefix><toPatch>} (inclusive), one flush for the whole batch rather than one per row.
+     */
+    private void persistPreReleaseVersions(
+            Extension extension,
+            String targetPlatform,
+            int fromPatch,
+            int toPatch,
+            String versionPrefix
+    ) {
+        for (var patch = fromPatch; patch <= toPatch; patch++) {
+            var extVersion = new ExtensionVersion();
+            extVersion.setExtension(extension);
+            extVersion.setVersion(versionPrefix + patch);
+            extVersion.setTargetPlatform(targetPlatform);
+            extVersion.setActive(true);
+            extVersion.setPreRelease(true);
+            extVersion.setPublishedWith(token);
+            em.persist(extVersion);
+        }
+        em.flush();
+    }
+
+    private void persistPreReleaseVersions(Extension extension, String targetPlatform, int fromPatch, int toPatch) {
+        persistPreReleaseVersions(extension, targetPlatform, fromPatch, toPatch, "0.0.");
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryTest.java
@@ -246,6 +246,35 @@ class ExtensionVersionJooqRepositoryTest extends AbstractPostgresContainerTest {
     }
 
     @Test
+    void tiedMajorMinorPatchPreReleasesAreStillCappedViaTheTimestampTiebreak() {
+        // All 105 rows share the exact same (major, minor, patch) - the version string itself is
+        // identical - and differ only in target platform and timestamp, exactly like one release
+        // published across many platform builds, or a CI channel that republishes without ever
+        // bumping semver. On a (major, minor, patch)-only comparison none of these rows outranks
+        // any other, so none would count against the cap and all 105 would come back uncapped.
+        var extension = persistExtension("ns12", "ext12");
+        var base = LocalDateTime.parse("2024-01-01T00:00:00");
+        for (var i = 1; i <= 105; i++) {
+            persistPreReleaseVersion(extension, "0.0.1", "platform-" + i, base.plusMinutes(i));
+        }
+        em.flush();
+
+        var result = repo.findAllActiveByExtensionIdAndTargetPlatform(List.of(extension.getId()), null, 100);
+
+        assertThat(result)
+                .as("rows tied on (major, minor, patch) must still be capped, via the timestamp/id tiebreak")
+                .hasSize(100);
+        assertThat(result)
+                .as("the most recently timestamped tied row ('latest') must survive the cap")
+                .anyMatch(ev -> ev.getTargetPlatform().equals("platform-105"));
+        assertThat(result)
+                .as("the 5 earliest-timestamped tied rows must be dropped by the cap")
+                .noneMatch(
+                        ev -> List.of("platform-1", "platform-2", "platform-3", "platform-4", "platform-5")
+                                .contains(ev.getTargetPlatform()));
+    }
+
+    @Test
     void negativeMaxPreReleaseVersionsDisablesTheCapEntirely() {
         // A negative "count < limit" can never hold, so a naive reading of the cap would exclude
         // *every* pre-release rather than none - the opposite of "unlimited". This pins down that
@@ -324,5 +353,22 @@ class ExtensionVersionJooqRepositoryTest extends AbstractPostgresContainerTest {
 
     private void persistPreReleaseVersions(Extension extension, String targetPlatform, int fromPatch, int toPatch) {
         persistPreReleaseVersions(extension, targetPlatform, fromPatch, toPatch, "0.0.");
+    }
+
+    private void persistPreReleaseVersion(
+            Extension extension,
+            String version,
+            String targetPlatform,
+            LocalDateTime timestamp
+    ) {
+        var extVersion = new ExtensionVersion();
+        extVersion.setExtension(extension);
+        extVersion.setVersion(version);
+        extVersion.setTargetPlatform(targetPlatform);
+        extVersion.setActive(true);
+        extVersion.setPreRelease(true);
+        extVersion.setTimestamp(timestamp);
+        extVersion.setPublishedWith(token);
+        em.persist(extVersion);
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -249,7 +249,7 @@ class RepositoryServiceSmokeTest extends AbstractPostgresContainerTest {
                 () -> repositories.topNamespaceExtensions(1),
                 () -> repositories.topNamespaceExtensionVersions(1),
                 () -> repositories.findFileResourcesByExtensionVersionIdAndType(LONG_LIST, STRING_LIST),
-                () -> repositories.findActiveExtensionVersions(LONG_LIST, "targetPlatform"),
+                () -> repositories.findActiveExtensionVersions(LONG_LIST, "targetPlatform", 100),
                 () -> repositories.findActiveExtension("name", "namespaceName"),
                 () -> repositories.findActiveExtensionsById(LONG_LIST),
                 () -> repositories.findActiveExtensionsByPublicId(STRING_LIST, "namespaceName"),


### PR DESCRIPTION
## What

`extensionQuery` (`/vscode/gallery/extensionquery`) fetches every active version of every requested extension when `FLAG_INCLUDE_VERSIONS` or `FLAG_INCLUDE_VERSION_PROPERTIES` is set. For an extension whose pre-release channel publishes one build per commit, that history can grow into the thousands, making the query and the response needlessly expensive.

Regular releases are left completely untouched. Active pre-release versions are now capped to the most recent N per extension (combined across all of its target platforms), ranked by the same semver-based ordering `ExtensionVersion.SORT_COMPARATOR` uses for "latest" - so the true latest pre-release (rank #1) can never be dropped by the cap, and downstream "latest version" computations stay correct.

## How

The cap is a plain method parameter threaded through:

```
LocalVSCodeService -> RepositoryService.findActiveExtensionVersions -> ExtensionVersionJooqRepository.findAllActiveByExtensionIdAndTargetPlatform
```

configured on `LocalVSCodeService` via `ovsx.extension-query.max-pre-release-versions` (default `100`). A negative value (e.g. `-1`) disables the cap entirely, matching the "negative means unlimited" convention already used for `ovsx.data.mirror.requests-per-second`.

Implementation detail: the SQL adds a correlated-subquery condition (`EXTENSION_VERSION.PRE_RELEASE.isFalse().or(isAmongLatestPreReleases(limit))`) rather than a window-function/derived-table rewrite, since the existing flat query's generic `toExtensionVersion` row mapper can't safely be reused once wrapped in a derived table (duplicate `NAMESPACE.ID`/`EXTENSION.ID`/`EXTENSION_VERSION.ID` column names collide once re-selected).

## Testing

`ExtensionVersionJooqRepositoryTest` gains coverage for:
- capping pre-releases while leaving all stable releases untouched
- capping across an extension's target platforms combined, not per platform
- the target-platform filter being applied *after* the cross-platform cap (so a platform-scoped request can see fewer versions than exist for that platform)
- honouring a caller-supplied limit rather than a value fixed in the repository
- a negative limit disabling the cap entirely

Existing call sites/mocks (`LocalVSCodeServiceTest`, `VSCodeAPITest`, `RegistryAPITest`, `RepositoryServiceSmokeTest`) updated for the new parameter.