### PR TITLE
fix: configure /openvsx context path for OpenShift deployment and fix test extension publish paths

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -128,8 +128,8 @@ commands:
         export OVSX_PAT=super_token
         export PUBLISHERS="DotJoshJohnson eamodio felixfbecker formulahendry HookyQR ms-azuretools ms-mssql ms-python ms-vscode octref redhat ritwickdey sburg vscode vscodevim Wscats"
         for pub in $PUBLISHERS; do cli/bin/ovsx create-namespace $pub; done
-        find server/build/test-extensions-builtin -name '*.vsix' -exec cli/bin/ovsx publish '{}' \;
-        find server/build/test-extensions -name '*.vsix' -exec cli/bin/ovsx publish '{}' \;
+        find server/build-local/test-extensions-builtin -name '*.vsix' -exec cli/bin/ovsx publish '{}' \;
+        find server/build-local/test-extensions -name '*.vsix' -exec cli/bin/ovsx publish '{}' \;
 
 # Commands to deploy OpenVSX to OpenShift
   - id: create-namespace

--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -247,7 +247,7 @@ commands:
       commandLine: |
           export CHECLUSTER_NAME="$(kubectl get checluster --all-namespaces -o json | jq -r '.items[0].metadata.name')" &&
           export CHECLUSTER_NAMESPACE="$(kubectl get checluster --all-namespaces -o json | jq -r '.items[0].metadata.namespace')" &&
-          export OPENVSX_ROUTE_URL="$(oc get route internal -n "$OPENVSX_NAMESPACE" -o jsonpath='{.spec.host}')" &&
+          export OPENVSX_ROUTE_URL="$(oc get route internal -n "$OPENVSX_NAMESPACE" -o jsonpath='{.spec.host}{.spec.path}')" &&
           export PATCH='{"spec":{"components":{"pluginRegistry":{"openVSXURL":"https://'"$OPENVSX_ROUTE_URL"'"}}}}' &&
           kubectl patch checluster "${CHECLUSTER_NAME}" --type=merge --patch "${PATCH}" -n "${CHECLUSTER_NAMESPACE}"
 

--- a/deploy/openshift/openvsx-deployment-no-es.yml
+++ b/deploy/openshift/openvsx-deployment-no-es.yml
@@ -147,7 +147,7 @@ objects:
             imagePullPolicy: IfNotPresent
             readinessProbe:
               httpGet:
-                path: /api/version
+                path: openvsx/api/version
                 port: 8080
               failureThreshold: 30
               initialDelaySeconds: 140
@@ -155,7 +155,7 @@ objects:
               timeoutSeconds: 5
             livenessProbe:
               httpGet:
-                path: /api/version
+                path: openvsx/api/version
                 port: 8080
               failureThreshold: 30
               initialDelaySeconds: 160
@@ -171,7 +171,7 @@ objects:
                 memory: 4Gi
             env:
               - name: OVSX_REGISTRY_URL
-                value: http://openvsx-server:8080
+                value: http://openvsx-server:8080/openvsx/.
               - name: OVSX_PAT
                 valueFrom:
                   secretKeyRef:
@@ -209,6 +209,7 @@ objects:
       app.kubernetes.io/instance: openvsx-server
       app.kubernetes.io/component: openvsx-server
   spec:
+    path: /openvsx
     to:
       kind: Service
       name: openvsx-server


### PR DESCRIPTION
  - Add /openvsx path to the OpenShift Route spec so the server is served under a subpath
  - Update readiness and liveness probe paths from /api/version to openvsx/api/version
  - Update OVSX_REGISTRY_URL to include the /openvsx/ context path
  - Include spec.path in the devfile route URL extraction via jsonpath {.spec.host}{.spec.path}
  - Fix test extension publish paths in devfile to use build-local/ instead of build/

<img width="1715" height="1228" alt="Screenshot 2026-08-20 at 13 55 28" src="https://github.com/user-attachments/assets/f7e0264b-bde1-446c-8f6d-2ee5d645dbd2" />
