### PR TITLE
Tolerate missing storage objects in the file-size backfill

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+import org.eclipse.openvsx.storage.FileNotFoundInStorageException;
 import org.eclipse.openvsx.util.NamingUtil;
 
 /**
@@ -60,7 +61,19 @@ public class FileResourceSizeJobRequestHandler implements JobRequestHandler<Migr
                 .addArgument(resource::getName)
                 .log();
 
-        resource.setSize(migrations.getFileSize(resource));
-        migrations.updateResource(resource);
+        try {
+            resource.setSize(migrations.getFileSize(resource));
+            migrations.updateResource(resource);
+        } catch (FileNotFoundInStorageException e) {
+            // The object backing this resource is confirmed gone, not just temporarily unreachable --
+            // there's nothing further this job can do about that (FixMissingFilesMigration is the
+            // mechanism for actually repairing missing files). Leave the size unset and consider this
+            // job done rather than exhausting retries on an outcome that will never change.
+            logger.atWarn()
+                    .setMessage("File missing in storage, cannot determine size for: {} ({})")
+                    .addArgument(() -> NamingUtil.toLogFormat(resource.getExtension()))
+                    .addArgument(resource::getName)
+                    .log();
+        }
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
@@ -25,6 +25,7 @@ import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.entities.FileResource;
 import org.eclipse.openvsx.entities.MigrationItem;
 import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.storage.FileNotFoundInStorageException;
 import org.eclipse.openvsx.storage.StorageUtilService;
 import org.eclipse.openvsx.util.NamingUtil;
 import org.eclipse.openvsx.util.TempFile;
@@ -117,7 +118,10 @@ public class MigrationService {
         return storageUtil.downloadFile(resource);
     }
 
-    @Retryable
+    // A FileNotFoundInStorageException means the object is definitively gone, not that this attempt
+    // hit a transient error -- retrying it would just spend 3 more round trips (and the accompanying
+    // delay) confirming the same absence, so it's excluded here and handled by the caller instead.
+    @Retryable(excludes = FileNotFoundInStorageException.class)
     public long getFileSize(FileResource resource) throws IOException {
         return storageUtil.getFileSize(resource);
     }

--- a/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AwsStorageService.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
@@ -341,14 +342,28 @@ public class AwsStorageService implements IStorageService {
     }
 
     @Override
-    public long getFileSize(FileResource resource) {
+    public long getFileSize(FileResource resource) throws IOException {
         // headObject is a metadata-only request; it doesn't transfer the object's content.
+        var objectKey = getObjectKey(resource);
         var request = HeadObjectRequest.builder()
                 .bucket(bucket)
-                .key(getObjectKey(resource))
+                .key(objectKey)
                 .build();
 
-        return getS3Client().headObject(request).contentLength();
+        try {
+            return getS3Client().headObject(request).contentLength();
+        } catch (S3Exception e) {
+            // A HEAD response has no body, so S3 can't return a specific error code (e.g. NoSuchKey)
+            // the way it would for a GET -- some implementations throw the specific
+            // NoSuchKeyException regardless, but a plain S3Exception with a 404 status is what's
+            // actually guaranteed, and what e.g. LocalStack sends. Check the status code rather than
+            // the exception type to catch "not found" reliably across implementations.
+            if (e.statusCode() == 404) {
+                throw new FileNotFoundInStorageException("Object not found: " + objectKey, e);
+            }
+
+            throw e;
+        }
     }
 
     @Override

--- a/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/AzureBlobStorageService.java
@@ -22,6 +22,7 @@ import com.azure.core.util.polling.SyncPoller;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.azure.storage.blob.models.BlobCopyInfo;
+import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobHttpHeaders;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.CopyStatusType;
@@ -204,6 +205,10 @@ public class AzureBlobStorageService implements IStorageService {
             // getProperties is a metadata-only request; it doesn't transfer the blob's content.
             return getContainerClient().getBlobClient(blobName).getProperties().getBlobSize();
         } catch (BlobStorageException e) {
+            if (e.getErrorCode() == BlobErrorCode.BLOB_NOT_FOUND) {
+                throw new FileNotFoundInStorageException("Blob not found: " + blobName, e);
+            }
+
             throw new IOException("Failed to determine file size for " + blobName, e);
         }
     }

--- a/server/src/main/java/org/eclipse/openvsx/storage/FileNotFoundInStorageException.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/FileNotFoundInStorageException.java
@@ -1,0 +1,33 @@
+/** ******************************************************************************
+ * Copyright (c) 2026 Precies. Software Ltd and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ * ****************************************************************************** */
+package org.eclipse.openvsx.storage;
+
+import java.io.IOException;
+
+import org.eclipse.openvsx.entities.FileResource;
+
+/**
+ * Signals that a {@link FileResource}'s backing object was confirmed absent from storage (e.g. an
+ * S3 {@code NoSuchKeyException}, a 404 from Azure/GCS, a missing local file) -- as opposed to some
+ * other, possibly transient, storage error (network blip, throttling, permission problem). Callers
+ * that can tolerate a resource's file already being gone (e.g. the size backfill migration, which
+ * has nothing further to do for a resource that isn't there) can catch this specifically and treat
+ * it as "no work to do" rather than as a failure worth retrying.
+ */
+public class FileNotFoundInStorageException extends IOException {
+
+    public FileNotFoundInStorageException(String message) {
+        super(message);
+    }
+
+    public FileNotFoundInStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/GoogleCloudStorageService.java
@@ -185,7 +185,7 @@ public class GoogleCloudStorageService implements IStorageService {
         // Storage.get is a metadata-only request; it doesn't transfer the blob's content.
         var blob = getStorage().get(BlobId.of(bucketId, getObjectKey(resource)));
         if (blob == null) {
-            throw new IOException("Blob not found: " + getObjectKey(resource));
+            throw new FileNotFoundInStorageException("Blob not found: " + getObjectKey(resource));
         }
 
         return blob.getSize();

--- a/server/src/main/java/org/eclipse/openvsx/storage/IStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/IStorageService.java
@@ -67,6 +67,9 @@ public interface IStorageService {
      * (e.g. a HEAD request) rather than downloading its content. Used to backfill
      * {@link FileResource#getSize()} for resources stored before that field existed, where
      * downloading every file just to measure it would be far too expensive at scale.
+     *
+     * @throws FileNotFoundInStorageException if the backing object is confirmed absent, as opposed
+     *         to some other (possibly transient) storage error
      */
     long getFileSize(FileResource resource) throws IOException;
 

--- a/server/src/main/java/org/eclipse/openvsx/storage/LocalStorageService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/LocalStorageService.java
@@ -12,6 +12,7 @@ package org.eclipse.openvsx.storage;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
@@ -159,7 +160,12 @@ public class LocalStorageService implements IStorageService {
 
     @Override
     public long getFileSize(FileResource resource) throws IOException {
-        return Files.size(getPath(resource));
+        var path = getPath(resource);
+        try {
+            return Files.size(path);
+        } catch (NoSuchFileException e) {
+            throw new FileNotFoundInStorageException("File not found: " + path, e);
+        }
     }
 
     @Override

--- a/server/src/test/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandlerTest.java
@@ -1,0 +1,70 @@
+package org.eclipse.openvsx.migration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.eclipse.openvsx.entities.Extension;
+import org.eclipse.openvsx.entities.ExtensionVersion;
+import org.eclipse.openvsx.entities.FileResource;
+import org.eclipse.openvsx.entities.Namespace;
+import org.eclipse.openvsx.storage.FileNotFoundInStorageException;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FileResourceSizeJobRequestHandlerTest {
+
+    @Mock
+    MigrationService migrations;
+
+    @Test
+    void run_leavesSizeUnsetAndDoesNotThrowWhenTheObjectIsMissingFromStorage() throws Exception {
+        var resource = fileResource();
+        var jobRequest = new MigrationJobRequest<>(FileResourceSizeJobRequestHandler.class, 1L);
+        when(migrations.getResource(jobRequest)).thenReturn(resource);
+        when(migrations.getFileSize(resource)).thenThrow(new FileNotFoundInStorageException("gone"));
+
+        var handler = new FileResourceSizeJobRequestHandler(migrations);
+
+        assertThatCode(() -> handler.run(jobRequest)).doesNotThrowAnyException();
+
+        verify(migrations, never()).updateResource(any());
+    }
+
+    @Test
+    void run_recordsTheSizeReturnedByStorage() throws Exception {
+        var resource = fileResource();
+        var jobRequest = new MigrationJobRequest<>(FileResourceSizeJobRequestHandler.class, 1L);
+        when(migrations.getResource(jobRequest)).thenReturn(resource);
+        when(migrations.getFileSize(resource)).thenReturn(42L);
+
+        new FileResourceSizeJobRequestHandler(migrations).run(jobRequest);
+
+        verify(migrations).updateResource(resource);
+    }
+
+    private FileResource fileResource() {
+        var namespace = new Namespace();
+        namespace.setName("foo");
+
+        var extension = new Extension();
+        extension.setName("bar");
+        extension.setNamespace(namespace);
+
+        var extVersion = new ExtensionVersion();
+        extVersion.setVersion("1.0.0");
+        extVersion.setTargetPlatform("universal");
+        extVersion.setExtension(extension);
+
+        var resource = new FileResource();
+        resource.setName("extension.vsix");
+        resource.setExtension(extVersion);
+        return resource;
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceIntegrationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/storage/AwsStorageServiceIntegrationTest.java
@@ -194,6 +194,18 @@ class AwsStorageServiceIntegrationTest {
     }
 
     @Test
+    void testGetFileSizeThrowsFileNotFoundInStorageExceptionForAMissingObject() {
+        // A name no other test in this class uploads to, so its object key is guaranteed absent --
+        // the shared `resource` field's key may already exist from another test in the same reused
+        // LocalStack container/bucket.
+        var missingResource = new FileResource();
+        missingResource.setName("never-uploaded.vsix");
+        missingResource.setExtension(extVersion);
+
+        assertThrows(FileNotFoundInStorageException.class, () -> storageService.getFileSize(missingResource));
+    }
+
+    @Test
     void testUploadAndDownloadNamespaceLogo() throws IOException {
         var logoFile = new TempFile("logo_", ".png");
         var logoContent = "fake-png-content";


### PR DESCRIPTION
## What

Fixes the crash reported after merging #2089:

```
WARN --- [backgroundjob-worker] o.jobrunr.server.BackgroundJobPerformer  : Job(..., jobName='Determine file size for published file resource') processing failed
software.amazon.awssdk.services.s3.model.NoSuchKeyException: (Service: S3, Status Code: 404, ...)
```

`FileResourceSizeJobRequestHandler` (the size backfill job from #1777/#2089) crashes whenever a `FileResource` row points at an object that's no longer actually in storage. This isn't transient — retrying will always fail the same way — but the job let it propagate as a generic failure, so it burned through `@Retryable`'s 3 attempts + JobRunr's own 3 retries, then permanently failed and left the `migration_item` row behind for investigation (per #2092's `MigrationItemCleanupFilter`), even though there's nothing to investigate: the file is just gone.

This is a known, already-tolerated category of problem in this codebase — see `FixMissingFilesJobRequestHandler`, which exists specifically to detect and repair extensions with missing files. This PR makes the size backfill tolerate it the same way instead of crash-looping on it.

## How

- New `FileNotFoundInStorageException` (an `IOException`) signals "the object is confirmed absent", as opposed to some other, possibly-transient, storage error.
- Each storage backend translates its own "definitely not found" signal into it:
  - **AWS**: a HEAD response has no body, so S3 can't return a specific error code the way a GET can — some SDKs/implementations throw `NoSuchKeyException` regardless, but a plain `S3Exception` with a 404 status is what's actually guaranteed. I verified against a real LocalStack S3 instance that LocalStack's `HeadObject` on a missing key throws the plain `S3Exception`, *not* `NoSuchKeyException` — so the fix checks the status code rather than the exception subtype (matching the pattern this codebase already uses in `AzureBlobStorageService.removeFile`).
  - **Azure**: `BlobErrorCode.BLOB_NOT_FOUND`.
  - **GCS**: already represented as a null `Blob` — now translated explicitly instead of a generic `IOException`.
  - **Local**: `NoSuchFileException` from `Files.size(...)`.
  - Any other storage error (auth failure, network blip, throttling, etc.) still propagates unchanged and is still retried as before.
- `MigrationService.getFileSize` excludes `FileNotFoundInStorageException` from its `@Retryable` — retrying a confirmed absence just spends 3 more round trips (and delay) confirming the same thing again.
- `FileResourceSizeJobRequestHandler` catches it, logs a warning, and leaves the resource's `size` unset instead of letting the job fail. There's nothing more this job can do for a resource whose file is gone; `FixMissingFilesMigration` is the actual repair mechanism.

## Testing

- New `FileResourceSizeJobRequestHandlerTest`: the job completes normally (no size set, no exception) when storage reports the object missing; still records the size on the normal path.
- New `AwsStorageServiceIntegrationTest.testGetFileSizeThrowsFileNotFoundInStorageExceptionForAMissingObject`, run against real LocalStack — this is what caught that LocalStack throws a plain `S3Exception`, not `NoSuchKeyException`, for a missing HEAD target.
- Full `unitTests` suite passes (948 tests) and `s3IntegrationTests` passes (24 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)