### PR TITLE
Backfill file sizes per extension version instead of per file resource

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
@@ -30,6 +30,11 @@ import org.eclipse.openvsx.util.NamingUtil;
  * of stored resources across a large registry, downloading every one of them just to measure it would
  * be far too slow and re-transfer an enormous amount of data for no reason.
  * <p>
+ * Scoped per extension version rather than per file resource: an extension version's handful of
+ * resources (download, README, CHANGELOG, icon, sha256 checksum, ...) are backfilled together in one
+ * job, instead of one job per resource -- for a registry with millions of resources, that's a lot
+ * fewer jobs for JobRunr (and this table) to carry for the same amount of work.
+ * <p>
  * Disabled on mirror instances: mirrored resources are mostly served on the fly rather than stored
  * locally (see {@code PublishExtensionVersionHandler#mirror}), so there is usually no stored object to
  * look up metadata for in the first place, other than the download and its sha256 checksum.
@@ -48,32 +53,39 @@ public class FileResourceSizeJobRequestHandler implements JobRequestHandler<Migr
     }
 
     @Override
-    @Job(name = "Determine file size for published file resource", retries = 3)
+    @Job(name = "Determine file sizes for published extension version", retries = 3)
     public void run(MigrationJobRequest jobRequest) throws Exception {
-        var resource = migrations.getResource(jobRequest);
-        if (resource == null || resource.getSize() != null) {
+        var extVersion = migrations.getExtension(jobRequest.getEntityId());
+        if (extVersion == null) {
             return;
         }
 
-        logger.atInfo()
-                .setMessage("Determine file size for: {} ({})")
-                .addArgument(() -> NamingUtil.toLogFormat(resource.getExtension()))
-                .addArgument(resource::getName)
-                .log();
+        for (var resource : migrations.getFileResources(extVersion)) {
+            if (resource.getSize() != null) {
+                continue;
+            }
 
-        try {
-            resource.setSize(migrations.getFileSize(resource));
-            migrations.updateResource(resource);
-        } catch (FileNotFoundInStorageException e) {
-            // The object backing this resource is confirmed gone, not just temporarily unreachable --
-            // there's nothing further this job can do about that (FixMissingFilesMigration is the
-            // mechanism for actually repairing missing files). Leave the size unset and consider this
-            // job done rather than exhausting retries on an outcome that will never change.
-            logger.atWarn()
-                    .setMessage("File missing in storage, cannot determine size for: {} ({})")
-                    .addArgument(() -> NamingUtil.toLogFormat(resource.getExtension()))
+            logger.atInfo()
+                    .setMessage("Determine file size for: {} ({})")
+                    .addArgument(() -> NamingUtil.toLogFormat(extVersion))
                     .addArgument(resource::getName)
                     .log();
+
+            try {
+                resource.setSize(migrations.getFileSize(resource));
+                migrations.updateResource(resource);
+            } catch (FileNotFoundInStorageException e) {
+                // The object backing this resource is confirmed gone, not just temporarily
+                // unreachable -- there's nothing further this job can do about that
+                // (FixMissingFilesMigration is the mechanism for actually repairing missing files).
+                // Leave the size unset and move on to this extension version's other resources
+                // rather than letting one missing file abort the whole job.
+                logger.atWarn()
+                        .setMessage("File missing in storage, cannot determine size for: {} ({})")
+                        .addArgument(() -> NamingUtil.toLogFormat(extVersion))
+                        .addArgument(resource::getName)
+                        .log();
+            }
         }
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
@@ -18,6 +18,7 @@ import org.jobrunr.jobs.lambdas.JobRequestHandler;
 import org.jobrunr.scheduling.JobRequestScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.util.Streamable;
 import org.springframework.resilience.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
@@ -149,6 +150,10 @@ public class MigrationService {
 
     public FileResource getFileResource(ExtensionVersion extVersion, String type) {
         return repositories.findFileByType(extVersion, type);
+    }
+
+    public Streamable<FileResource> getFileResources(ExtensionVersion extVersion) {
+        return repositories.findFiles(extVersion);
     }
 
     public FileResource getDownload(ExtensionVersion extVersion) {

--- a/server/src/main/resources/db/migration/V1_73__File_Resource_Size.sql
+++ b/server/src/main/resources/db/migration/V1_73__File_Resource_Size.sql
@@ -3,8 +3,8 @@ ALTER TABLE file_resource ADD COLUMN IF NOT EXISTS size BIGINT;
 
 -- Backfill the size of existing file resources, most downloaded extensions first
 INSERT INTO migration_item(id, job_name, entity_id, migration_scheduled)
-SELECT nextval('hibernate_sequence'), 'FileResourceSizeMigration', fr.id, FALSE
-FROM file_resource fr
-JOIN extension_version ev ON ev.id = fr.extension_id
-JOIN extension e ON e.id = ev.extension_id
+SELECT nextval('migration_item_seq'), 'FileResourceSizeMigration', ev.id, FALSE
+FROM extension_version ev
+         JOIN extension e ON e.id = ev.extension_id
+WHERE EXISTS (SELECT 1 FROM file_resource fr WHERE fr.extension_id = ev.id AND fr.size IS NULL)
 ORDER BY e.download_count DESC;

--- a/server/src/test/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandlerTest.java
@@ -1,9 +1,22 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
 package org.eclipse.openvsx.migration;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.util.Streamable;
 
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionVersion;
@@ -24,32 +37,52 @@ class FileResourceSizeJobRequestHandlerTest {
     MigrationService migrations;
 
     @Test
-    void run_leavesSizeUnsetAndDoesNotThrowWhenTheObjectIsMissingFromStorage() throws Exception {
-        var resource = fileResource();
+    void run_doesNothingWhenTheExtensionVersionIsGone() throws Exception {
         var jobRequest = new MigrationJobRequest<>(FileResourceSizeJobRequestHandler.class, 1L);
-        when(migrations.getResource(jobRequest)).thenReturn(resource);
-        when(migrations.getFileSize(resource)).thenThrow(new FileNotFoundInStorageException("gone"));
+        when(migrations.getExtension(1L)).thenReturn(null);
+
+        new FileResourceSizeJobRequestHandler(migrations).run(jobRequest);
+
+        verify(migrations, never()).getFileResources(any());
+    }
+
+    @Test
+    void run_recordsSizeForEveryUnsizedResourceOfTheExtensionVersionAndSkipsAlreadySizedOnes() throws Exception {
+        var extVersion = extVersion();
+        var unsized = fileResource(extVersion, "extension.vsix", null);
+        var alreadySized = fileResource(extVersion, "README.md", 7L);
+        var jobRequest = new MigrationJobRequest<>(FileResourceSizeJobRequestHandler.class, 1L);
+        when(migrations.getExtension(1L)).thenReturn(extVersion);
+        when(migrations.getFileResources(extVersion)).thenReturn(Streamable.of(unsized, alreadySized));
+        when(migrations.getFileSize(unsized)).thenReturn(42L);
+
+        new FileResourceSizeJobRequestHandler(migrations).run(jobRequest);
+
+        verify(migrations).updateResource(unsized);
+        verify(migrations, never()).updateResource(alreadySized);
+        verify(migrations, never()).getFileSize(alreadySized);
+    }
+
+    @Test
+    void run_skipsAMissingResourceButStillProcessesTheRestOfTheExtensionVersion() throws Exception {
+        var extVersion = extVersion();
+        var missing = fileResource(extVersion, "extension.vsix", null);
+        var present = fileResource(extVersion, "README.md", null);
+        var jobRequest = new MigrationJobRequest<>(FileResourceSizeJobRequestHandler.class, 1L);
+        when(migrations.getExtension(1L)).thenReturn(extVersion);
+        when(migrations.getFileResources(extVersion)).thenReturn(Streamable.of(missing, present));
+        when(migrations.getFileSize(missing)).thenThrow(new FileNotFoundInStorageException("gone"));
+        when(migrations.getFileSize(present)).thenReturn(11L);
 
         var handler = new FileResourceSizeJobRequestHandler(migrations);
 
         assertThatCode(() -> handler.run(jobRequest)).doesNotThrowAnyException();
 
-        verify(migrations, never()).updateResource(any());
+        verify(migrations, never()).updateResource(missing);
+        verify(migrations).updateResource(present);
     }
 
-    @Test
-    void run_recordsTheSizeReturnedByStorage() throws Exception {
-        var resource = fileResource();
-        var jobRequest = new MigrationJobRequest<>(FileResourceSizeJobRequestHandler.class, 1L);
-        when(migrations.getResource(jobRequest)).thenReturn(resource);
-        when(migrations.getFileSize(resource)).thenReturn(42L);
-
-        new FileResourceSizeJobRequestHandler(migrations).run(jobRequest);
-
-        verify(migrations).updateResource(resource);
-    }
-
-    private FileResource fileResource() {
+    private ExtensionVersion extVersion() {
         var namespace = new Namespace();
         namespace.setName("foo");
 
@@ -61,10 +94,14 @@ class FileResourceSizeJobRequestHandlerTest {
         extVersion.setVersion("1.0.0");
         extVersion.setTargetPlatform("universal");
         extVersion.setExtension(extension);
+        return extVersion;
+    }
 
+    private FileResource fileResource(ExtensionVersion extVersion, String name, Long size) {
         var resource = new FileResource();
-        resource.setName("extension.vsix");
+        resource.setName(name);
         resource.setExtension(extVersion);
+        resource.setSize(size);
         return resource;
     }
 }


### PR DESCRIPTION
## What

Scopes the `FileResourceSizeMigration` backfill (#1777) by extension version rather than by individual file resource: an extension version's handful of resources (download, README, CHANGELOG, icon, sha256 checksum, ...) are now backfilled together in one job, instead of one job (and one `migration_item` row) per resource — for a registry with millions of resources, that's a lot fewer jobs for JobRunr to carry for the same amount of work.

## How

- `FileResourceSizeJobRequestHandler` now looks up the `ExtensionVersion` and loops over all its file resources via `migrations.getFileResources(extVersion)`, backfilling each one still missing a size. A resource whose object is missing from storage (`FileNotFoundInStorageException`, from #2094) no longer aborts the whole job — its siblings are still processed.
- `MigrationService.getFileResources(ExtensionVersion)` added, delegating to `RepositoryService.findFiles` — the same accessor `FixMissingFilesJobRequestHandler` already uses.
- `V1_73__File_Resource_Size.sql`'s seeding updated to insert one `migration_item` per extension version that still has an unsized resource, rather than one per file resource. Edited in place rather than layered as a new migration, since nothing has shipped with the original seeding yet. Also fixes the seed insert to use `migration_item_seq` (`MigrationItem`'s actual sequence since `V1_40`) instead of the unrelated `hibernate_sequence` it was using before.

## Testing

- `FileResourceSizeJobRequestHandlerTest` rewritten for the per-extension-version shape: no-op when the extension version is gone, backfills every unsized resource while skipping already-sized ones, and one resource's missing object doesn't block backfilling the rest of that version's resources.
- Full `unitTests` suite passes (949 tests).
- Verified against a real Postgres instance (`ExtensionVersionJooqRepositoryTest`, which boots the full Spring context) that the updated `V1_73` migration still applies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)