### PR TITLE
feat: check max extension size in publish before uploading

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ This change log covers only the command line interface (CLI) of Open VSX.
 
 ### [v1.1.1] (09/08/2026)
 
+#### Added
+
+- `publish` checks the packaged extension's size against the limit reported by the registry's `/api/version` endpoint before uploading, instead of failing only after the upload completes ([#1953](https://github.com/eclipse-openvsx/openvsx/issues/1953))
+
 ### Dependencies
 
 - Bump ip-address from `10.2.0` to `10.4.0`

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 This change log covers only the command line interface (CLI) of Open VSX.
 
-### [v1.1.1] (09/08/2026)
+### [next] (unreleased)
 
 #### Added
 
+- Add `unpublish` command to delete an extension or some of its versions, mirroring `vsce unpublish` ([#1958](https://github.com/eclipse-openvsx/openvsx/issues/1958)); requires a registry running version 1.2.0 or later, which `unpublish` checks for before deleting
 - `publish` checks the packaged extension's size against the limit reported by the registry's `/api/version` endpoint before uploading, instead of failing only after the upload completes ([#1953](https://github.com/eclipse-openvsx/openvsx/issues/1953))
+
+### [v1.1.1] (09/08/2026)
 
 ### Dependencies
 
@@ -18,7 +21,6 @@ This change log covers only the command line interface (CLI) of Open VSX.
 
 #### Added
 
-- Add `unpublish` command to delete an extension or some of its versions, mirroring `vsce unpublish` ([#1958](https://github.com/eclipse-openvsx/openvsx/issues/1958)); requires a registry running version 1.2.0 or later, which `unpublish` checks for before deleting
 - Add an encrypted filestore as fallback to the system keychain if it cant be accessed ([#1950](https://github.com/eclipse/openvsx/pull/1950))
 - Add `--allow-missing-repository` option to the `publish` command, passed on to `vsce` to package an extension whose `package.json` has no `repository` field without asking for confirmation ([#1735](https://github.com/eclipse-openvsx/openvsx/issues/1735))
 - Support trusted publishing: `publish` can exchange an OIDC ID token for a short-lived publishing token, via `--trusted-publishing`, `--idToken` and `--oidcAudience`

--- a/cli/README.md
+++ b/cli/README.md
@@ -24,6 +24,8 @@ Variants:
  * `ovsx publish <file>`
    publishes an already packaged file.
 
+Before uploading, `ovsx` checks the packaged extension's size against the limit the registry reports on `/api/version`, so an oversized package is rejected locally instead of failing after the whole file has been uploaded.
+
 ### Trusted Publishing
 
 Instead of a long-lived personal access token, `ovsx` can publish from a CI workflow with a short-lived token that the registry issues in exchange for an OIDC ID token of the workflow. The registry only issues such a token if the workflow matches a trusted publisher that a namespace owner registered under [trusted publishers](https://open-vsx.org/user-settings/trusted-publishers). No access token needs to be stored as a secret.

--- a/cli/src/publish.ts
+++ b/cli/src/publish.ts
@@ -7,9 +7,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
+import * as fs from 'fs';
 import { createVSIX, IPackageOptions } from '@vscode/vsce';
 import { getPAT } from './pat';
-import { createTempFile, addEnvOptions, addTrustedPublishingEnvOptions } from './util';
+import { createTempFile, addEnvOptions, addTrustedPublishingEnvOptions, formatBytes } from './util';
 import { Extension, Registry } from './registry';
 import { checkLicense } from './check-license';
 import { readVSIXPackage } from './zip';
@@ -22,16 +23,35 @@ import { getTrustedPublishingToken, useTrustedPublishing } from './trusted-publi
 export async function publish(options: PublishOptions = {}): Promise<PromiseSettledResult<void>[]> {
     addEnvOptions(options);
     addTrustedPublishingEnvOptions(options);
+
+    // Looked up once and shared by every target/package below, rather than once per artifact.
+    const maxExtensionSize = await getMaxExtensionSize(new Registry(options));
+
     const internalPublishOptions: InternalPublishOptions[] = [];
     const packagePaths = options.packagePath || [undefined];
     const targets = options.targets || [undefined];
     for (const packagePath of packagePaths) {
         for (const target of targets) {
-            internalPublishOptions.push({ ...options, packagePath: packagePath, target: target });
+            internalPublishOptions.push({ ...options, packagePath: packagePath, target: target, maxExtensionSize });
         }
     }
 
     return Promise.allSettled(internalPublishOptions.map(publishOptions => doPublish(publishOptions)));
+}
+
+/**
+ * Looks up the registry's configured extension size limit, so an oversized package can be rejected
+ * locally before the upload instead of after transferring the whole payload.
+ *
+ * Best-effort: registries that don't expose `/api/version`, or don't report a limit, return
+ * `undefined` here, and the upload proceeds to let the server enforce its own limit as before.
+ */
+async function getMaxExtensionSize(registry: Registry): Promise<number | undefined> {
+    try {
+        return (await registry.getRegistryVersion()).maxExtensionSize || undefined;
+    } catch {
+        return undefined;
+    }
 }
 
 async function doPublish(options: InternalPublishOptions = {}): Promise<void> {
@@ -48,6 +68,8 @@ async function doPublish(options: InternalPublishOptions = {}): Promise<void> {
     } else if (options.preRelease) {
         console.warn("Ignoring option '--pre-release' for prepackaged extension.");
     }
+
+    await ensureWithinSizeLimit(options.extensionFile!, options.maxExtensionSize, registry.url);
 
     if (!options.pat) {
         const manifest = await readVSIXPackage(options.extensionFile!);
@@ -80,6 +102,26 @@ async function doPublish(options: InternalPublishOptions = {}): Promise<void> {
     console.log(`\ud83d\ude80  Published ${description}`);
     if (extension.warning) {
         console.log(`\n!!  ${extension.warning}`);
+    }
+}
+
+/**
+ * Fails fast with an actionable message when the packaged extension is already known to exceed the
+ * registry's configured size limit, rather than uploading the whole file only to have the server
+ * reject it. `maxSize` is `undefined` when the limit couldn't be determined, in which case the check
+ * is skipped and the upload is left to the server to accept or reject.
+ */
+async function ensureWithinSizeLimit(extensionFile: string, maxSize: number | undefined, registryUrl: string): Promise<void> {
+    if (!maxSize) {
+        return;
+    }
+
+    const { size } = await fs.promises.stat(extensionFile);
+    if (size > maxSize) {
+        throw new Error(
+            `The extension package (${formatBytes(size)}) exceeds the size limit of ${formatBytes(maxSize)} `
+            + `accepted by the registry at ${registryUrl}.`
+        );
     }
 }
 
@@ -124,4 +166,10 @@ interface InternalPublishOptions extends PublishCommonOptions {
      * Whether to do dependency detection via npm or yarn
      */
     dependencies?: boolean;
+
+    /**
+     * The registry's configured extension size limit in bytes, looked up once via `/api/version` and
+     * shared across every target/package being published. `undefined` when it couldn't be determined.
+     */
+    maxExtensionSize?: number;
 }

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -105,14 +105,14 @@ export function handleError(debug?: boolean, additionalMessage?: string, exit: b
  * the same way.
  */
 export function formatBytes(bytes: number): string {
-    const units = ['bytes', 'KB', 'MB', 'GB', 'TB'];
+    const units = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB'];
     let size = bytes;
     let unit = 0;
     while (size >= 1024 && unit < units.length - 1) {
         size /= 1024;
         unit++;
     }
-    return `${unit === 0 ? size : size.toFixed(1)} ${units[unit]}`;
+    return `${Math.floor(size)} ${units[unit]}`;
 }
 
 export function statusError(response: http.IncomingMessage): Error {

--- a/cli/src/util.ts
+++ b/cli/src/util.ts
@@ -99,6 +99,22 @@ export function handleError(debug?: boolean, additionalMessage?: string, exit: b
     };
 }
 
+/**
+ * Formats a byte count for display, e.g. `1536` -> `1.5 KB`. Mirrors the registry's own
+ * `FileUtils.byteCountToDisplaySize` formatting so client- and server-side size limit messages read
+ * the same way.
+ */
+export function formatBytes(bytes: number): string {
+    const units = ['bytes', 'KB', 'MB', 'GB', 'TB'];
+    let size = bytes;
+    let unit = 0;
+    while (size >= 1024 && unit < units.length - 1) {
+        size /= 1024;
+        unit++;
+    }
+    return `${unit === 0 ? size : size.toFixed(1)} ${units[unit]}`;
+}
+
 export function statusError(response: http.IncomingMessage): Error {
     if (response.statusMessage)
         return new Error(`The server responded with status ${response.statusCode}: ${response.statusMessage}`);

--- a/cli/test/unit/publish.spec.ts
+++ b/cli/test/unit/publish.spec.ts
@@ -1,0 +1,147 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { AddressInfo } from 'net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { publish } from '../../src/publish';
+
+interface RecordedRequest {
+    pathname: string;
+    query: URLSearchParams;
+}
+
+interface RegistryStub {
+    url: string;
+    publishRequests: RecordedRequest[];
+    close: () => Promise<void>;
+}
+
+/**
+ * Stands in for the registry's `/api/version` and `/api/-/publish` endpoints.
+ */
+async function startRegistryStub(
+    version: { status?: number; body?: unknown } = {},
+    publishResponse: { status?: number; body?: unknown } = {}
+): Promise<RegistryStub> {
+    const publishRequests: RecordedRequest[] = [];
+    const versionStatus = version.status ?? 200;
+    const versionBody = version.body ?? { version: '1.2.0' };
+    const publishStatus = publishResponse.status ?? 200;
+    const publishBody = publishResponse.body ?? {
+        namespace: 'foo',
+        name: 'bar',
+        version: '1.0.0',
+        targetPlatform: 'universal'
+    };
+    const server = http.createServer((req, res) => {
+        const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+        req.on('data', () => undefined);
+        req.on('end', () => {
+            if (url.pathname === '/api/version') {
+                res.writeHead(versionStatus, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(versionBody));
+            } else {
+                publishRequests.push({ pathname: url.pathname, query: url.searchParams });
+                res.writeHead(publishStatus, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(publishBody));
+            }
+        });
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    return {
+        url: `http://127.0.0.1:${port}`,
+        publishRequests,
+        close: () => new Promise<void>(resolve => server.close(() => resolve()))
+    };
+}
+
+describe('publish', () => {
+
+    const stubs: RegistryStub[] = [];
+    const tmpFiles: string[] = [];
+
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await Promise.all(stubs.splice(0).map(stub => stub.close()));
+        tmpFiles.splice(0).forEach(file => fs.rmSync(file, { force: true }));
+    });
+
+    async function givenRegistry(
+        version?: { status?: number; body?: unknown },
+        publishResponse?: { status?: number; body?: unknown }
+    ): Promise<RegistryStub> {
+        const stub = await startRegistryStub(version, publishResponse);
+        stubs.push(stub);
+        return stub;
+    }
+
+    function givenExtensionFile(sizeInBytes: number): string {
+        const file = path.join(os.tmpdir(), `ovsx-publish-test-${Math.random().toString(36).slice(2)}.vsix`);
+        fs.writeFileSync(file, Buffer.alloc(sizeInBytes));
+        tmpFiles.push(file);
+        return file;
+    }
+
+    it('publishes a package that is within the registry size limit', async () => {
+        const registry = await givenRegistry({ body: { version: '1.2.0', maxExtensionSize: 1024 } });
+        const extensionFile = givenExtensionFile(100);
+
+        const [result] = await publish({ extensionFile, pat: 'the.pat', registryUrl: registry.url });
+
+        expect(result.status).toBe('fulfilled');
+        expect(registry.publishRequests).toHaveLength(1);
+    });
+
+    it('rejects locally, without uploading, when the package exceeds the registry size limit', async () => {
+        const registry = await givenRegistry({ body: { version: '1.2.0', maxExtensionSize: 100 } });
+        const extensionFile = givenExtensionFile(200);
+
+        const [result] = await publish({ extensionFile, pat: 'the.pat', registryUrl: registry.url });
+
+        expect(result.status).toBe('rejected');
+        expect((result as PromiseRejectedResult).reason.message).toBe(
+            `The extension package (200 bytes) exceeds the size limit of 100 bytes accepted by the registry at ${registry.url}.`
+        );
+        expect(registry.publishRequests).toHaveLength(0);
+    });
+
+    it('proceeds when the registry does not report a size limit', async () => {
+        const registry = await givenRegistry({ body: { version: '1.2.0' } });
+        const extensionFile = givenExtensionFile(200);
+
+        const [result] = await publish({ extensionFile, pat: 'the.pat', registryUrl: registry.url });
+
+        expect(result.status).toBe('fulfilled');
+        expect(registry.publishRequests).toHaveLength(1);
+    });
+
+    it('proceeds when the registry does not expose `/api/version`', async () => {
+        const registry = await givenRegistry({ status: 404, body: {} });
+        const extensionFile = givenExtensionFile(200);
+
+        const [result] = await publish({ extensionFile, pat: 'the.pat', registryUrl: registry.url });
+
+        expect(result.status).toBe('fulfilled');
+        expect(registry.publishRequests).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## What

Resolves #1953. `ovsx publish` now checks the packaged extension's size against the registry's configured limit *before* uploading, instead of only failing after the whole file has been transferred.

The registry's limit is already exposed via `/api/version`'s `maxExtensionSize` field (added in #1937, and reused by the `unpublish` command's version check). This is the last consumer-side piece to make the setting actionable for CLI users.

## How

- `publish()` looks up `maxExtensionSize` **once** per invocation and shares it across every target/package being published, avoiding a redundant `/api/version` call per artifact for multi-target publishes.
- The check runs in `doPublish()` right after the file is packaged/resolved, before requesting a PAT or exchanging a trusted-publishing token, so it fails before any unnecessary auth prompt too.
- Best-effort, like the unpublish version check: a lookup failure, or a registry that doesn't report a limit (older/self-hosted registries), skips the check silently and leaves the server to enforce its own limit as before.
- The error message mirrors the server's own wording style (`FileUtils.byteCountToDisplaySize`), via a new small `formatBytes()` helper.

## Testing

- Added `cli/test/unit/publish.spec.ts` covering: publish within limit, local rejection over limit (asserting the upload is never attempted), and two fail-open cases (no limit reported, `/api/version` not exposed).
- `vitest`, `eslint`, and `tsc --noEmit` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)