### PR TITLE
fix: clear scan admin loading spinner once fresh data lands after a tab switch

### DIFF
--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This change log covers only the frontend library (webui) of Open VSX.
 
+## [next] (unreleased)
+
+### Fixed
+
+- Fix the admin dashboard Scan tab getting stuck on the loading spinner after switching tabs, even though the new tab's data had already loaded successfully
+
 ## [v1.1.2] (20/08/2026)
 
 ### Added

--- a/webui/src/context/scan-admin/scan-api-effects.ts
+++ b/webui/src/context/scan-admin/scan-api-effects.ts
@@ -252,6 +252,11 @@ export const useScansEffect = (
     useEffect(() => {
         if (data) {
             dispatch({ type: 'SET_SCANS', payload: data });
+            // `keepPreviousData` makes the query's `isLoading` stay false across a key
+            // change once any fetch has ever succeeded, so it never flips the loading
+            // flag `SET_TAB` forced on back to false. Fresh data for the current key is
+            // the reliable signal that the forced spinner can be cleared.
+            dispatch({ type: 'SET_LOADING_SCANS', payload: false });
             dispatch({ type: 'SET_LAST_REFRESHED', payload: new Date() });
         }
     }, [data, dispatch]);
@@ -396,6 +401,10 @@ export const useFilesEffect = (
     useEffect(() => {
         if (data) {
             dispatch({ type: 'SET_FILES', payload: data });
+            // See the matching comment in useScansEffect: `keepPreviousData` keeps
+            // `isLoading` false across a key change, so the loading flag `SET_TAB`
+            // forces on can only be cleared reliably once fresh data lands.
+            dispatch({ type: 'SET_LOADING_FILES', payload: false });
             dispatch({ type: 'SET_LAST_REFRESHED', payload: new Date() });
         }
     }, [data, dispatch]);

--- a/webui/test/unit/context/scan-admin/scan-context.spec.tsx
+++ b/webui/test/unit/context/scan-admin/scan-context.spec.tsx
@@ -1,0 +1,108 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { TestProviders } from '../../support/test-providers';
+import { ScanProvider, useScanContext } from '../../../../src/context/scan-admin';
+
+/** A promise plus its resolver, so a test can settle a mocked fetch on demand. */
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>(res => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+function scanFixture(id: string, extensionName: string) {
+    return { id, namespace: 'acme', extensionName, version: '1.0.0', status: 'PASSED', dateScanStarted: '2026-01-01' };
+}
+
+/**
+ * `getAllScans` is deferred so each test controls exactly when a given request
+ * settles; every other admin endpoint resolves immediately since only the scans
+ * loading flag is under test here.
+ */
+function createMockService() {
+    const scansCalls: Array<ReturnType<typeof deferred<{ scans: unknown[]; totalSize: number }>>> = [];
+    const getAllScans = vi.fn(() => {
+        const call = deferred<{ scans: unknown[]; totalSize: number }>();
+        scansCalls.push(call);
+        return call.promise;
+    });
+
+    const service = {
+        admin: {
+            getAllScans,
+            getScanFilterOptions: vi
+                .fn()
+                .mockResolvedValue({ validationTypes: ['Malware'], threatScannerNames: ['ClamAV'] }),
+            getScanCounts: vi.fn().mockResolvedValue({
+                STARTED: 0,
+                VALIDATING: 0,
+                SCANNING: 0,
+                PASSED: 0,
+                QUARANTINED: 0,
+                AUTO_REJECTED: 0,
+                ERROR: 0,
+                ALLOWED: 0,
+                BLOCKED: 0,
+                NEEDS_REVIEW: 0
+            }),
+            getFiles: vi.fn().mockResolvedValue({ files: [], totalSize: 0 }),
+            getFileCounts: vi.fn().mockResolvedValue({ allowed: 0, blocked: 0, total: 0 })
+        }
+    };
+
+    return { service, scansCalls, getAllScans };
+}
+
+function setup(service: unknown) {
+    return renderHook(() => useScanContext(), {
+        wrapper: ({ children }) => (
+            <TestProviders mainContext={{ service: service as never }}>
+                <ScanProvider service={service} handleError={() => {}}>
+                    {children}
+                </ScanProvider>
+            </TestProviders>
+        )
+    });
+}
+
+describe('ScanProvider — scans loading flag', () => {
+    // Regression test: switching tabs forces `isLoadingScans` back on (scan-reducer's
+    // SET_TAB) to hide the outgoing tab's rows. `keepPreviousData` on the scans query
+    // means its `isLoading` stays false across that key change once any fetch has
+    // succeeded once, so the flag must be cleared when fresh data for the new tab
+    // lands rather than by mirroring the query's `isLoading`.
+    it('clears the spinner once the new tab data arrives, even though the query never reports isLoading again', async () => {
+        const { service, scansCalls, getAllScans } = createMockService();
+        const { result } = setup(service);
+
+        await waitFor(() => expect(getAllScans).toHaveBeenCalledTimes(1));
+        act(() => scansCalls[0].resolve({ scans: [scanFixture('scan-0', 'foo')], totalSize: 1 }));
+        await waitFor(() => expect(result.current.state.scans).toHaveLength(1));
+        expect(result.current.state.isLoadingScans).toBe(false);
+
+        act(() => result.current.actions.setTab(1));
+        expect(result.current.state.isLoadingScans).toBe(true);
+        expect(result.current.state.scans).toHaveLength(0);
+
+        await waitFor(() => expect(getAllScans).toHaveBeenCalledTimes(2));
+        act(() => scansCalls[1].resolve({ scans: [scanFixture('scan-1', 'bar')], totalSize: 1 }));
+
+        await waitFor(() => expect(result.current.state.scans).toHaveLength(1));
+        expect(result.current.state.isLoadingScans).toBe(false);
+    });
+});


### PR DESCRIPTION
## Problem

The scan admin page's Scans/Quarantined/Auto Rejected/Allowed Files/Blocked Files
tabs sometimes get stuck showing a loading spinner even though the request
already succeeded and the data is available.

## Root cause

Switching tabs forces `isLoadingScans`/`isLoadingFiles` back to `true`
(`SET_TAB` in `scan-reducer.ts`) to hide the outgoing tab's rows while the new
tab's data loads. The only code that cleared that flag mirrored the scans/files
query's `isLoading` value — but the query uses `placeholderData: keepPreviousData`,
which makes `isLoading` report `false` across *every* query-key change once any
fetch at that call site has ever succeeded (`isLoading` = `isPending && isFetching`,
and `keepPreviousData` keeps `isPending` false). After the first tab switch, the
effect's dependencies (`enabled`, `isLoading`) never change value again, so it
never re-fires, and the spinner set by `SET_TAB` never gets cleared — even though
the fetch succeeds and the fresh rows are already sitting in state underneath it.

## Fix

Clear the loading flag directly inside the effect that reacts to fresh data
arriving, for both the scans and files hooks. That effect only fires on a
genuinely new data reference, so it's unaffected by the `keepPreviousData`
quirk and doesn't reintroduce a spinner flash during ordinary pagination/filter
changes (which don't force the flag on in the first place).

## Testing

Added a regression test (`scan-context.spec.tsx`) that drives a real
`ScanProvider` through a tab switch with a controllable mock service, asserting
the spinner clears once the new tab's data lands. Confirmed it fails without the
fix and passes with it.

Fixes #2083

🤖 Generated with [Claude Code](https://claude.com/claude-code)