### PR TITLE
fix: restore response compression for VS Code Gallery API JSON responses

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -77,6 +77,9 @@ dependencies {
             replacedBy("org.springframework.boot:spring-boot-starter-jetty")
         }
     }
+    // Only a transitive runtime dependency of spring-boot-starter-jetty otherwise; needed at compile
+    // time to reconfigure the installed CompressionHandler in VSCodeGalleryCompressionConfig.
+    implementation "org.eclipse.jetty.compression:jetty-compression-server"
     implementation "org.springframework.boot:spring-boot-starter-restclient"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-jooq"

--- a/server/src/main/java/org/eclipse/openvsx/adapter/IVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/IVSCodeService.java
@@ -13,6 +13,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 public interface IVSCodeService {
+
+    /**
+     * The version of the VS Code Gallery API protocol this service speaks, as used in the
+     * {@code api-version} media type parameter of the {@code Accept}/{@code Content-Type} headers,
+     * e.g. {@code application/json;api-version=3.0-preview.1}. Shared between the outgoing requests
+     * to an upstream marketplace ({@link VSCodeIdService}) and the {@code Content-Type} this server
+     * itself returns from the gallery endpoints in {@link VSCodeAPI}.
+     */
+    // TODO: check if this version is still valid when connecting to the VSC Marketplace
+    String GALLERY_API_VERSION = "3.0-preview.1";
+
     ExtensionQueryResult extensionQuery(ExtensionQueryParam param, int defaultPageSize);
 
     ExtensionQueryResult.Extension latest(String namespaceName, String extensionName);

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeGalleryCompressionConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeGalleryCompressionConfig.java
@@ -15,6 +15,7 @@ package org.eclipse.openvsx.adapter;
 import org.eclipse.jetty.compression.server.CompressionConfig;
 import org.eclipse.jetty.compression.server.CompressionHandler;
 import org.eclipse.jetty.http.pathmap.PathSpec;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.jetty.ConfigurableJettyWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -41,8 +42,14 @@ import org.springframework.context.annotation.Configuration;
  * trade for a project that has already committed to Jetty exclusively. The upside is that no
  * deployment's {@code server.compression.mime-types} needs to know about the VS Code Gallery API's
  * versioned Content-Type at all - it always works, regardless of configuration.
+ * <p>
+ * Guarded by {@link ConditionalOnClass} on both Jetty-specific types this class touches, so that if
+ * Jetty (and its compression module) were ever absent from the classpath - a Tomcat/Undertow
+ * deployment, or a test slice that doesn't pull in {@code spring-boot-starter-jetty} - this
+ * configuration is skipped instead of failing to load with a {@code NoClassDefFoundError}.
  */
 @Configuration
+@ConditionalOnClass({ CompressionHandler.class, ConfigurableJettyWebServerFactory.class })
 public class VSCodeGalleryCompressionConfig {
 
     private static final PathSpec DEFAULT_PATH_SPEC = PathSpec.from("/");

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeGalleryCompressionConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeGalleryCompressionConfig.java
@@ -1,0 +1,75 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.adapter;
+
+import org.eclipse.jetty.compression.server.CompressionConfig;
+import org.eclipse.jetty.compression.server.CompressionHandler;
+import org.eclipse.jetty.http.pathmap.PathSpec;
+import org.springframework.boot.jetty.ConfigurableJettyWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Makes {@link VSCodeGalleryContentTypeAdvice}'s fixed {@code application/json;api-version=...}
+ * Content-Type compressible without requiring an operator to add that exact literal to
+ * {@code server.compression.mime-types} - see
+ * <a href="https://github.com/eclipse-openvsx/openvsx/issues/2071">#2071</a> for why the literal is
+ * otherwise needed at all (Jetty 12.1's {@code CompressionHandler} does an exact string match on
+ * {@code Content-Type}, after stripping only the {@code charset} parameter).
+ * <p>
+ * Rather than duplicating whatever {@code server.compression.*} already installed, this reads back
+ * the {@link CompressionConfig} the {@code spring-boot-jetty} auto-configuration already built for
+ * the default path (from {@code server.compression.mime-types} et al.) and replaces it with an
+ * equivalent one that additionally includes the Gallery API's fixed Content-Type. If compression is
+ * disabled ({@code server.compression.enabled=false}), no {@link CompressionHandler} is installed at
+ * all and this is a no-op.
+ * <p>
+ * This trades a config-only fix for a code-only one: it adds a compile-time dependency on
+ * {@code jetty-compression-server} (otherwise only a transitive runtime dependency) and reaches into
+ * Jetty-specific classes that a Tomcat/Undertow deployment wouldn't have, which is an acceptable
+ * trade for a project that has already committed to Jetty exclusively. The upside is that no
+ * deployment's {@code server.compression.mime-types} needs to know about the VS Code Gallery API's
+ * versioned Content-Type at all - it always works, regardless of configuration.
+ */
+@Configuration
+public class VSCodeGalleryCompressionConfig {
+
+    private static final PathSpec DEFAULT_PATH_SPEC = PathSpec.from("/");
+
+    @Bean
+    WebServerFactoryCustomizer<ConfigurableJettyWebServerFactory> vsCodeGalleryCompressionCustomizer() {
+        return factory -> factory.addServerCustomizers(server -> {
+            var compressionHandler = server.getDescendant(CompressionHandler.class);
+            if (compressionHandler == null) {
+                return;
+            }
+
+            var existing = compressionHandler.getConfiguration(DEFAULT_PATH_SPEC);
+            var builder = CompressionConfig.builder();
+            if (existing != null) {
+                existing.getCompressIncludeMimeTypes().forEach(builder::compressIncludeMimeType);
+                existing.getCompressExcludeMimeTypes().forEach(builder::compressExcludeMimeType);
+                existing.getCompressIncludeMethods().forEach(builder::compressIncludeMethod);
+                existing.getCompressExcludeMethods().forEach(builder::compressExcludeMethod);
+                existing.getCompressIncludeEncodings().forEach(builder::compressIncludeEncoding);
+                existing.getCompressExcludeEncodings().forEach(builder::compressExcludeEncoding);
+                existing.getCompressIncludePaths().forEach(builder::compressIncludePath);
+                existing.getCompressExcludePaths().forEach(builder::compressExcludePath);
+                builder.compressPreferredEncodings(existing.getCompressPreferredEncodings());
+            }
+            builder.compressIncludeMimeType(VSCodeGalleryContentTypeAdvice.GALLERY_JSON.toString());
+            compressionHandler.putConfiguration(DEFAULT_PATH_SPEC, builder.build());
+        });
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeGalleryContentTypeAdvice.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeGalleryContentTypeAdvice.java
@@ -1,0 +1,81 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.adapter;
+
+import java.util.Map;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * The real VS Code Marketplace tags its Gallery API JSON responses with an {@code api-version}
+ * media type parameter, e.g. {@code Content-Type: application/json;api-version=3.0-preview.1}, and
+ * VS Code clients rely on it being present for compatibility. Spring's own content negotiation would
+ * get us most of the way there on its own - a requested media type with more parameters is considered
+ * "more specific" than the plain type declared via {@code produces}, so a client sending
+ * {@code Accept: application/json;api-version=3.0-preview.1} already gets that parameter echoed back
+ * verbatim.
+ * <p>
+ * But relying on that echo has two problems: it depends entirely on what the client happened to send
+ * (a client asking for plain {@code application/json}, or omitting {@code api-version}, gets no
+ * version marker at all) and, since it makes the response {@code Content-Type} client-controlled, it
+ * turns compression into an unbounded matching problem - Jetty 12.1's {@code CompressionHandler} (used
+ * since the Spring Boot 4 migration) matches {@code Content-Type} against
+ * {@code server.compression.mime-types} with an exact string comparison, after stripping only the
+ * {@code charset} parameter. There is no way to list every {@code api-version} value a client might
+ * send, so compression would only ever work for whichever exact strings happen to be enumerated, see
+ * <a href="https://github.com/eclipse-openvsx/openvsx/issues/2071">#2071</a>.
+ * <p>
+ * This advice sidesteps that by always stamping the fixed, server-controlled
+ * {@link IVSCodeService#GALLERY_API_VERSION} onto every JSON response from {@link VSCodeAPI},
+ * regardless of what the client's {@code Accept} header asked for. That keeps the resulting
+ * {@code Content-Type} a single, known literal -
+ * {@code application/json;api-version=} + {@link IVSCodeService#GALLERY_API_VERSION} - which must be
+ * added to {@code server.compression.mime-types} alongside {@code application/json} for compression
+ * to apply to these responses.
+ */
+@ControllerAdvice(assignableTypes = VSCodeAPI.class)
+public class VSCodeGalleryContentTypeAdvice implements ResponseBodyAdvice<Object> {
+
+    static final MediaType GALLERY_JSON = new MediaType(
+            MediaType.APPLICATION_JSON,
+            Map.of("api-version", IVSCodeService.GALLERY_API_VERSION));
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class<? extends HttpMessageConverter<?>> selectedConverterType,
+            ServerHttpRequest request,
+            ServerHttpResponse response
+    ) {
+        // Only touch JSON responses - VSCodeAPI also serves binary assets (application/octet-stream)
+        // and those must be left alone.
+        if (selectedContentType != null && selectedContentType.equalsTypeAndSubtype(MediaType.APPLICATION_JSON)) {
+            response.getHeaders().setContentType(GALLERY_JSON);
+        }
+
+        return body;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeIdService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeIdService.java
@@ -34,8 +34,6 @@ import org.eclipse.openvsx.util.UrlUtil;
 
 @Service
 public class VSCodeIdService {
-    // TODO: check if this version is still valid when connecting to the VSC Marketplace
-    private static final String API_VERSION = "3.0-preview.1";
 
     private final RestTemplate vsCodeIdRestTemplate;
     private final UrlConfigService urlConfigService;
@@ -106,7 +104,7 @@ public class VSCodeIdService {
         var requestData = createRequestData(extension);
         var headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(HttpHeaders.ACCEPT, "application/json;api-version=" + API_VERSION);
+        headers.set(HttpHeaders.ACCEPT, "application/json;api-version=" + IVSCodeService.GALLERY_API_VERSION);
         var result = vsCodeIdRestTemplate
                 .postForObject(requestUrl, new HttpEntity<>(requestData, headers), ExtensionQueryResult.class);
         if (result != null && result.results() != null && !result.results().isEmpty()) {

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -124,6 +124,29 @@ class VSCodeAPITest {
     }
 
     @Test
+    void testSearchStampsTheGalleryApiVersionOnTheResponseContentType() throws Exception {
+        // Regression for eclipse-openvsx/openvsx#2071: without VSCodeGalleryContentTypeAdvice,
+        // Spring's content negotiation echoes back whatever "api-version" the client's Accept
+        // header happened to carry (or omits it entirely, like this request does), which then
+        // failed the exact-string match Jetty 12.1's CompressionHandler does against
+        // server.compression.mime-types - silently disabling compression for these responses.
+        // Real VS Code clients always send api-version=3.0-preview.1, but the fix must not depend
+        // on that: the server stamps its own, fixed api-version onto every Gallery JSON response.
+        var extension = mockSearch(true);
+        mockExtensionVersions(extension, null, "universal");
+
+        mockMvc.perform(
+                post("/vscode/gallery/extensionquery")
+                        .content(file("search-yaml-query.json"))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(
+                        header().string(
+                                "Content-Type",
+                                "application/json;api-version=" + IVSCodeService.GALLERY_API_VERSION));
+    }
+
+    @Test
     void testSearchPostMissingSortFields() throws Exception {
         // reproduces eclipse-openvsx/openvsx#2059 exactly: POST body omits pageNumber's siblings
         // sortBy/sortOrder entirely. Confirms the @RequestBody path (fixed by #2052 / JacksonConfig)

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeGalleryCompressionConfigTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeGalleryCompressionConfigTest.java
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.adapter;
+
+import org.eclipse.jetty.compression.server.CompressionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link VSCodeGalleryCompressionConfig} is guarded by {@code @ConditionalOnClass} so that a
+ * hypothetical deployment without Jetty on the classpath (e.g. Tomcat/Undertow) skips it instead of
+ * failing to start with a {@code NoClassDefFoundError}.
+ */
+class VSCodeGalleryCompressionConfigTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(VSCodeGalleryCompressionConfig.class);
+
+    @Test
+    void registersTheCustomizerWhenJettyIsOnTheClasspath() {
+        contextRunner.run(context -> assertThat(context).hasSingleBean(VSCodeGalleryCompressionConfig.class));
+    }
+
+    @Test
+    void isSkippedWithoutJettysCompressionSupportOnTheClasspath() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader(CompressionHandler.class))
+                .run(context -> assertThat(context).doesNotHaveBean(VSCodeGalleryCompressionConfig.class));
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeGalleryCompressionTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeGalleryCompressionTest.java
@@ -41,7 +41,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *     used to be enough under Spring Boot 3 / Jetty 12.0's {@code GzipHandler}, is <b>not</b> enough
  *     any more once the response carries {@link VSCodeGalleryContentTypeAdvice}'s versioned
  *     Content-Type;</li>
- *     <li>adding that exact literal restores compression.</li>
+ *     <li>adding that exact literal restores compression;</li>
+ *     <li>so does {@link VSCodeGalleryCompressionConfig}'s customizer alone, with the literal still
+ *     absent from the configured mime types - proving the config-only fix is not the only way.</li>
  * </ul>
  * See <a href="https://github.com/eclipse-openvsx/openvsx/issues/2071">#2071</a>. Deliberately talks
  * to a real {@link WebServer} rather than {@code MockMvc}, since MockMvc never touches the actual
@@ -71,6 +73,16 @@ class VSCodeGalleryCompressionTest {
         assertThat(response.headers().firstValue("Content-Encoding")).isEmpty();
     }
 
+    // Same "application/json"-only configuration as the test above - the literal is deliberately
+    // absent from server.compression.mime-types - but with VSCodeGalleryCompressionConfig's
+    // customizer also applied, proving that config alone is not the only way to fix this.
+    @Test
+    void theCompressionCustomizerRestoresCompressionWithoutTheLiteralInConfig() throws Exception {
+        var response = requestGalleryResponseCompressedWith(true, "application/json");
+
+        assertThat(response.headers().firstValue("Content-Encoding")).contains("gzip");
+    }
+
     @Test
     void addingTheVersionedLiteralRestoresCompression() throws Exception {
         var response = requestGalleryResponseCompressedWith("application/json", GALLERY_CONTENT_TYPE);
@@ -88,6 +100,13 @@ class VSCodeGalleryCompressionTest {
 
     private HttpResponse<byte[]> requestGalleryResponseCompressedWith(String... configuredMimeTypes)
             throws IOException, InterruptedException {
+        return requestGalleryResponseCompressedWith(false, configuredMimeTypes);
+    }
+
+    private HttpResponse<byte[]> requestGalleryResponseCompressedWith(
+            boolean withCompressionCustomizer,
+            String... configuredMimeTypes
+    ) throws IOException, InterruptedException {
         var compression = new Compression();
         compression.setEnabled(true);
         compression.setMimeTypes(configuredMimeTypes);
@@ -95,6 +114,9 @@ class VSCodeGalleryCompressionTest {
 
         var factory = new JettyServletWebServerFactory(0);
         factory.setCompression(compression);
+        if (withCompressionCustomizer) {
+            new VSCodeGalleryCompressionConfig().vsCodeGalleryCompressionCustomizer().customize(factory);
+        }
         server = factory.getWebServer(
                 servletContext -> servletContext
                         .addServlet("gallery", new HttpServlet() {

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeGalleryCompressionTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeGalleryCompressionTest.java
@@ -1,0 +1,117 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.adapter;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.jetty.servlet.JettyServletWebServerFactory;
+import org.springframework.boot.web.server.Compression;
+import org.springframework.boot.web.server.WebServer;
+import org.springframework.util.unit.DataSize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end proof against the real embedded Jetty {@code CompressionHandler} (used by the
+ * {@code spring-boot-jetty} auto-configuration since the Spring Boot 4 migration) that:
+ * <ul>
+ *     <li>the bare {@code application/json} entry in {@code server.compression.mime-types}, which
+ *     used to be enough under Spring Boot 3 / Jetty 12.0's {@code GzipHandler}, is <b>not</b> enough
+ *     any more once the response carries {@link VSCodeGalleryContentTypeAdvice}'s versioned
+ *     Content-Type;</li>
+ *     <li>adding that exact literal restores compression.</li>
+ * </ul>
+ * See <a href="https://github.com/eclipse-openvsx/openvsx/issues/2071">#2071</a>. Deliberately talks
+ * to a real {@link WebServer} rather than {@code MockMvc}, since MockMvc never touches the actual
+ * Jetty handler chain that does the compression.
+ */
+class VSCodeGalleryCompressionTest {
+
+    private static final String GALLERY_CONTENT_TYPE = "application/json;api-version="
+            + IVSCodeService.GALLERY_API_VERSION;
+
+    // Comfortably over any minResponseSize used below.
+    private static final String RESPONSE_BODY = "{\"value\":\"" + "x".repeat(4096) + "\"}";
+
+    private WebServer server;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    void bareApplicationJsonAloneNoLongerCompressesTheVersionedContentType() throws Exception {
+        var response = requestGalleryResponseCompressedWith("application/json");
+
+        assertThat(response.headers().firstValue("Content-Encoding")).isEmpty();
+    }
+
+    @Test
+    void addingTheVersionedLiteralRestoresCompression() throws Exception {
+        var response = requestGalleryResponseCompressedWith("application/json", GALLERY_CONTENT_TYPE);
+
+        assertThat(response.headers().firstValue("Content-Encoding")).contains("gzip");
+        // Not just a spoofed header - the body is genuinely gzip-compressed and decodes back to the
+        // original JSON, and (being 4KB of repeated characters) noticeably smaller on the wire.
+        assertThat(response.body().length).isLessThan(RESPONSE_BODY.length());
+        assertThat(
+                new String(
+                        new GZIPInputStream(new ByteArrayInputStream(response.body())).readAllBytes(),
+                        StandardCharsets.UTF_8))
+                .isEqualTo(RESPONSE_BODY);
+    }
+
+    private HttpResponse<byte[]> requestGalleryResponseCompressedWith(String... configuredMimeTypes)
+            throws IOException, InterruptedException {
+        var compression = new Compression();
+        compression.setEnabled(true);
+        compression.setMimeTypes(configuredMimeTypes);
+        compression.setMinResponseSize(DataSize.ofBytes(10));
+
+        var factory = new JettyServletWebServerFactory(0);
+        factory.setCompression(compression);
+        server = factory.getWebServer(
+                servletContext -> servletContext
+                        .addServlet("gallery", new HttpServlet() {
+                            @Override
+                            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+                                // What VSCodeGalleryContentTypeAdvice ends up writing as Content-Type.
+                                resp.setContentType(GALLERY_CONTENT_TYPE);
+                                resp.getOutputStream().write(RESPONSE_BODY.getBytes(StandardCharsets.UTF_8));
+                            }
+                        })
+                        .addMapping("/*"));
+        server.start();
+
+        var request = HttpRequest.newBuilder(URI.create("http://localhost:" + server.getPort() + "/"))
+                .header("Accept-Encoding", "gzip")
+                .GET()
+                .build();
+        return HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofByteArray());
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeGalleryContentTypeAdviceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeGalleryContentTypeAdviceTest.java
@@ -1,0 +1,85 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.adapter;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for https://github.com/eclipse-openvsx/openvsx/issues/2071 - see
+ * {@link VSCodeGalleryContentTypeAdvice} for the full explanation.
+ */
+class VSCodeGalleryContentTypeAdviceTest {
+
+    private final VSCodeGalleryContentTypeAdvice advice = new VSCodeGalleryContentTypeAdvice();
+    private final HttpHeaders headers = new HttpHeaders();
+    private final ServerHttpResponse response = mock(ServerHttpResponse.class);
+    private final ServerHttpRequest request = mock(ServerHttpRequest.class);
+
+    @Test
+    void appliesToAnyReturnType() {
+        assertThat(advice.supports(null, JacksonJsonHttpMessageConverter.class)).isTrue();
+    }
+
+    // Independent of whatever the client's Accept header asked for (or omitted): the response
+    // always carries the server's own, fixed api-version - matching the real VS Code Marketplace
+    // and keeping the Content-Type a single known literal for compression to match against.
+    @Test
+    void alwaysStampsTheFixedGalleryApiVersionOnAJsonResponse() {
+        when(response.getHeaders()).thenReturn(headers);
+
+        advice.beforeBodyWrite(new Object(), null, MediaType.APPLICATION_JSON, null, request, response);
+
+        assertThat(headers.getContentType().toString())
+                .isEqualTo("application/json;api-version=" + IVSCodeService.GALLERY_API_VERSION);
+    }
+
+    @Test
+    void overridesAnEchoedAcceptParameterWithTheFixedVersion() {
+        when(response.getHeaders()).thenReturn(headers);
+        // What Spring's content negotiation alone would have picked, had the client asked for a
+        // different (or malformed) api-version.
+        var echoed = new MediaType("application", "json", Map.of("api-version", "9.9-bogus"));
+
+        advice.beforeBodyWrite(new Object(), null, echoed, null, request, response);
+
+        assertThat(headers.getContentType().toString())
+                .isEqualTo("application/json;api-version=" + IVSCodeService.GALLERY_API_VERSION);
+    }
+
+    @Test
+    void leavesANonJsonContentTypeUntouched() {
+        advice.beforeBodyWrite(new Object(), null, MediaType.APPLICATION_OCTET_STREAM, null, request, response);
+
+        // VSCodeAPI also serves binary assets through the same advice scope - must not be touched.
+        verifyNoInteractions(response);
+    }
+
+    @Test
+    void handlesAMissingSelectedContentType() {
+        advice.beforeBodyWrite(new Object(), null, null, null, request, response);
+
+        verifyNoInteractions(response);
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeGalleryExtensionQueryCompressionIntegrationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeGalleryExtensionQueryCompressionIntegrationTest.java
@@ -1,0 +1,101 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.adapter;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import org.eclipse.openvsx.AbstractPostgresContainerTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end proof, against the real running application (real embedded Jetty, real
+ * {@link VSCodeGalleryContentTypeAdvice} and {@link VSCodeGalleryCompressionConfig} wiring - not the
+ * synthetic servlet {@link VSCodeGalleryCompressionTest} uses), that a real request to
+ * {@code /vscode/gallery/extensionquery} comes back compressed.
+ * <p>
+ * {@code server.compression.mime-types} is deliberately left at the bare {@code application/json}
+ * that a Spring Boot 3-era config would have had - the point of {@link VSCodeGalleryCompressionConfig}
+ * is that the Gallery API's versioned Content-Type gets compressed anyway, without an operator ever
+ * adding that literal. See <a href="https://github.com/eclipse-openvsx/openvsx/issues/2071">#2071</a>.
+ */
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = {
+        "server.compression.enabled=true",
+        "server.compression.mime-types=application/json",
+        "server.compression.min-response-size=1B",
+        "ovsx.databasesearch.enabled=true"
+    }
+)
+class VSCodeGalleryExtensionQueryCompressionIntegrationTest extends AbstractPostgresContainerTest {
+
+    private static final String QUERY_BODY = """
+            {"filters":[{"criteria":[{"filterType":10,"value":"editorconfig"}],"pageNumber":1,"pageSize":50}],"flags":950}""";
+
+    @LocalServerPort
+    int port;
+
+    @Test
+    void extensionQueryResponseIsCompressed() throws IOException, InterruptedException {
+        var response = postExtensionQuery(true);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.headers().firstValue("Content-Encoding")).contains("gzip");
+        // The whole point of VSCodeGalleryContentTypeAdvice: a fixed, known Content-Type that
+        // VSCodeGalleryCompressionConfig can make compressible without any operator-side config.
+        assertThat(response.headers().firstValue("Content-Type"))
+                .hasValueSatisfying(
+                        contentType -> assertThat(contentType)
+                                .startsWith("application/json;api-version="));
+
+        var decoded = new String(
+                new GZIPInputStream(new ByteArrayInputStream(response.body())).readAllBytes(),
+                StandardCharsets.UTF_8);
+        assertThat(decoded).contains("\"results\"");
+    }
+
+    @Test
+    void extensionQueryResponseIsNotCompressedWithoutAcceptEncoding() throws IOException, InterruptedException {
+        var response = postExtensionQuery(false);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.headers().firstValue("Content-Encoding")).isEmpty();
+        assertThat(new String(response.body(), StandardCharsets.UTF_8)).contains("\"results\"");
+    }
+
+    private HttpResponse<byte[]> postExtensionQuery(boolean acceptGzip) throws IOException, InterruptedException {
+        var requestBuilder = HttpRequest
+                .newBuilder(URI.create("http://localhost:" + port + "/vscode/gallery/extensionquery"))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json;api-version=3.0-preview.1")
+                .POST(HttpRequest.BodyPublishers.ofString(QUERY_BODY, StandardCharsets.UTF_8));
+        if (acceptGzip) {
+            requestBuilder.header("Accept-Encoding", "gzip");
+        }
+
+        return HttpClient.newHttpClient().send(requestBuilder.build(), HttpResponse.BodyHandlers.ofByteArray());
+    }
+}


### PR DESCRIPTION
## What

Fixes #2071: response compression silently stopped applying to VS Code Gallery API JSON responses (e.g. `/vscode/gallery/extensionquery`) after the Spring Boot 4 migration.

## Root cause

- Spring's content negotiation treats a requested media type with more parameters as "more specific" than the plain type declared via `produces`, so a client sending `Accept: application/json;api-version=3.0-preview.1` got that parameter echoed back verbatim as the response `Content-Type`. Unchanged behavior between Spring Framework 6.2 and 7 - verified by decompiling `AbstractMessageConverterMethodProcessor`/`MimeType` from both versions.
- The regression is that Boot 4 bumped Jetty from 12.0.x to 12.1.x, which replaced `GzipHandler` with a new `CompressionHandler`/`CompressionConfig` API. The old `GzipHandler` stripped **all** `Content-Type` parameters before matching against `server.compression.mime-types`; the new `CompressionHandler` only strips `charset` (`MimeTypes.getContentTypeWithoutCharset`), then does an **exact string match**. Any other parameter left in place - like an echoed `api-version` - breaks the match and compression is silently skipped.
- It turns out the real VS Code Marketplace *does* include `api-version` in its Gallery API response `Content-Type`, so simply stripping the parameter (my first attempt) would have broken client compatibility.

## Fix

- **`VSCodeGalleryContentTypeAdvice`** - a `ResponseBodyAdvice` scoped to `VSCodeAPI` that always stamps the server's own fixed `IVSCodeService.GALLERY_API_VERSION` (`3.0-preview.1`, promoted out of `VSCodeIdService` where it was private) onto Gallery JSON responses, regardless of what the client's `Accept` header asked for (or omitted). This matches the real Marketplace's behavior and turns the `Content-Type` back into a single known literal instead of a client-controlled value.
- **`VSCodeGalleryCompressionConfig`** - rather than requiring every deployment to add that literal to `server.compression.mime-types`, this is a `WebServerFactoryCustomizer<ConfigurableJettyWebServerFactory>` that reads back the `CompressionConfig` `spring-boot-jetty` already installed from `server.compression.*` and replaces it with an equivalent one that additionally includes the Gallery API's fixed Content-Type. Compression works regardless of configuration; a no-op if compression is disabled. Guarded by `@ConditionalOnClass` so a hypothetical non-Jetty deployment isn't affected.

## Testing

- `VSCodeGalleryContentTypeAdviceTest` / `VSCodeAPITest` - unit + `MockMvc` coverage that the fixed `api-version` is stamped regardless of the client's `Accept` header.
- `VSCodeGalleryCompressionTest` - boots a **real embedded Jetty server** (MockMvc never touches the actual compression handler chain) and proves: (1) the bare `application/json` entry alone no longer compresses the versioned Content-Type (reproducing the bug against real Jetty), (2) adding the literal restores compression, and (3) the `VSCodeGalleryCompressionConfig` customizer alone restores compression with the literal still absent from configured mime types - the body is gunzip-decoded and checked against the original.
- `VSCodeGalleryCompressionConfigTest` - `ApplicationContextRunner` + `FilteredClassLoader` proving the `@ConditionalOnClass` guard actually skips the configuration when Jetty's compression support isn't on the classpath, and registers it when it is.
- Ran the full `IntegrationTest` (real app context, real embedded Jetty, Postgres via Testcontainers) to confirm the new bean wires in cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
