### PR TITLE
feat: removing extension overview sidebar intermediate state

### DIFF
--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This change log covers only the frontend library (webui) of Open VSX.
 
+## [next] (unreleased)
+
+### Fixed
+
+- Fix the extension overview sidebar overlapping the readme content at narrower ("tablet") window widths: there are now only mobile and desktop layouts, with tablet widths using the desktop layout ([#2068](https://github.com/eclipse-openvsx/openvsx/issues/2068))
+
 ## [v1.1.1] (09/08/2026)
 
 ### Fixed

--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -301,8 +301,7 @@ export const ExtensionDetailOverview: FunctionComponent<ExtensionDetailOverviewP
     };
     const resourcesGroup = {
         display: 'flex',
-        flexDirection: 'column',
-        mb: { xs: 2, sm: 2, md: 0, lg: 0, xl: 2 }
+        flexDirection: 'column'
     };
 
     const ClaimNamespace = pageSettings.elements.claimNamespace;

--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -302,7 +302,6 @@ export const ExtensionDetailOverview: FunctionComponent<ExtensionDetailOverviewP
     const resourcesGroup = {
         display: 'flex',
         flexDirection: 'column',
-        flex: { xs: 'none', sm: 'none', md: 1, lg: 1, xl: 'none' },
         mb: { xs: 2, sm: 2, md: 0, lg: 0, xl: 2 }
     };
 
@@ -334,12 +333,10 @@ export const ExtensionDetailOverview: FunctionComponent<ExtensionDetailOverviewP
         <Box
             sx={{
                 display: 'flex',
+                gap: 4,
                 flexDirection: {
                     xs: 'column-reverse',
-                    sm: 'column-reverse',
-                    md: 'column-reverse',
-                    lg: 'column-reverse',
-                    xl: 'row'
+                    md: 'row'
                 }
             }}>
             <Box flex={5} sx={{ minWidth: 0, overflow: 'auto' }}>
@@ -350,10 +347,9 @@ export const ExtensionDetailOverview: FunctionComponent<ExtensionDetailOverviewP
                     flex: 1,
                     display: 'flex',
                     width: '100%',
-                    minWidth: { xs: 0, xl: '290px' },
-                    mb: { xs: 2, sm: 2, md: 2, lg: 2, xl: 0 },
-                    ml: { xs: 0, sm: 0, md: 0, lg: 0, xl: '4.8rem' },
-                    flexDirection: { xs: 'column', sm: 'column', md: 'row', lg: 'row', xl: 'column' }
+                    minWidth: { xs: 0, md: '290px' },
+                    gap: 2,
+                    flexDirection: 'column'
                 }}>
                 <Box sx={resourcesGroup}>
                     <Box>{renderVersionSection()}</Box>


### PR DESCRIPTION
This patch fixes  #2068 by removing the intermediate state of the sidebar, now there's only two possibilities, mobile or desktop, not tablet, for tablet the sidebar would remain as in desktop.