### PR TITLE
Delete migration_item rows once their job completes

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilter.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilter.java
@@ -21,10 +21,11 @@ import org.springframework.stereotype.Component;
 /**
  * Deletes the {@link org.eclipse.openvsx.entities.MigrationItem} row backing a migration job once
  * that job has actually finished successfully, instead of leaving completed rows in the table
- * forever (see <a href="https://github.com/eclipse-openvsx/openvsx/issues/1588">...</a>). Deletion doesn't live at
- * the end of every {@code *JobRequestHandler} because there would be a lot of them to touch and
- * to keep touching for every future migration -- a single JobRunr filter that inspects the
- * {@link MigrationJobRequest} on state transitions covers all of them at once, present and future.
+ * forever (see <a href="https://github.com/eclipse-openvsx/openvsx/issues/1588">issue #1588</a>).
+ * Deletion doesn't live at the end of every {@code *JobRequestHandler} because there would be a
+ * lot of them to touch and to keep touching for every future migration -- a single JobRunr filter
+ * that inspects the {@link MigrationJobRequest} on state transitions covers all of them at once,
+ * present and future.
  * <p>
  * On failure (even after retries are exhausted) the row is deliberately left in place: the next
  * {@link MigrationScheduler} run will pick it up again via
@@ -65,7 +66,7 @@ public class MigrationItemCleanupFilter implements JobServerFilter {
 
     private Long getMigrationItemId(Job job) {
         for (var value : job.getJobDetails().getJobParameterValues()) {
-            if (value instanceof MigrationJobRequest<?> request && request.getMigrationItemId() != 0) {
+            if (value instanceof MigrationJobRequest<?> request && request.getMigrationItemId() > 0) {
                 return request.getMigrationItemId();
             }
         }

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilter.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilter.java
@@ -1,0 +1,75 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.migration;
+
+import org.jobrunr.jobs.Job;
+import org.jobrunr.jobs.filters.JobServerFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Deletes the {@link org.eclipse.openvsx.entities.MigrationItem} row backing a migration job once
+ * that job has actually finished successfully, instead of leaving completed rows in the table
+ * forever (see <a href="https://github.com/eclipse-openvsx/openvsx/issues/1588">...</a>). Deletion doesn't live at
+ * the end of every {@code *JobRequestHandler} because there would be a lot of them to touch and
+ * to keep touching for every future migration -- a single JobRunr filter that inspects the
+ * {@link MigrationJobRequest} on state transitions covers all of them at once, present and future.
+ * <p>
+ * On failure (even after retries are exhausted) the row is deliberately left in place: the next
+ * {@link MigrationScheduler} run will pick it up again via
+ * {@code MigrationItemRepository#findByMigrationScheduledFalseOrderById}... except
+ * {@code migrationScheduled} was already flipped to {@code true} in
+ * {@link MigrationService#enqueueMigration}, so a permanently-failing item currently just sits
+ * there for an operator to notice and investigate, the same as before this change. Fixing that
+ * retry gap is out of scope for this sketch.
+ */
+@Component
+public class MigrationItemCleanupFilter implements JobServerFilter {
+
+    protected final Logger logger = LoggerFactory.getLogger(MigrationItemCleanupFilter.class);
+
+    private final MigrationService migrations;
+
+    public MigrationItemCleanupFilter(MigrationService migrations) {
+        this.migrations = migrations;
+    }
+
+    @Override
+    public void onProcessingSucceeded(Job job) {
+        var migrationItemId = getMigrationItemId(job);
+        if (migrationItemId != null) {
+            migrations.deleteMigrationItem(migrationItemId);
+        }
+    }
+
+    @Override
+    public void onFailedAfterRetries(Job job) {
+        var migrationItemId = getMigrationItemId(job);
+        if (migrationItemId != null) {
+            logger.warn(
+                    "Migration item {} failed after all retries, leaving it in the database for investigation",
+                    migrationItemId);
+        }
+    }
+
+    private Long getMigrationItemId(Job job) {
+        for (var value : job.getJobDetails().getJobParameterValues()) {
+            if (value instanceof MigrationJobRequest<?> request && request.getMigrationItemId() != 0) {
+                return request.getMigrationItemId();
+            }
+        }
+
+        return null;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilterRegistrar.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilterRegistrar.java
@@ -15,9 +15,8 @@ package org.eclipse.openvsx.migration;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.annotation.PostConstruct;
 import org.jobrunr.server.BackgroundJobServer;
-import org.springframework.boot.context.event.ApplicationStartedEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 /**
@@ -29,6 +28,13 @@ import org.springframework.stereotype.Component;
  * be done explicitly against the server's {@code JobDefaultFilters}, and via
  * {@code addAll(...)} rather than {@code setJobFilters(...)} so JobRunr's own built-in filters
  * (e.g. {@code RetryFilter}) are appended to, not replaced.
+ * <p>
+ * Registration happens in {@link PostConstruct}, i.e. as soon as this bean (and therefore its
+ * {@code Optional<BackgroundJobServer>} dependency) is constructed, rather than waiting for an
+ * application-lifecycle event: {@code BackgroundJobServer} only starts actually processing jobs
+ * once JobRunr's own {@code JobRunrStarter} calls {@code start()} on {@code ApplicationReadyEvent}
+ * -- confirmed via javap that this is strictly later than bean construction -- but there's no
+ * reason to rely on that ordering when registering earlier is just as easy and removes any doubt.
  * <p>
  * {@link BackgroundJobServer} is injected as {@link Optional} because it's only present when
  * {@code jobrunr.background-job-server.enabled=true} (e.g. it's absent on nodes that only
@@ -48,8 +54,8 @@ public class MigrationItemCleanupFilterRegistrar {
         this.migrationItemCleanupFilter = migrationItemCleanupFilter;
     }
 
-    @EventListener
-    public void applicationStarted(ApplicationStartedEvent event) {
+    @PostConstruct
+    public void registerFilter() {
         backgroundJobServer.ifPresent(server -> server.getJobFilters().addAll(List.of(migrationItemCleanupFilter)));
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilterRegistrar.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilterRegistrar.java
@@ -1,0 +1,55 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.migration;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.jobrunr.server.BackgroundJobServer;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Registers {@link MigrationItemCleanupFilter} with JobRunr's {@link BackgroundJobServer}.
+ * <p>
+ * JobRunr's Spring Boot starter ({@code JobRunrAutoConfiguration}) does not pick up
+ * {@link org.jobrunr.jobs.filters.JobFilter} beans automatically -- confirmed by inspecting its
+ * bean definitions, none of which take a {@code List<JobFilter>} or similar. Registration has to
+ * be done explicitly against the server's {@code JobDefaultFilters}, and via
+ * {@code addAll(...)} rather than {@code setJobFilters(...)} so JobRunr's own built-in filters
+ * (e.g. {@code RetryFilter}) are appended to, not replaced.
+ * <p>
+ * {@link BackgroundJobServer} is injected as {@link Optional} because it's only present when
+ * {@code jobrunr.background-job-server.enabled=true} (e.g. it's absent on nodes that only
+ * schedule jobs, not process them); there's nothing to register the filter on in that case.
+ */
+@Component
+public class MigrationItemCleanupFilterRegistrar {
+
+    private final Optional<BackgroundJobServer> backgroundJobServer;
+    private final MigrationItemCleanupFilter migrationItemCleanupFilter;
+
+    public MigrationItemCleanupFilterRegistrar(
+            Optional<BackgroundJobServer> backgroundJobServer,
+            MigrationItemCleanupFilter migrationItemCleanupFilter
+    ) {
+        this.backgroundJobServer = backgroundJobServer;
+        this.migrationItemCleanupFilter = migrationItemCleanupFilter;
+    }
+
+    @EventListener
+    public void applicationStarted(ApplicationStartedEvent event) {
+        backgroundJobServer.ifPresent(server -> server.getJobFilters().addAll(List.of(migrationItemCleanupFilter)));
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationJobRequest.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationJobRequest.java
@@ -19,15 +19,31 @@ import org.jobrunr.jobs.lambdas.JobRequestHandler;
 // `handler` field for JobRunr's queue storage. See MigrationJobRequestTest for a standalone repro.
 public class MigrationJobRequest<T extends JobRequestHandler<?>> implements JobRequest {
 
+    // Not every MigrationJobRequest is backed by a migration_item row: GenerateKeyPairJobRequestHandler
+    // reuses this same "run this handler for this entity id" shape to enqueue signature jobs directly,
+    // outside the migration_item bookkeeping table entirely. 0 (no real id ever has this value; the
+    // backing sequence starts at 1) marks "not applicable" for MigrationItemCleanupFilter to skip.
+    private static final long NO_MIGRATION_ITEM = 0;
+
     private Class<T> handler;
     private long entityId;
+    // The governing migration_item row's id, so MigrationItemCleanupFilter can delete exactly that
+    // row once this job completes -- see that class for why deletion doesn't live in each handler.
+    private long migrationItemId = NO_MIGRATION_ITEM;
 
     public MigrationJobRequest() {
     }
 
+    /** For a MigrationJobRequest not backed by any migration_item row. */
     public MigrationJobRequest(Class<T> handler, long entityId) {
         this.handler = handler;
         this.entityId = entityId;
+    }
+
+    public MigrationJobRequest(Class<T> handler, long entityId, long migrationItemId) {
+        this.handler = handler;
+        this.entityId = entityId;
+        this.migrationItemId = migrationItemId;
     }
 
     @Override
@@ -45,5 +61,13 @@ public class MigrationJobRequest<T extends JobRequestHandler<?>> implements JobR
 
     public void setEntityId(long entityId) {
         this.entityId = entityId;
+    }
+
+    public long getMigrationItemId() {
+        return migrationItemId;
+    }
+
+    public void setMigrationItemId(long migrationItemId) {
+        this.migrationItemId = migrationItemId;
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
@@ -81,16 +81,29 @@ public class MigrationService {
         var jobIdText = item.getJobName() + "->itemId=" + item.getId();
         var jobId = uuidService.generateFromName(jobIdText);
         var handler = JOB_HANDLERS.get(item.getJobName());
-        scheduler.enqueue(jobId, new MigrationJobRequest<>(handler, item.getEntityId()));
+        scheduler.enqueue(jobId, new MigrationJobRequest<>(handler, item.getEntityId(), item.getId()));
         logger.info("Enqueued migration {}", jobIdText);
         item.setMigrationScheduled(true);
+    }
+
+    /**
+     * Deletes the {@link MigrationItem} row identified by {@code id}, if it still exists. Called by
+     * {@link MigrationItemCleanupFilter} once the job it scheduled has actually completed -- see that
+     * class for why this isn't just done inline at the end of every job handler.
+     */
+    @Transactional
+    public void deleteMigrationItem(long id) {
+        var item = entityManager.find(MigrationItem.class, id);
+        if (item != null) {
+            entityManager.remove(item);
+        }
     }
 
     public ExtensionVersion getExtension(long entityId) {
         return entityManager.find(ExtensionVersion.class, entityId);
     }
 
-    public FileResource getResource(MigrationJobRequest jobRequest) {
+    public FileResource getResource(MigrationJobRequest<?> jobRequest) {
         return entityManager.find(FileResource.class, jobRequest.getEntityId());
     }
 

--- a/server/src/main/resources/db/migration/V1_73__Delete_Scheduled_MigrationItems.sql
+++ b/server/src/main/resources/db/migration/V1_73__Delete_Scheduled_MigrationItems.sql
@@ -1,4 +1,0 @@
--- Clears the backlog of already-completed migration_item rows that accumulated before automatic
--- cleanup existed (see MigrationItemCleanupFilter). This is the last such cleanup migration ever
--- needed: from now on, completed items are deleted as their jobs finish instead of piling up here.
-DELETE FROM migration_item WHERE migration_scheduled = true;

--- a/server/src/main/resources/db/migration/V1_73__Delete_Scheduled_MigrationItems.sql
+++ b/server/src/main/resources/db/migration/V1_73__Delete_Scheduled_MigrationItems.sql
@@ -1,0 +1,4 @@
+-- Clears the backlog of already-completed migration_item rows that accumulated before automatic
+-- cleanup existed (see MigrationItemCleanupFilter). This is the last such cleanup migration ever
+-- needed: from now on, completed items are deleted as their jobs finish instead of piling up here.
+DELETE FROM migration_item WHERE migration_scheduled = true;

--- a/server/src/test/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilterTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilterTest.java
@@ -1,0 +1,77 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.migration;
+
+import java.util.List;
+
+import org.jobrunr.jobs.Job;
+import org.jobrunr.jobs.JobDetails;
+import org.jobrunr.jobs.JobParameter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MigrationItemCleanupFilterTest {
+
+    @Mock
+    MigrationService migrations;
+
+    @Test
+    void onProcessingSucceeded_deletesMigrationItemBackedRequest() {
+        var filter = new MigrationItemCleanupFilter(migrations);
+        var request = new MigrationJobRequest<>(FixMissingFilesJobRequestHandler.class, 42L, 7L);
+        var job = jobFor(request);
+
+        filter.onProcessingSucceeded(job);
+
+        verify(migrations).deleteMigrationItem(7L);
+    }
+
+    @Test
+    void onProcessingSucceeded_leavesNonMigrationItemBackedRequestAlone() {
+        var filter = new MigrationItemCleanupFilter(migrations);
+        // GenerateKeyPairJobRequestHandler-style: no migration_item row backs this job.
+        var request = new MigrationJobRequest<>(FixMissingFilesJobRequestHandler.class, 42L);
+        var job = jobFor(request);
+
+        filter.onProcessingSucceeded(job);
+
+        verify(migrations, never()).deleteMigrationItem(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    void onFailedAfterRetries_doesNotDeleteMigrationItem() {
+        var filter = new MigrationItemCleanupFilter(migrations);
+        var request = new MigrationJobRequest<>(FixMissingFilesJobRequestHandler.class, 42L, 7L);
+        var job = jobFor(request);
+
+        filter.onFailedAfterRetries(job);
+
+        verify(migrations, never()).deleteMigrationItem(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    private Job jobFor(MigrationJobRequest<?> request) {
+        var jobDetails = new JobDetails(
+                "org.eclipse.openvsx.migration.MigrationItemJobRequestHandler",
+                null,
+                "run",
+                List.of(new JobParameter(request)));
+
+        return new Job(jobDetails);
+    }
+}


### PR DESCRIPTION
## What

Fixes #1588. `migration_item` rows currently stay in the table forever once their job has run, which eventually needs a fresh one-off SQL migration to clear the backlog. This deletes each row automatically once the job it scheduled actually finishes successfully.

## How

- `MigrationJobRequest` now carries the id of the `migration_item` row backing it (`0` for the handful of `MigrationJobRequest` usages that aren't backed by one, e.g. `GenerateKeyPairJobRequestHandler`'s ad-hoc signature jobs). While touching this class I also had to relax its handler type bound from `T extends JobRequestHandler<MigrationJobRequest<?>>` (self-referential) to `T extends JobRequestHandler<?>` — the self-referential bound makes Jackson 3's `TypeFactory` recurse infinitely while serializing the request for JobRunr's queue storage, currently surfacing as a `StackOverflowError`/`DatabindException` the moment any migration item is enqueued on `main`.
- `MigrationService.deleteMigrationItem(id)` deletes a `migration_item` row if it still exists.
- `MigrationItemCleanupFilter` is a JobRunr `JobServerFilter` that, on `onProcessingSucceeded`, looks at the job's parameters for a `MigrationJobRequest` and deletes its backing row. On `onFailedAfterRetries` it leaves the row in place (with a warning logged) so a permanently-failing item stays visible for investigation, same as today.
- `MigrationItemCleanupFilterRegistrar` registers the filter with JobRunr's `BackgroundJobServer` in `@PostConstruct` — confirmed JobRunr's Spring Boot autoconfiguration does not pick up `JobFilter` beans on its own, and that `addAll` appends to JobRunr's built-in filters (e.g. `RetryFilter`) instead of replacing them.

## How this PR does *not* clean up the existing backlog

An earlier revision included a one-off `DELETE FROM migration_item WHERE migration_scheduled = true` migration to clear the backlog already sitting in production. Review caught that this is unsafe: `migration_scheduled` is set at *enqueue* time, not on completion, so it can't distinguish rows that actually finished from ones still in flight or — worse — ones that failed permanently and are deliberately being kept for investigation. There's no column in the current schema that captures "done" vs "failed", so a safe automatic one-time cleanup isn't possible without more information than what's there today. That migration has been dropped; the existing backlog is left in place exactly as it is today, while all newly-created rows benefit from the new auto-delete-on-success behavior going forward.

## Testing

- `MigrationItemCleanupFilterTest`: successful completion deletes the row; a request not backed by a `migration_item` row is left alone; failure-after-retries does not delete.
- Full `unitTests` suite passes (941 tests).

## Notes / open question

A migration item whose job fails after all retries has its `migration_scheduled` flag already set to `true` in `enqueueMigration`, so `MigrationScheduler` won't automatically pick it up again even though the row survives — that's pre-existing behavior, not something this PR changes, but flagging it since it's adjacent. Happy to address it here too if desired, or leave it for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
