### PR TITLE
feat: store filesizes for each FileResource

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/entities/FileResource.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/FileResource.java
@@ -48,6 +48,8 @@ public class FileResource {
     @Column(length = 32)
     private String storageType;
 
+    private Long size;
+
     public long getId() {
         return id;
     }
@@ -86,5 +88,17 @@ public class FileResource {
 
     public void setStorageType(String storageType) {
         this.storageType = storageType;
+    }
+
+    /**
+     * The size of the file in bytes, or {@code null} if it hasn't been determined yet
+     * (e.g. for resources created before this field was introduced, pending backfill).
+     */
+    public Long getSize() {
+        return size;
+    }
+
+    public void setSize(Long size) {
+        this.size = size;
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
@@ -1,0 +1,64 @@
+/** ******************************************************************************
+ * Copyright (c) 2026 Precies. Software OU and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.migration;
+
+import java.nio.file.Files;
+
+import org.jobrunr.jobs.annotations.Job;
+import org.jobrunr.jobs.context.JobRunrDashboardLogger;
+import org.jobrunr.jobs.lambdas.JobRequestHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import org.eclipse.openvsx.util.NamingUtil;
+
+/**
+ * Backfills {@link org.eclipse.openvsx.entities.FileResource#getSize()} for file resources that were
+ * stored before the size was tracked.
+ * <p>
+ * Disabled on mirror instances: mirrored resources are mostly served on the fly rather than stored
+ * locally (see {@code PublishExtensionVersionHandler#mirror}), so downloading them here to measure
+ * their size would just fail for anything other than the download and its sha256 checksum.
+ */
+@Component
+@ConditionalOnProperty(value = "ovsx.data.mirror.enabled", havingValue = "false", matchIfMissing = true)
+public class FileResourceSizeJobRequestHandler implements JobRequestHandler<MigrationJobRequest<?>> {
+
+    protected final Logger logger = new JobRunrDashboardLogger(
+            LoggerFactory.getLogger(FileResourceSizeJobRequestHandler.class));
+
+    private final MigrationService migrations;
+
+    public FileResourceSizeJobRequestHandler(MigrationService migrations) {
+        this.migrations = migrations;
+    }
+
+    @Override
+    @Job(name = "Determine file size for published file resource", retries = 3)
+    public void run(MigrationJobRequest jobRequest) throws Exception {
+        var resource = migrations.getResource(jobRequest);
+        if (resource == null || resource.getSize() != null) {
+            return;
+        }
+
+        logger.atInfo()
+                .setMessage("Determine file size for: {} ({})")
+                .addArgument(() -> NamingUtil.toLogFormat(resource.getExtension()))
+                .addArgument(resource::getName)
+                .log();
+
+        try (var file = migrations.getExtensionFile(resource)) {
+            resource.setSize(Files.size(file.getPath()));
+            migrations.updateResource(resource);
+        }
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
@@ -9,8 +9,6 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.migration;
 
-import java.nio.file.Files;
-
 import org.jobrunr.jobs.annotations.Job;
 import org.jobrunr.jobs.context.JobRunrDashboardLogger;
 import org.jobrunr.jobs.lambdas.JobRequestHandler;
@@ -23,11 +21,14 @@ import org.eclipse.openvsx.util.NamingUtil;
 
 /**
  * Backfills {@link org.eclipse.openvsx.entities.FileResource#getSize()} for file resources that were
- * stored before the size was tracked.
+ * stored before the size was tracked, via a metadata-only lookup against the storage backend
+ * (e.g. an S3 HEAD request) rather than downloading each file's content -- with potentially millions
+ * of stored resources across a large registry, downloading every one of them just to measure it would
+ * be far too slow and re-transfer an enormous amount of data for no reason.
  * <p>
  * Disabled on mirror instances: mirrored resources are mostly served on the fly rather than stored
- * locally (see {@code PublishExtensionVersionHandler#mirror}), so downloading them here to measure
- * their size would just fail for anything other than the download and its sha256 checksum.
+ * locally (see {@code PublishExtensionVersionHandler#mirror}), so there is usually no stored object to
+ * look up metadata for in the first place, other than the download and its sha256 checksum.
  */
 @Component
 @ConditionalOnProperty(value = "ovsx.data.mirror.enabled", havingValue = "false", matchIfMissing = true)
@@ -56,9 +57,7 @@ public class FileResourceSizeJobRequestHandler implements JobRequestHandler<Migr
                 .addArgument(resource::getName)
                 .log();
 
-        try (var file = migrations.getExtensionFile(resource)) {
-            resource.setSize(Files.size(file.getPath()));
-            migrations.updateResource(resource);
-        }
+        resource.setSize(migrations.getFileSize(resource));
+        migrations.updateResource(resource);
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
@@ -1,12 +1,15 @@
-/** ******************************************************************************
- * Copyright (c) 2026 Precies. Software OU and others
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
- * ****************************************************************************** */
+ *****************************************************************************/
 package org.eclipse.openvsx.migration;
 
 import org.jobrunr.jobs.annotations.Job;

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationJobRequest.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationJobRequest.java
@@ -12,7 +12,12 @@ package org.eclipse.openvsx.migration;
 import org.jobrunr.jobs.lambdas.JobRequest;
 import org.jobrunr.jobs.lambdas.JobRequestHandler;
 
-public class MigrationJobRequest<T extends JobRequestHandler<MigrationJobRequest<?>>> implements JobRequest {
+// The type parameter is deliberately bounded by the non-specific JobRequestHandler<?> rather than
+// JobRequestHandler<MigrationJobRequest<?>>: that self-referential bound (T's bound mentions this
+// class parametrized with itself again) sends Jackson's generic type resolution into infinite
+// recursion -- a StackOverflowError wrapped as a DatabindException -- while serializing the
+// `handler` field for JobRunr's queue storage. See MigrationJobRequestTest for a standalone repro.
+public class MigrationJobRequest<T extends JobRequestHandler<?>> implements JobRequest {
 
     private Class<T> handler;
     private long entityId;

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
@@ -49,7 +49,9 @@ public class MigrationService {
             "RemoveFileResourceTypeResourceMigration",
             RemoveFileResourceTypeResourceJobRequestHandler.class,
             "FixMissingFilesMigration",
-            FixMissingFilesJobRequestHandler.class);
+            FixMissingFilesJobRequestHandler.class,
+            "FileResourceSizeMigration",
+            FileResourceSizeJobRequestHandler.class);
 
     protected final Logger logger = LoggerFactory.getLogger(MigrationService.class);
 

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
@@ -105,6 +105,11 @@ public class MigrationService {
     }
 
     @Retryable
+    public long getFileSize(FileResource resource) throws IOException {
+        return storageUtil.getFileSize(resource);
+    }
+
+    @Retryable
     public void uploadFileResource(TempFile tempFile) {
         storageUtil.uploadFile(tempFile);
     }

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionService.java
@@ -9,6 +9,9 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.publish;
 
+import java.io.IOException;
+import java.nio.file.Files;
+
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.slf4j.Logger;
@@ -16,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.resilience.annotation.Retryable;
 import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerErrorException;
 
 import org.eclipse.openvsx.ExtensionService;
 import org.eclipse.openvsx.entities.ExtensionVersion;
@@ -61,7 +65,17 @@ public class PublishExtensionVersionService {
 
     @Transactional
     public void mirrorResource(TempFile tempFile) {
-        mirrorResource(tempFile.getResource());
+        var resource = tempFile.getResource();
+        try {
+            // the bytes were extracted from the mirrored package to build this TempFile, even though
+            // they aren't uploaded to storage here (mirror mode serves resources on the fly), so the
+            // size is still known and worth recording.
+            resource.setSize(Files.size(tempFile.getPath()));
+        } catch (IOException e) {
+            throw new ServerErrorException("Failed to determine file size", e);
+        }
+
+        mirrorResource(resource);
     }
 
     @Transactional

--- a/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.services.s3.endpoints.S3EndpointProvider;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -337,6 +338,17 @@ public class AwsStorageService implements IStorageService {
         }
         tempFile.setResource(resource);
         return tempFile;
+    }
+
+    @Override
+    public long getFileSize(FileResource resource) {
+        // headObject is a metadata-only request; it doesn't transfer the object's content.
+        var request = HeadObjectRequest.builder()
+                .bucket(bucket)
+                .key(getObjectKey(resource))
+                .build();
+
+        return getS3Client().headObject(request).contentLength();
     }
 
     @Override

--- a/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
@@ -194,6 +194,21 @@ public class AzureBlobStorageService implements IStorageService {
     }
 
     @Override
+    public long getFileSize(FileResource resource) throws IOException {
+        var blobName = getObjectKey(resource);
+        if (StringUtils.isEmpty(serviceEndpoint)) {
+            throw new IllegalStateException(missingEndpointMessage(blobName));
+        }
+
+        try {
+            // getProperties is a metadata-only request; it doesn't transfer the blob's content.
+            return getContainerClient().getBlobClient(blobName).getProperties().getBlobSize();
+        } catch (BlobStorageException e) {
+            throw new IOException("Failed to determine file size for " + blobName, e);
+        }
+    }
+
+    @Override
     public void copyFiles(List<Pair<FileResource, FileResource>> pairs) {
         var copyOperations = new ArrayList<SyncPoller<BlobCopyInfo, Void>>();
         for (var pair : pairs) {

--- a/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
@@ -16,7 +16,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;

--- a/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
@@ -174,6 +175,21 @@ public class GoogleCloudStorageService implements IStorageService {
         getStorage().downloadTo(BlobId.of(bucketId, objectId), tempFile.getPath());
         tempFile.setResource(resource);
         return tempFile;
+    }
+
+    @Override
+    public long getFileSize(FileResource resource) throws IOException {
+        if (StringUtils.isEmpty(bucketId)) {
+            throw new IllegalStateException(missingBucketIdMessage(resource.getName()));
+        }
+
+        // Storage.get is a metadata-only request; it doesn't transfer the blob's content.
+        var blob = getStorage().get(BlobId.of(bucketId, getObjectKey(resource)));
+        if (blob == null) {
+            throw new IOException("Blob not found: " + getObjectKey(resource));
+        }
+
+        return blob.getSize();
     }
 
     private String missingBucketIdMessage(String name) {

--- a/server/src/main/java/org/eclipse/openvsx/storage/IStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/IStorageService.java
@@ -62,6 +62,14 @@ public interface IStorageService {
 
     TempFile downloadFile(FileResource resource) throws IOException;
 
+    /**
+     * Returns the size in bytes of {@code resource} as already stored, via a metadata-only lookup
+     * (e.g. a HEAD request) rather than downloading its content. Used to backfill
+     * {@link FileResource#getSize()} for resources stored before that field existed, where
+     * downloading every file just to measure it would be far too expensive at scale.
+     */
+    long getFileSize(FileResource resource) throws IOException;
+
     void copyFiles(List<Pair<FileResource, FileResource>> pairs);
 
     void copyNamespaceLogo(Namespace oldNamespace, Namespace newNamespace);

--- a/server/src/main/java/org/eclipse/openvsx/storage/LocalStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/LocalStorageService.java
@@ -158,6 +158,11 @@ public class LocalStorageService implements IStorageService {
     }
 
     @Override
+    public long getFileSize(FileResource resource) throws IOException {
+        return Files.size(getPath(resource));
+    }
+
+    @Override
     public void copyFiles(List<Pair<FileResource, FileResource>> pairs) {
         try {
             for (var pair : pairs) {

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.util.Pair;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerErrorException;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ArrayNode;
@@ -214,6 +215,15 @@ public class StorageUtilService implements IStorageService {
         var storageType = getStorageTypeForResource(resource);
         getStorageService(storageType).uploadFile(tempFile);
         resource.setStorageType(storageType);
+        resource.setSize(getFileSize(tempFile));
+    }
+
+    private long getFileSize(TempFile tempFile) {
+        try {
+            return Files.size(tempFile.getPath());
+        } catch (IOException e) {
+            throw new ServerErrorException("Failed to determine file size", e);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -285,6 +285,19 @@ public class StorageUtilService implements IStorageService {
     }
 
     /**
+     * Returns the size in bytes of {@code resource} as already stored, via a metadata-only lookup
+     * rather than downloading its content -- see {@link IStorageService#getFileSize(FileResource)}.
+     */
+    public long getFileSize(FileResource resource) throws IOException {
+        var storageService = getStorageServiceForRetrieval(resource.getStorageType());
+        if (storageService == null) {
+            throw new IOException("Storage '" + resource.getStorageType() + "' is not available.");
+        }
+
+        return storageService.getFileSize(resource);
+    }
+
+    /**
      * Returns URLs for the given file types as a map of ExtensionVersion.id by a map of type by file URL, to be used in JSON response data.
      */
     public Map<Long, Map<String, String>> getFileUrls(

--- a/server/src/main/jooq-gen/org/eclipse/openvsx/jooq/tables/FileResource.java
+++ b/server/src/main/jooq-gen/org/eclipse/openvsx/jooq/tables/FileResource.java
@@ -78,6 +78,11 @@ public class FileResource extends TableImpl<FileResourceRecord> {
      */
     public final TableField<FileResourceRecord, String> STORAGE_TYPE = createField(DSL.name("storage_type"), SQLDataType.VARCHAR(32), this, "");
 
+    /**
+     * The column <code>public.file_resource.size</code>.
+     */
+    public final TableField<FileResourceRecord, Long> SIZE = createField(DSL.name("size"), SQLDataType.BIGINT, this, "");
+
     private FileResource(Name alias, Table<FileResourceRecord> aliased) {
         this(alias, aliased, (Field<?>[]) null, null);
     }

--- a/server/src/main/jooq-gen/org/eclipse/openvsx/jooq/tables/records/FileResourceRecord.java
+++ b/server/src/main/jooq-gen/org/eclipse/openvsx/jooq/tables/records/FileResourceRecord.java
@@ -87,6 +87,20 @@ public class FileResourceRecord extends UpdatableRecordImpl<FileResourceRecord> 
         return (String) get(4);
     }
 
+    /**
+     * Setter for <code>public.file_resource.size</code>.
+     */
+    public void setSize(Long value) {
+        set(5, value);
+    }
+
+    /**
+     * Getter for <code>public.file_resource.size</code>.
+     */
+    public Long getSize() {
+        return (Long) get(5);
+    }
+
     // -------------------------------------------------------------------------
     // Primary key information
     // -------------------------------------------------------------------------
@@ -110,7 +124,7 @@ public class FileResourceRecord extends UpdatableRecordImpl<FileResourceRecord> 
     /**
      * Create a detached, initialised FileResourceRecord
      */
-    public FileResourceRecord(Long id, String type, Long extensionId, String name, String storageType) {
+    public FileResourceRecord(Long id, String type, Long extensionId, String name, String storageType, Long size) {
         super(FileResource.FILE_RESOURCE);
 
         setId(id);
@@ -118,6 +132,7 @@ public class FileResourceRecord extends UpdatableRecordImpl<FileResourceRecord> 
         setExtensionId(extensionId);
         setName(name);
         setStorageType(storageType);
+        setSize(size);
         resetChangedOnNotNull();
     }
 }

--- a/server/src/main/resources/db/migration/V1_73__File_Resource_Size.sql
+++ b/server/src/main/resources/db/migration/V1_73__File_Resource_Size.sql
@@ -1,0 +1,10 @@
+-- Track the size (in bytes) of each file resource
+ALTER TABLE file_resource ADD COLUMN IF NOT EXISTS size BIGINT;
+
+-- Backfill the size of existing file resources, most downloaded extensions first
+INSERT INTO migration_item(id, job_name, entity_id, migration_scheduled)
+SELECT nextval('hibernate_sequence'), 'FileResourceSizeMigration', fr.id, FALSE
+FROM file_resource fr
+JOIN extension_version ev ON ev.id = fr.extension_id
+JOIN extension e ON e.id = ev.extension_id
+ORDER BY e.download_count DESC;

--- a/server/src/test/java/org/eclipse/openvsx/migration/MigrationJobRequestTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/migration/MigrationJobRequestTest.java
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.migration;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A self-referential type bound here -- T extends JobRequestHandler&lt;MigrationJobRequest&lt;?&gt;&gt;,
+ * i.e. T's bound mentions this very class parametrized with itself again -- previously sent Jackson's
+ * generic type resolution into infinite recursion while serializing the {@code handler} field for
+ * JobRunr's queue storage, surfacing as a StackOverflowError wrapped in a DatabindException the moment
+ * any migration item was actually enqueued (see MigrationJobRequest's Class&lt;T&gt; field).
+ */
+class MigrationJobRequestTest {
+
+    @Test
+    void serializesWithoutInfiniteRecursion() {
+        // JobRunr's own Jackson3JsonMapper wraps a JsonMapper built much like this one; a plain
+        // JsonMapper is enough to reproduce (and guard against regressing) the type-resolution issue,
+        // which happens purely from the field's declared generic signature, not JobRunr-specific config.
+        var mapper = JsonMapper.builder().build();
+        var request = new MigrationJobRequest<>(FileResourceSizeJobRequestHandler.class, 42L);
+
+        var json = mapper.writeValueAsString(request);
+
+        assertThat(json).contains("42");
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionServiceTest.java
@@ -12,6 +12,7 @@
  *****************************************************************************/
 package org.eclipse.openvsx.publish;
 
+import java.nio.file.Files;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.EntityManager;
@@ -27,10 +28,12 @@ import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.entities.ExtensionVersionChange;
 import org.eclipse.openvsx.entities.ExtensionVersionState;
+import org.eclipse.openvsx.entities.FileResource;
 import org.eclipse.openvsx.entities.Namespace;
 import org.eclipse.openvsx.repositories.RepositoryService;
 import org.eclipse.openvsx.storage.StorageUtilService;
 import org.eclipse.openvsx.util.TargetPlatform;
+import org.eclipse.openvsx.util.TempFile;
 import org.eclipse.openvsx.util.TimeUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -157,6 +160,23 @@ class PublishExtensionVersionServiceTest {
         assertThat(extVersion.isActive()).isFalse();
         verify(extensions, never()).updateExtension(any());
         verify(repositories, never()).recordExtensionVersionChange(any(), any(), any());
+    }
+
+    @Test
+    void mirrorResource_recordsTheSizeOfTheExtractedBytes() throws Exception {
+        // Mirror mode doesn't upload the bytes to storage -- they're served on the fly from the
+        // origin registry instead -- but the TempFile still holds real bytes extracted from the
+        // mirrored package, so the size is there for the taking.
+        var resource = new FileResource();
+        try (var tempFile = new TempFile("mirror_", ".tmp")) {
+            tempFile.setResource(resource);
+            Files.writeString(tempFile.getPath(), "package contents");
+
+            svc.mirrorResource(tempFile);
+
+            assertThat(resource.getSize()).isEqualTo(Files.size(tempFile.getPath()));
+        }
+        verify(entityManager).persist(resource);
     }
 
     private ExtensionVersion version(long id, boolean removed) {

--- a/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceIntegrationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceIntegrationTest.java
@@ -14,6 +14,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
@@ -183,12 +184,13 @@ class AwsStorageServiceIntegrationTest {
     void testGetFileSizeWithoutDownloading() throws IOException {
         var tempFile = new TempFile("test_", ".vsix");
         var testContent = "This is test extension content";
-        Files.write(tempFile.getPath(), testContent.getBytes(), StandardOpenOption.CREATE);
+        var testContentBytes = testContent.getBytes(StandardCharsets.UTF_8);
+        Files.write(tempFile.getPath(), testContentBytes, StandardOpenOption.CREATE);
         tempFile.setResource(resource);
         storageService.uploadFile(tempFile);
         tempFile.close();
 
-        assertEquals(testContent.length(), storageService.getFileSize(resource));
+        assertEquals(testContentBytes.length, storageService.getFileSize(resource));
     }
 
     @Test

--- a/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceIntegrationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceIntegrationTest.java
@@ -180,6 +180,18 @@ class AwsStorageServiceIntegrationTest {
     }
 
     @Test
+    void testGetFileSizeWithoutDownloading() throws IOException {
+        var tempFile = new TempFile("test_", ".vsix");
+        var testContent = "This is test extension content";
+        Files.write(tempFile.getPath(), testContent.getBytes(), StandardOpenOption.CREATE);
+        tempFile.setResource(resource);
+        storageService.uploadFile(tempFile);
+        tempFile.close();
+
+        assertEquals(testContent.length(), storageService.getFileSize(resource));
+    }
+
+    @Test
     void testUploadAndDownloadNamespaceLogo() throws IOException {
         var logoFile = new TempFile("logo_", ".png");
         var logoContent = "fake-png-content";

--- a/server/src/test/java/org/eclipse/openvsx/storage/StorageUtilServiceUploadFileTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/StorageUtilServiceUploadFileTest.java
@@ -1,0 +1,90 @@
+/** ******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.storage;
+
+import java.nio.file.Files;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.eclipse.openvsx.entities.FileResource;
+import org.eclipse.openvsx.metrics.ExtensionDownloadMetrics;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.search.SearchUtilService;
+import org.eclipse.openvsx.storage.log.DownloadCountService;
+import org.eclipse.openvsx.util.TempFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link StorageUtilService#uploadFile(TempFile)}.
+ */
+@ExtendWith(MockitoExtension.class)
+class StorageUtilServiceUploadFileTest {
+
+    @Mock
+    RepositoryService repositories;
+    @Mock
+    GoogleCloudStorageService googleStorage;
+    @Mock
+    AzureBlobStorageService azureStorage;
+    @Mock
+    LocalStorageService localStorage;
+    @Mock
+    AwsStorageService awsStorage;
+    @Mock
+    DownloadCountService downloadCountService;
+    @Mock
+    ExtensionDownloadMetrics downloadMetrics;
+    @Mock
+    SearchUtilService search;
+    @Mock
+    org.eclipse.openvsx.cache.CacheService cache;
+    @Mock
+    EntityManager entityManager;
+    @Mock
+    FileCacheDurationConfig fileCacheDurationConfig;
+    @Mock
+    CdnServiceConfig cdnServiceConfig;
+
+    @Test
+    void uploadFile_recordsTheSizeOfTheUploadedBytes() throws Exception {
+        when(localStorage.isEnabled()).thenReturn(true);
+
+        var svc = new StorageUtilService(
+                repositories,
+                googleStorage,
+                azureStorage,
+                localStorage,
+                awsStorage,
+                downloadCountService,
+                downloadMetrics,
+                search,
+                cache,
+                entityManager,
+                fileCacheDurationConfig,
+                cdnServiceConfig);
+
+        var resource = new FileResource();
+        try (var tempFile = new TempFile("upload_", ".tmp")) {
+            tempFile.setResource(resource);
+            Files.writeString(tempFile.getPath(), "extension package bytes");
+
+            svc.uploadFile(tempFile);
+
+            assertThat(resource.getStorageType()).isEqualTo(FileResource.STORAGE_LOCAL);
+            assertThat(resource.getSize()).isEqualTo(Files.size(tempFile.getPath()));
+        }
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/storage/StorageUtilServiceUploadFileTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/StorageUtilServiceUploadFileTest.java
@@ -1,12 +1,15 @@
-/** ******************************************************************************
+/******************************************************************************
  * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
  * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
  *
  * SPDX-License-Identifier: EPL-2.0
- * ****************************************************************************** */
+ *****************************************************************************/
 package org.eclipse.openvsx.storage;
 
 import java.nio.file.Files;

--- a/server/src/test/java/org/eclipse/openvsx/storage/StorageUtilServiceUploadFileTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/StorageUtilServiceUploadFileTest.java
@@ -25,10 +25,12 @@ import org.eclipse.openvsx.storage.log.DownloadCountService;
 import org.eclipse.openvsx.util.TempFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link StorageUtilService#uploadFile(TempFile)}.
+ * Unit tests for {@link StorageUtilService#uploadFile(TempFile)} and
+ * {@link StorageUtilService#getFileSize(FileResource)}.
  */
 @ExtendWith(MockitoExtension.class)
 class StorageUtilServiceUploadFileTest {
@@ -62,7 +64,38 @@ class StorageUtilServiceUploadFileTest {
     void uploadFile_recordsTheSizeOfTheUploadedBytes() throws Exception {
         when(localStorage.isEnabled()).thenReturn(true);
 
-        var svc = new StorageUtilService(
+        var svc = newService();
+        var resource = new FileResource();
+        try (var tempFile = new TempFile("upload_", ".tmp")) {
+            tempFile.setResource(resource);
+            Files.writeString(tempFile.getPath(), "extension package bytes");
+
+            svc.uploadFile(tempFile);
+
+            assertThat(resource.getStorageType()).isEqualTo(FileResource.STORAGE_LOCAL);
+            assertThat(resource.getSize()).isEqualTo(Files.size(tempFile.getPath()));
+        }
+    }
+
+    @Test
+    void getFileSize_delegatesToTheResourcesStorageBackend() throws Exception {
+        var resource = new FileResource();
+        resource.setStorageType(FileResource.STORAGE_AWS);
+        when(awsStorage.getFileSize(resource)).thenReturn(1234L);
+
+        assertThat(newService().getFileSize(resource)).isEqualTo(1234L);
+    }
+
+    @Test
+    void getFileSize_failsFastForAnUnknownStorageType() {
+        var resource = new FileResource();
+        resource.setStorageType("not-a-real-storage-type");
+
+        assertThatThrownBy(() -> newService().getFileSize(resource)).isInstanceOf(java.io.IOException.class);
+    }
+
+    private StorageUtilService newService() {
+        return new StorageUtilService(
                 repositories,
                 googleStorage,
                 azureStorage,
@@ -75,16 +108,5 @@ class StorageUtilServiceUploadFileTest {
                 entityManager,
                 fileCacheDurationConfig,
                 cdnServiceConfig);
-
-        var resource = new FileResource();
-        try (var tempFile = new TempFile("upload_", ".tmp")) {
-            tempFile.setResource(resource);
-            Files.writeString(tempFile.getPath(), "extension package bytes");
-
-            svc.uploadFile(tempFile);
-
-            assertThat(resource.getStorageType()).isEqualTo(FileResource.STORAGE_LOCAL);
-            assertThat(resource.getSize()).isEqualTo(Files.size(tempFile.getPath()));
-        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1777.

Adds a nullable `size` (bytes) column to `FileResource`, populates it wherever a resource's content is actually available, and backfills it for existing data.

## Changes

- **Schema**: `V1_73__File_Resource_Size.sql` adds `file_resource.size BIGINT` and seeds `migration_item` rows (most-downloaded extensions first) for the backfill job. jOOQ generated sources were regenerated for the new column.
- **Capture at write time**:
  - `StorageUtilService.uploadFile()` — the single choke point every regular (non-mirror) publish resource passes through (download, manifest, readme, changelog, license, icon, vsixmanifest, signature, sha256) — now records the byte size right after upload.
  - `PublishExtensionVersionService.mirrorResource(TempFile)` — mirror mode never uploads bytes (it serves content from the origin registry on the fly), but the extracted `TempFile` still holds real bytes at that point, so the size is captured there too.
- **Backfill**: a new `FileResourceSizeJobRequestHandler`, following the existing `migration_item`/JobRunr pattern (same shape as the sha256-checksum and missing-files migrations). **Updated per review feedback** (thanks @netomi): the handler no longer downloads each file's full content to measure it — at 100k+ extensions that would mean re-transferring an enormous amount of data just to learn a number every storage backend already tracks as metadata. It now does a metadata-only lookup instead:
  - Added `IStorageService.getFileSize(FileResource)`, implemented per backend with no content transfer: `Files.size(path)` locally, `Storage.get(BlobId)` on GCS, `BlobClient.getProperties().getBlobSize()` on Azure, `S3Client.headObject(...)` on AWS (a HEAD request).
  - The backfill job now calls this instead of downloading each resource.
  - Disabled on mirror instances (same guard as `FixMissingFilesMigration`), since most of their resources have no locally stored object to look up metadata for in the first place.

## Out of scope

Exposing file size through a public API/JSON response is left for a follow-up — `ExtensionJson.files` is currently a `Map<String,String>` (type → URL) and would need a shape change to carry sizes, which felt like a separate API-design decision beyond what the issue asked for (collect, store, backfill).

## Testing

- `StorageUtilServiceUploadFileTest` — verifies `uploadFile` records the byte size, and that `getFileSize` dispatches to the right backend / fails fast for an unrecognized storage type.
- `PublishExtensionVersionServiceTest.mirrorResource_recordsTheSizeOfTheExtractedBytes` — verifies the mirror path.
- `AwsStorageServiceIntegrationTest.testGetFileSizeWithoutDownloading` — against a real LocalStack S3 instance, confirms the size comes back correctly via a HEAD request after upload.
- Full server unit test suite (`./gradlew unitTests`) passes.
- Verified the full Flyway migration chain (all 74 scripts, including `V1_73`) applies cleanly against a real Postgres instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
