### PR TITLE
fix: handle non-absolute URLs in ExtensionValidator

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/ExtensionValidator.java
+++ b/server/src/main/java/org/eclipse/openvsx/ExtensionValidator.java
@@ -267,9 +267,14 @@ public class ExtensionValidator {
         }
 
         try {
-            var url = new URI(value).toURL();
+            var uri = new URI(value);
+            if (!uri.isAbsolute()) {
+                return true;
+            }
+
+            var url = uri.toURL();
             return url.getProtocol().matches("http(s)?") && StringUtils.isEmpty(url.getHost());
-        } catch (URISyntaxException | MalformedURLException exc) {
+        } catch (URISyntaxException | MalformedURLException | IllegalArgumentException exc) {
             return true;
         }
     }

--- a/server/src/test/java/org/eclipse/openvsx/ExtensionValidatorTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/ExtensionValidatorTest.java
@@ -50,7 +50,7 @@ class ExtensionValidatorTest {
         extension.setVersion("1.0.0");
         var issues = validator.validateMetadata(extension);
         assertThat(issues).hasSize(1);
-        assertThat(issues.get(0))
+        assertThat(issues.getFirst())
                 .isEqualTo(new ExtensionValidator.Issue("Unsupported target platform 'debian-x64'"));
     }
 
@@ -62,7 +62,7 @@ class ExtensionValidatorTest {
         extension.setRepository("Foo and bar!");
         var issues = validator.validateMetadata(extension);
         assertThat(issues).hasSize(1);
-        assertThat(issues.get(0))
+        assertThat(issues.getFirst())
                 .isEqualTo(new ExtensionValidator.Issue("Invalid URL in field 'repository': Foo and bar!"));
     }
 
@@ -74,7 +74,7 @@ class ExtensionValidatorTest {
         extension.setRepository("https://");
         var issues = validator.validateMetadata(extension);
         assertThat(issues).hasSize(1);
-        assertThat(issues.get(0))
+        assertThat(issues.getFirst())
                 .isEqualTo(new ExtensionValidator.Issue("Invalid URL in field 'repository': https://"));
     }
 
@@ -86,8 +86,32 @@ class ExtensionValidatorTest {
         extension.setRepository("http://");
         var issues = validator.validateMetadata(extension);
         assertThat(issues).hasSize(1);
-        assertThat(issues.get(0))
+        assertThat(issues.getFirst())
                 .isEqualTo(new ExtensionValidator.Issue("Invalid URL in field 'repository': http://"));
+    }
+
+    @Test
+    void testNonAbsoluteURL() {
+        var extension = new ExtensionVersion();
+        extension.setTargetPlatform(TargetPlatform.NAME_UNIVERSAL);
+        extension.setVersion("1.0.0");
+        extension.setRepository("github.com/Foo/Bar");
+        var issues = validator.validateMetadata(extension);
+        assertThat(issues).hasSize(1);
+        assertThat(issues.getFirst())
+                .isEqualTo(new ExtensionValidator.Issue("Invalid URL in field 'repository': github.com/Foo/Bar"));
+    }
+
+    @Test
+    void testNonAbsoluteURLWithGitPrefix() {
+        var extension = new ExtensionVersion();
+        extension.setTargetPlatform(TargetPlatform.NAME_UNIVERSAL);
+        extension.setVersion("1.0.0");
+        extension.setRepository("git+github.com/Foo/Bar");
+        var issues = validator.validateMetadata(extension);
+        assertThat(issues).hasSize(1);
+        assertThat(issues.getFirst())
+                .isEqualTo(new ExtensionValidator.Issue("Invalid URL in field 'repository': git+github.com/Foo/Bar"));
     }
 
     @Test


### PR DESCRIPTION
## What
Fixes #2076 — publishing an extension fails with a 500 Internal Server Error:

```
Caused by: java.lang.IllegalArgumentException: URI is not absolute
        at java.base/java.net.URL.of(URL.java:820)
        at java.base/java.net.URI.toURL(URI.java:1176)
        at org.eclipse.openvsx.ExtensionValidator.isInvalidURL(ExtensionValidator.java:270)
        at org.eclipse.openvsx.ExtensionValidator.checkURL(ExtensionValidator.java:256)
        at org.eclipse.openvsx.ExtensionValidator.validateMetadata(ExtensionValidator.java:128)
```

## Why
`ExtensionValidator.isInvalidURL` calls `new URI(value).toURL()` to validate `homepage`,
`repository`, `bugs` and `qna` metadata fields. `URI#toURL()` throws `IllegalArgumentException`
when the URI is syntactically valid but **not absolute** (e.g. a value with no scheme, such as
`github.com/foo/bar`). That exception isn't a `URISyntaxException` or `MalformedURLException`, so
the existing catch block let it propagate all the way out of the publish flow as an unhandled 500
error instead of being reported as a normal metadata validation issue.

## Fix
- Check `URI#isAbsolute()` explicitly before calling `toURL()` and treat a non-absolute URI as
  invalid.
- Additionally catch `IllegalArgumentException` in the existing try/catch as a defensive backstop.

## Testing
Added `testNonAbsoluteURL` and `testNonAbsoluteURLWithGitPrefix` to `ExtensionValidatorTest`,
covering a repository value with no scheme (with and without the `git+` prefix). All tests in
`ExtensionValidatorTest` pass.