### PR TITLE
bug: consume request body before sending response

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -9,7 +9,9 @@
  ********************************************************************************/
 package org.eclipse.openvsx;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -715,7 +717,7 @@ public class LocalRegistryService implements IExtensionRegistry {
     public ResultJson createNamespace(NamespaceJson json, String tokenValue) {
         var token = tokens.useAccessToken(tokenValue);
         if (token == null) {
-            throw new ErrorResultException(ACCESS_TOKEN_ERROR);
+            throw new ErrorResultException(ACCESS_TOKEN_ERROR, HttpStatus.UNAUTHORIZED);
         }
 
         return createNamespace(json, token.getUser());
@@ -793,9 +795,14 @@ public class LocalRegistryService implements IExtensionRegistry {
     }
 
     public ExtensionJson publish(InputStream content, String tokenValue) throws ErrorResultException {
-        var token = tokens.useAccessToken(tokenValue);
+        PersonalAccessToken token = tokens.useAccessToken(tokenValue);
         if (token == null || token.getUser() == null) {
-            throw new ErrorResultException(ACCESS_TOKEN_ERROR);
+            try {
+                content.transferTo(OutputStream.nullOutputStream());
+            } catch (IOException ignored) {
+                // best-effort drain; connection state doesn't matter once we're returning an error
+            }
+            throw new ErrorResultException(ACCESS_TOKEN_ERROR, HttpStatus.UNAUTHORIZED);
         }
 
         // Check whether the user has a valid publisher agreement

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -769,7 +769,7 @@ public class LocalRegistryService implements IExtensionRegistry {
     public ResultJson verifyToken(String namespaceName, String tokenValue) {
         var token = tokens.useAccessToken(tokenValue);
         if (token == null) {
-            throw new ErrorResultException(ACCESS_TOKEN_ERROR);
+            throw new ErrorResultException(ACCESS_TOKEN_ERROR, HttpStatus.UNAUTHORIZED);
         }
 
         var namespace = repositories.findNamespace(namespaceName);
@@ -779,7 +779,9 @@ public class LocalRegistryService implements IExtensionRegistry {
 
         var user = token.getUser();
         if (!users.hasPublishPermission(user, namespace)) {
-            throw new ErrorResultException("Insufficient access rights for namespace: " + namespace.getName());
+            throw new ErrorResultException(
+                    "Insufficient access rights for namespace: " + namespace.getName(),
+                    HttpStatus.FORBIDDEN);
         }
 
         return ResultJson.success("Valid token");
@@ -795,18 +797,27 @@ public class LocalRegistryService implements IExtensionRegistry {
     }
 
     public ExtensionJson publish(InputStream content, String tokenValue) throws ErrorResultException {
-        PersonalAccessToken token = tokens.useAccessToken(tokenValue);
-        if (token == null || token.getUser() == null) {
+        // Everything up to extensions.publishVersion(...) below can reject the request without ever
+        // touching `content` (invalid/expired token, missing publisher agreement). Drain it before
+        // any such rejection is sent, so a LB/proxy doesn't see an early response to a request whose
+        // body is still arriving and mistake it for a 50x.
+        PersonalAccessToken token;
+        try {
+            token = tokens.useAccessToken(tokenValue);
+            if (token == null || token.getUser() == null) {
+                throw new ErrorResultException(ACCESS_TOKEN_ERROR, HttpStatus.UNAUTHORIZED);
+            }
+
+            // Check whether the user has a valid publisher agreement
+            eclipse.checkPublisherAgreement(token.getUser());
+        } catch (ErrorResultException exc) {
             try {
                 content.transferTo(OutputStream.nullOutputStream());
             } catch (IOException ignored) {
                 // best-effort drain; connection state doesn't matter once we're returning an error
             }
-            throw new ErrorResultException(ACCESS_TOKEN_ERROR, HttpStatus.UNAUTHORIZED);
+            throw exc;
         }
-
-        // Check whether the user has a valid publisher agreement
-        eclipse.checkPublisherAgreement(token.getUser());
 
         var extVersion = extensions.publishVersion(content, token);
         var json = toExtensionVersionJson(extVersion, null, true);

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -803,8 +803,9 @@ public class LocalRegistryService implements IExtensionRegistry {
         // try-with-resources to always close it, on every exit path, drains whatever is left
         // automatically instead of requiring each rejection site to remember to do it, so a LB/proxy
         // doesn't see an early response to a request whose body is still arriving and mistake it
-        // for a 50x.
-        try (var content = new DrainOnCloseInputStream(rawContent)) {
+        // for a 50x. Capped at the same max upload size a successful publish already reads in full,
+        // so an oversized/abusive body doesn't tie up the request thread and bandwidth beyond that.
+        try (var content = new DrainOnCloseInputStream(rawContent, publishingConfig.getMaxContentSize())) {
             var token = tokens.useAccessToken(tokenValue);
             if (token == null || token.getUser() == null) {
                 throw new ErrorResultException(ACCESS_TOKEN_ERROR, HttpStatus.UNAUTHORIZED);

--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -11,7 +11,6 @@ package org.eclipse.openvsx;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -47,6 +46,7 @@ import org.eclipse.openvsx.search.SearchUtilService;
 import org.eclipse.openvsx.search.SimilarityCheckService;
 import org.eclipse.openvsx.storage.StorageUtilService;
 import org.eclipse.openvsx.util.ChangesCursor;
+import org.eclipse.openvsx.util.DrainOnCloseInputStream;
 import org.eclipse.openvsx.util.ErrorResultException;
 import org.eclipse.openvsx.util.ExtensionId;
 import org.eclipse.openvsx.util.NamingUtil;
@@ -796,53 +796,50 @@ public class LocalRegistryService implements IExtensionRegistry {
         }
     }
 
-    public ExtensionJson publish(InputStream content, String tokenValue) throws ErrorResultException {
-        // Everything up to extensions.publishVersion(...) below can reject the request without ever
-        // touching `content` (invalid/expired token, missing publisher agreement). Drain it before
-        // any such rejection is sent, so a LB/proxy doesn't see an early response to a request whose
-        // body is still arriving and mistake it for a 50x.
-        PersonalAccessToken token;
-        try {
-            token = tokens.useAccessToken(tokenValue);
+    public ExtensionJson publish(InputStream rawContent, String tokenValue) throws ErrorResultException {
+        // A rejection anywhere below - invalid/expired token, missing publisher agreement, or
+        // (pre-existing, inside extensions.publishVersion) an oversized package - can happen before
+        // the request body has been fully read. Wrapping it once here and relying on
+        // try-with-resources to always close it, on every exit path, drains whatever is left
+        // automatically instead of requiring each rejection site to remember to do it, so a LB/proxy
+        // doesn't see an early response to a request whose body is still arriving and mistake it
+        // for a 50x.
+        try (var content = new DrainOnCloseInputStream(rawContent)) {
+            var token = tokens.useAccessToken(tokenValue);
             if (token == null || token.getUser() == null) {
                 throw new ErrorResultException(ACCESS_TOKEN_ERROR, HttpStatus.UNAUTHORIZED);
             }
 
             // Check whether the user has a valid publisher agreement
             eclipse.checkPublisherAgreement(token.getUser());
-        } catch (ErrorResultException exc) {
-            try {
-                content.transferTo(OutputStream.nullOutputStream());
-            } catch (IOException ignored) {
-                // best-effort drain; connection state doesn't matter once we're returning an error
+
+            var extVersion = extensions.publishVersion(content, token);
+            var json = toExtensionVersionJson(extVersion, null, true);
+            json.setSuccess("It can take a couple minutes before the extension version is available");
+
+            if (repositories.hasSameVersion(extVersion)) {
+                var existingRelease = extVersion.isPreRelease() ? "stable release" : "pre-release";
+                var thisRelease = extVersion.isPreRelease() ? "pre-release" : "stable release";
+                var extension = extVersion.getExtension();
+                var semver = extVersion.getSemanticVersion();
+                var newVersion = String
+                        .join(".", String.valueOf(semver.getMajor()), String.valueOf(semver.getMinor() + 1), "0");
+
+                json.setWarning(
+                        "A " + existingRelease + " already exists for "
+                                + NamingUtil.toLogFormat(
+                                        extension.getNamespace().getName(),
+                                        extension.getName(),
+                                        extVersion.getVersion())
+                                + ".\n" +
+                                "To prevent update conflicts, we recommend that this " + thisRelease + " uses "
+                                + newVersion + " as its version instead.");
             }
-            throw exc;
+
+            return json;
+        } catch (IOException e) {
+            throw new ErrorResultException("Failed to read extension file", e);
         }
-
-        var extVersion = extensions.publishVersion(content, token);
-        var json = toExtensionVersionJson(extVersion, null, true);
-        json.setSuccess("It can take a couple minutes before the extension version is available");
-
-        if (repositories.hasSameVersion(extVersion)) {
-            var existingRelease = extVersion.isPreRelease() ? "stable release" : "pre-release";
-            var thisRelease = extVersion.isPreRelease() ? "pre-release" : "stable release";
-            var extension = extVersion.getExtension();
-            var semver = extVersion.getSemanticVersion();
-            var newVersion = String
-                    .join(".", String.valueOf(semver.getMajor()), String.valueOf(semver.getMinor() + 1), "0");
-
-            json.setWarning(
-                    "A " + existingRelease + " already exists for "
-                            + NamingUtil.toLogFormat(
-                                    extension.getNamespace().getName(),
-                                    extension.getName(),
-                                    extVersion.getVersion())
-                            + ".\n" +
-                            "To prevent update conflicts, we recommend that this " + thisRelease + " uses " + newVersion
-                            + " as its version instead.");
-        }
-
-        return json;
     }
 
     @Transactional(rollbackOn = ResponseStatusException.class)

--- a/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
@@ -128,8 +128,13 @@ public class RegistryAPI {
         content = @Content(schema = @Schema(implementation = ResultJson.class))
     )
     @ApiResponse(
-        responseCode = "400",
-        description = "The token has no publishing permission in the namespace or is not valid",
+        responseCode = "401",
+        description = "The token is missing, invalid or expired",
+        content = @Content(schema = @Schema(implementation = ResultJson.class))
+    )
+    @ApiResponse(
+        responseCode = "403",
+        description = "The token is valid but has no publishing permission in the namespace",
         content = @Content(schema = @Schema(implementation = ResultJson.class))
     )
     @ApiResponse(
@@ -1407,8 +1412,22 @@ public class RegistryAPI {
         description = "The extension could not be published",
         content = @Content(
             mediaType = MediaType.APPLICATION_JSON_VALUE,
+            examples = @ExampleObject(value = "{ \"error\": \"Unknown publisher: foobar\" }")
+        )
+    )
+    @ApiResponse(
+        responseCode = "401",
+        description = "The token is missing, invalid or expired",
+        content = @Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
             examples = @ExampleObject(value = "{ \"error\": \"Invalid access token.\" }")
         )
+    )
+    @ApiResponse(
+        responseCode = "403",
+        description = "The token is valid but has no publishing permission in the namespace, "
+                + "or the user has not signed a Publisher Agreement",
+        content = @Content(schema = @Schema(implementation = ResultJson.class))
     )
     public ResponseEntity<ExtensionJson> publish(
             InputStream content,
@@ -1464,7 +1483,8 @@ public class RegistryAPI {
     )
     @ApiResponse(
         responseCode = "403",
-        description = "User is not logged in"
+        description = "User is not logged in, has no publishing permission in the namespace, "
+                + "or has not signed a Publisher Agreement"
     )
     public ResponseEntity<ExtensionJson> publish(InputStream content) {
         try {

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
@@ -114,9 +114,10 @@ public class AccessTokenService {
         if (token == null || !token.isActive()) {
             return null;
         }
-        // expiration
+        // expiration - <=, not <, to match expireAccessTokens' "expires_timestamp <= ?1" and
+        // findByExpiresTimestampLessThanEqual...: a token expiring at exactly `now` is expired.
         LocalDateTime now = TimeUtil.getCurrentUTC();
-        if (token.getExpiresTimestamp() != null && token.getExpiresTimestamp().isBefore(now)) {
+        if (token.getExpiresTimestamp() != null && !token.getExpiresTimestamp().isAfter(now)) {
             token.setActive(false);
             return null;
         }

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
@@ -29,6 +29,7 @@ import org.eclipse.openvsx.util.NotFoundException;
 import org.eclipse.openvsx.util.TimeUtil;
 import org.eclipse.openvsx.util.UrlUtil;
 
+import static jakarta.transaction.Transactional.TxType;
 import static org.eclipse.openvsx.util.UrlUtil.createApiUrl;
 
 @Service
@@ -100,7 +101,13 @@ public class AccessTokenService {
         return ResultJson.success("Deactivated access token for user " + user.getLoginName() + ".");
     }
 
-    @Transactional
+    // REQUIRES_NEW: callers such as LocalRegistryService#createNamespace(NamespaceJson, String) wrap
+    // the whole request in their own @Transactional(rollbackOn = ErrorResultException.class). Without
+    // its own transaction, the setActive(false)/setAccessedTimestamp mutations below would join that
+    // caller's transaction and be rolled back together with the very ErrorResultException the caller
+    // throws once this method returns null - silently discarding the fact that the token was touched
+    // or found expired.
+    @Transactional(TxType.REQUIRES_NEW)
     public PersonalAccessToken useAccessToken(String tokenValue) {
         var token = repositories.findAccessToken(tokenValue);
         // existence + active

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
@@ -103,7 +103,14 @@ public class AccessTokenService {
     @Transactional
     public PersonalAccessToken useAccessToken(String tokenValue) {
         var token = repositories.findAccessToken(tokenValue);
+        // existence + active
         if (token == null || !token.isActive()) {
+            return null;
+        }
+        // expiration
+        LocalDateTime now = TimeUtil.getCurrentUTC();
+        if (token.getExpiresTimestamp() != null && token.getExpiresTimestamp().isBefore(now)) {
+            token.setActive(false);
             return null;
         }
         token.setAccessedTimestamp(TimeUtil.getCurrentUTC());

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
@@ -113,7 +113,8 @@ public class EclipseService {
         var personId = user.getEclipsePersonId();
         if (personId == null) {
             throw new ErrorResultException(
-                    "You must log in with an Eclipse Foundation account and sign a Publisher Agreement before publishing any extension.");
+                    "You must log in with an Eclipse Foundation account and sign a Publisher Agreement before publishing any extension.",
+                    HttpStatus.FORBIDDEN);
         }
 
         var json = user.toUserJson();
@@ -122,7 +123,8 @@ public class EclipseService {
 
         if (publisherAgreement == null || publisherAgreement.getStatus().equals("none")) {
             throw new ErrorResultException(
-                    "You must sign a Publisher Agreement with the Eclipse Foundation before publishing any extension.");
+                    "You must sign a Publisher Agreement with the Eclipse Foundation before publishing any extension.",
+                    HttpStatus.FORBIDDEN);
         }
 
         if (!publisherAgreement.getStatus().equals("signed")) {
@@ -130,9 +132,12 @@ public class EclipseService {
                 throw new ErrorResultException(
                         "Your Publisher Agreement with the Eclipse Foundation is outdated (version "
                                 + publisherAgreement.getVersion() + "). The current version is "
-                                + publisherAgreementVersion + ".");
+                                + publisherAgreementVersion + ".",
+                        HttpStatus.FORBIDDEN);
             } else {
-                throw new ErrorResultException("Your Publisher Agreement with the Eclipse Foundation is outdated.");
+                throw new ErrorResultException(
+                        "Your Publisher Agreement with the Eclipse Foundation is outdated.",
+                        HttpStatus.FORBIDDEN);
             }
         }
     }

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -30,6 +30,7 @@ import org.jobrunr.scheduling.JobRequestScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.resilience.annotation.Retryable;
 import org.springframework.resilience.retry.MethodRetryPredicate;
 import org.springframework.scheduling.annotation.Async;
@@ -192,7 +193,9 @@ public class PublishExtensionVersionHandler {
                             + "\nUse the 'create-namespace' command to create a namespace corresponding to your publisher name.");
         }
         if (!users.hasPublishPermission(user, namespace)) {
-            throw new ErrorResultException("Insufficient access rights for publisher: " + namespace.getName());
+            throw new ErrorResultException(
+                    "Insufficient access rights for publisher: " + namespace.getName(),
+                    HttpStatus.FORBIDDEN);
         }
         return namespace;
     }

--- a/server/src/main/java/org/eclipse/openvsx/util/DrainOnCloseInputStream.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/DrainOnCloseInputStream.java
@@ -17,8 +17,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import com.google.common.io.ByteStreams;
+
 /**
- * InputStream wrapper that drains any remaining unread bytes before closing.
+ * InputStream wrapper that drains up to a fixed number of remaining unread bytes before closing.
  * <p>
  * A request body that a validation check rejects before the body has been fully read can make
  * some load balancers/proxies mistake the resulting early connection close for a server error.
@@ -26,17 +28,52 @@ import java.io.OutputStream;
  * try-with-resources makes draining automatic on every exit path - success, an early validation
  * throw, or anything added later - instead of relying on each call site remembering to drain
  * manually before it responds.
+ * <p>
+ * The <b>total</b> bytes ever read from the underlying stream over this instance's lifetime -
+ * whatever a caller reads normally before rejecting, plus whatever close() then drains - is capped
+ * at {@code maxBytes}: without a bound, a client rejected for any reason (invalid token, an
+ * oversized upload, ...) could force the server to read and discard an arbitrarily large body
+ * before responding, trading the original LB/proxy problem for a resource-exhaustion one.
+ * {@code maxBytes} should be the same "reasonable size" limit the caller already accepts reading
+ * in full on the success path (e.g. the configured max upload size) - draining up to that bound
+ * costs nothing beyond what a legitimate request already costs, while anything beyond it is by
+ * definition not a legitimate request, and is left undrained.
  */
 public class DrainOnCloseInputStream extends FilterInputStream {
 
-    public DrainOnCloseInputStream(InputStream in) {
+    private final long maxBytes;
+    private long bytesRead = 0;
+
+    public DrainOnCloseInputStream(InputStream in, long maxBytes) {
         super(in);
+        this.maxBytes = maxBytes;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int b = super.read();
+        if (b != -1) {
+            bytesRead++;
+        }
+        return b;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int n = super.read(b, off, len);
+        if (n != -1) {
+            bytesRead += n;
+        }
+        return n;
     }
 
     @Override
     public void close() throws IOException {
         try {
-            transferTo(OutputStream.nullOutputStream());
+            long remaining = maxBytes - bytesRead;
+            if (remaining > 0) {
+                ByteStreams.limit(this, remaining).transferTo(OutputStream.nullOutputStream());
+            }
         } catch (IOException ignored) {
             // best-effort drain; connection state doesn't matter once we're closing this stream
         } finally {

--- a/server/src/main/java/org/eclipse/openvsx/util/DrainOnCloseInputStream.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/DrainOnCloseInputStream.java
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.util;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * InputStream wrapper that drains any remaining unread bytes before closing.
+ * <p>
+ * A request body that a validation check rejects before the body has been fully read can make
+ * some load balancers/proxies mistake the resulting early connection close for a server error.
+ * Wrapping a request InputStream once at the entry point and reading it exclusively through
+ * try-with-resources makes draining automatic on every exit path - success, an early validation
+ * throw, or anything added later - instead of relying on each call site remembering to drain
+ * manually before it responds.
+ */
+public class DrainOnCloseInputStream extends FilterInputStream {
+
+    public DrainOnCloseInputStream(InputStream in) {
+        super(in);
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            transferTo(OutputStream.nullOutputStream());
+        } catch (IOException ignored) {
+            // best-effort drain; connection state doesn't matter once we're closing this stream
+        } finally {
+            super.close();
+        }
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/util/DrainOnCloseInputStream.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/DrainOnCloseInputStream.java
@@ -20,7 +20,8 @@ import java.io.OutputStream;
 import com.google.common.io.ByteStreams;
 
 /**
- * InputStream wrapper that drains up to a fixed number of remaining unread bytes before closing.
+ * InputStream wrapper whose close() drains whatever's left of a {@code maxBytes} budget that
+ * normal reads haven't already consumed.
  * <p>
  * A request body that a validation check rejects before the body has been fully read can make
  * some load balancers/proxies mistake the resulting early connection close for a server error.
@@ -29,15 +30,17 @@ import com.google.common.io.ByteStreams;
  * throw, or anything added later - instead of relying on each call site remembering to drain
  * manually before it responds.
  * <p>
- * The <b>total</b> bytes ever read from the underlying stream over this instance's lifetime -
- * whatever a caller reads normally before rejecting, plus whatever close() then drains - is capped
- * at {@code maxBytes}: without a bound, a client rejected for any reason (invalid token, an
- * oversized upload, ...) could force the server to read and discard an arbitrarily large body
- * before responding, trading the original LB/proxy problem for a resource-exhaustion one.
- * {@code maxBytes} should be the same "reasonable size" limit the caller already accepts reading
- * in full on the success path (e.g. the configured max upload size) - draining up to that bound
- * costs nothing beyond what a legitimate request already costs, while anything beyond it is by
- * definition not a legitimate request, and is left undrained.
+ * This does <b>not</b> itself enforce a hard limit on how many bytes a caller may read normally -
+ * only close()'s own drain is bounded, to whatever remains of {@code maxBytes} once normal reads
+ * are subtracted. Without any bound at all, a client rejected for any reason (invalid token, an
+ * oversized upload, ...) could force close() to read and discard an arbitrarily large remainder
+ * before responding, trading the original LB/proxy problem for a resource-exhaustion one; this
+ * keeps close() itself from being the one to do that. The actual total (normal reads plus
+ * whatever close() drains) only stays bounded near {@code maxBytes} in combination with a caller
+ * that itself stops reading once it has seen enough to reject the request - e.g.
+ * {@code ExtensionService#createExtensionFile}, which detects an oversized package after at most
+ * {@code maxContentSize + 1} bytes. {@code maxBytes} should be that same "reasonable size" limit
+ * the caller already accepts reading in full on the success path.
  */
 public class DrainOnCloseInputStream extends FilterInputStream {
 

--- a/server/src/test/java/org/eclipse/openvsx/ExtensionServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/ExtensionServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.util.Streamable;
+import org.springframework.http.HttpStatus;
 
 import org.eclipse.openvsx.cache.CacheService;
 import org.eclipse.openvsx.entities.*;
@@ -37,6 +38,7 @@ import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.scanning.ExtensionScanPersistenceService;
 import org.eclipse.openvsx.scanning.ExtensionScanService;
 import org.eclipse.openvsx.search.SearchUtilService;
+import org.eclipse.openvsx.util.DrainOnCloseInputStream;
 import org.eclipse.openvsx.util.ErrorResultException;
 import org.eclipse.openvsx.util.LogService;
 
@@ -324,6 +326,26 @@ class ExtensionServiceTest {
         Mockito.verify(scanService, Mockito.never()).removeScan(Mockito.any());
         Mockito.verify(publishHandler, Mockito.never())
                 .publishAsync(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void shouldRejectAPackageExceedingTheMaxContentSize() {
+        var maxContentSize = 10L;
+        Mockito.when(publishingConfig.getMaxContentSize()).thenReturn(maxContentSize);
+
+        var token = mockToken();
+        var raw = new ByteArrayInputStream(
+                "this content is well over ten bytes long".getBytes(StandardCharsets.UTF_8));
+        // LocalRegistryService#publish always wraps the request body this way before calling
+        // publishVersion(...); wrapping it here too, with the same cap, is what actually reaches
+        // this code path in production.
+        var content = new DrainOnCloseInputStream(raw, maxContentSize);
+
+        assertThatThrownBy(() -> svc.publishVersion(content, token))
+                .isInstanceOf(ErrorResultException.class)
+                .hasMessageContaining("exceeds the size limit")
+                .extracting(exc -> ((ErrorResultException) exc).getStatus())
+                .isEqualTo(HttpStatus.CONTENT_TOO_LARGE);
     }
 
     // ---------- UTILITY ----------//

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -1708,7 +1708,7 @@ class RegistryAPITest {
     @Test
     void testCreateNamespaceExpiredToken() throws Exception {
         var token = mockAccessToken();
-        token.setExpiresTimestamp(LocalDateTime.now().minusDays(1));
+        token.setExpiresTimestamp(TimeUtil.getCurrentUTC().minusDays(1));
         mockMvc.perform(
                 post("/api/-/namespace/create?token={token}", "my_token")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -1935,7 +1935,7 @@ class RegistryAPITest {
     @Test
     void testPublishExpiredToken() throws Exception {
         var token = mockAccessToken();
-        token.setExpiresTimestamp(LocalDateTime.now().minusDays(1));
+        token.setExpiresTimestamp(TimeUtil.getCurrentUTC().minusDays(1));
         var bytes = createExtensionPackage("bar", "1.0.0", null);
         mockMvc.perform(
                 post("/api/-/publish?token={token}", "my_token")

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -1757,7 +1757,7 @@ class RegistryAPITest {
         mockForPublish("invalid");
 
         mockMvc.perform(get("/api/{namespace}/verify-pat?token={token}", "foo", "my_token"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -1775,7 +1775,7 @@ class RegistryAPITest {
         mockNamespace();
 
         mockMvc.perform(get("/api/{namespace}/verify-pat?token={token}", "foobar", "my_token"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isForbidden());
     }
 
     @Test
@@ -1786,7 +1786,7 @@ class RegistryAPITest {
                 post("/api/-/publish?token={token}", "my_token")
                         .contentType(MediaType.APPLICATION_OCTET_STREAM)
                         .content(bytes))
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isForbidden())
                 .andExpect(content().json(errorJson("Insufficient access rights for publisher: foo")));
     }
 
@@ -2057,7 +2057,7 @@ class RegistryAPITest {
                 post("/api/-/publish?token={token}", "my_token")
                         .contentType(MediaType.APPLICATION_OCTET_STREAM)
                         .content(bytes))
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isForbidden())
                 .andExpect(content().json(errorJson("Insufficient access rights for publisher: foo")));
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -1701,7 +1701,21 @@ class RegistryAPITest {
                         .content(namespaceJson(n -> {
                             n.setName("foobar");
                         })))
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().json(errorJson("Invalid access token.")));
+    }
+
+    @Test
+    void testCreateNamespaceExpiredToken() throws Exception {
+        var token = mockAccessToken();
+        token.setExpiresTimestamp(LocalDateTime.now().minusDays(1));
+        mockMvc.perform(
+                post("/api/-/namespace/create?token={token}", "my_token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(namespaceJson(n -> {
+                            n.setName("foobar");
+                        })))
+                .andExpect(status().isUnauthorized())
                 .andExpect(content().json(errorJson("Invalid access token.")));
     }
 
@@ -1914,7 +1928,20 @@ class RegistryAPITest {
                 post("/api/-/publish?token={token}", "my_token")
                         .contentType(MediaType.APPLICATION_OCTET_STREAM)
                         .content(bytes))
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().json(errorJson("Invalid access token.")));
+    }
+
+    @Test
+    void testPublishExpiredToken() throws Exception {
+        var token = mockAccessToken();
+        token.setExpiresTimestamp(LocalDateTime.now().minusDays(1));
+        var bytes = createExtensionPackage("bar", "1.0.0", null);
+        mockMvc.perform(
+                post("/api/-/publish?token={token}", "my_token")
+                        .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                        .content(bytes))
+                .andExpect(status().isUnauthorized())
                 .andExpect(content().json(errorJson("Invalid access token.")));
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/util/DrainOnCloseInputStreamTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/util/DrainOnCloseInputStreamTest.java
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.util;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import com.google.common.io.ByteStreams;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class DrainOnCloseInputStreamTest {
+
+    @Test
+    void closeDrainsWhateverWasNeverRead() throws IOException {
+        var underlying = new ByteArrayInputStream("the rest of the body".getBytes(StandardCharsets.UTF_8));
+        var stream = new DrainOnCloseInputStream(underlying);
+
+        // Nothing read at all before closing - the whole thing must still get drained.
+        stream.close();
+
+        assertThat(underlying.available()).isZero();
+    }
+
+    @Test
+    void closeIsACheapNoOpWhenAlreadyFullyRead() throws IOException {
+        var underlying = new ByteArrayInputStream("fully consumed".getBytes(StandardCharsets.UTF_8));
+        var stream = new DrainOnCloseInputStream(underlying);
+        stream.readAllBytes();
+
+        assertThatCode(stream::close).doesNotThrowAnyException();
+    }
+
+    // Mirrors the exact chain ExtensionService#createExtensionFile builds around the InputStream
+    // it's handed: BufferedInputStream wrapped in a size-capped Guava view that gives up once the
+    // package exceeds the configured limit, leaving everything past the cap unread on the wire.
+    // Wrapping once here at the entry point and closing through try-with-resources drains that
+    // remainder for free via the close() cascade, without ExtensionService needing to know about it.
+    @Test
+    void drainsWhateverASizeCappedViewDeeperInTheChainNeverReached() throws IOException {
+        var body = "x".repeat(20).getBytes(StandardCharsets.UTF_8);
+        var underlying = new ByteArrayInputStream(body);
+        var draining = new DrainOnCloseInputStream(underlying);
+
+        try (
+                var buffered = new BufferedInputStream(draining);
+                var capped = ByteStreams.limit(buffered, 5)
+        ) {
+            capped.readAllBytes();
+        }
+
+        assertThat(underlying.available()).isZero();
+    }
+
+    @Test
+    void closeSwallowsAnIOExceptionFromDraining() {
+        InputStream failing = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException("connection reset");
+            }
+        };
+
+        assertThatCode(new DrainOnCloseInputStream(failing)::close).doesNotThrowAnyException();
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/util/DrainOnCloseInputStreamTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/util/DrainOnCloseInputStreamTest.java
@@ -29,7 +29,7 @@ class DrainOnCloseInputStreamTest {
     @Test
     void closeDrainsWhateverWasNeverRead() throws IOException {
         var underlying = new ByteArrayInputStream("the rest of the body".getBytes(StandardCharsets.UTF_8));
-        var stream = new DrainOnCloseInputStream(underlying);
+        var stream = new DrainOnCloseInputStream(underlying, 1024);
 
         // Nothing read at all before closing - the whole thing must still get drained.
         stream.close();
@@ -40,22 +40,60 @@ class DrainOnCloseInputStreamTest {
     @Test
     void closeIsACheapNoOpWhenAlreadyFullyRead() throws IOException {
         var underlying = new ByteArrayInputStream("fully consumed".getBytes(StandardCharsets.UTF_8));
-        var stream = new DrainOnCloseInputStream(underlying);
+        var stream = new DrainOnCloseInputStream(underlying, 1024);
         stream.readAllBytes();
 
         assertThatCode(stream::close).doesNotThrowAnyException();
+    }
+
+    // Without a cap, a client rejected for any reason could force the server to read and discard
+    // an arbitrarily large body before responding - trading the original LB/proxy problem for a
+    // resource-exhaustion one. Only what's within the bound gets drained; the rest is left alone.
+    @Test
+    void closeDoesNotDrainPastMaxBytes() throws IOException {
+        var body = "x".repeat(20).getBytes(StandardCharsets.UTF_8);
+        var underlying = new ByteArrayInputStream(body);
+        var stream = new DrainOnCloseInputStream(underlying, 5);
+
+        stream.close();
+
+        assertThat(underlying.available()).isEqualTo(15);
+    }
+
+    // maxBytes bounds the TOTAL bytes ever read over this instance's lifetime, not just what
+    // close() itself reads: ExtensionService#createExtensionFile's own oversized-package detection
+    // already reads up to maxContentSize + 1 bytes normally before rejecting. If close() didn't
+    // account for that and instead drained a fresh maxBytes on top, an oversized upload would cost
+    // up to ~2x maxBytes total - defeating the bound for exactly the case it exists to protect.
+    @Test
+    void closeAccountsForBytesAlreadyReadNormally() throws IOException {
+        var body = "x".repeat(20).getBytes(StandardCharsets.UTF_8);
+        var underlying = new ByteArrayInputStream(body);
+        var stream = new DrainOnCloseInputStream(underlying, 12);
+
+        // Simulates createExtensionFile's own read of the first part of the body.
+        var read = stream.readNBytes(10);
+        assertThat(read).hasSize(10);
+
+        stream.close();
+
+        // Only 12 - 10 = 2 bytes of budget were left for the drain, not the full 12: 8 bytes
+        // (20 - 10 read - 2 drained) are correctly left undrained.
+        assertThat(underlying.available()).isEqualTo(8);
     }
 
     // Mirrors the exact chain ExtensionService#createExtensionFile builds around the InputStream
     // it's handed: BufferedInputStream wrapped in a size-capped Guava view that gives up once the
     // package exceeds the configured limit, leaving everything past the cap unread on the wire.
     // Wrapping once here at the entry point and closing through try-with-resources drains that
-    // remainder for free via the close() cascade, without ExtensionService needing to know about it.
+    // remainder for free via the close() cascade, without ExtensionService needing to know about it -
+    // as long as our own bound is generous enough to cover it, which callers get by using the same
+    // max upload size for both.
     @Test
     void drainsWhateverASizeCappedViewDeeperInTheChainNeverReached() throws IOException {
         var body = "x".repeat(20).getBytes(StandardCharsets.UTF_8);
         var underlying = new ByteArrayInputStream(body);
-        var draining = new DrainOnCloseInputStream(underlying);
+        var draining = new DrainOnCloseInputStream(underlying, 100);
 
         try (
                 var buffered = new BufferedInputStream(draining);
@@ -76,6 +114,6 @@ class DrainOnCloseInputStreamTest {
             }
         };
 
-        assertThatCode(new DrainOnCloseInputStream(failing)::close).doesNotThrowAnyException();
+        assertThatCode(new DrainOnCloseInputStream(failing, 1024)::close).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
As otherwise LB/proxies may translate this as server error and produce 50x errors downstream.

Changes:
* in case of inactive/expired token return 401 instead of 400
* in case of attempt to publish with expired token, consume (into /dev/null) the payload BEFORE sending response, to cleanly follow HTTP request/response flow


Fixes https://github.com/EclipseFdn/open-vsx.org/issues/12463

**Note**: Changed code is/will conflict with trusted publishing, where even the "verify" use case has been totally separated out. This PR merely copies the applicable bits from trusted publishing `AccessTokenService` and adds body consumption before throwing error (and modifies error from 400 to 401).