### PR TITLE
Throttle migration item scheduling to avoid crowding out real jobs

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilter.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemCleanupFilter.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
  * {@link MigrationScheduler} run will pick it up again via
  * {@code MigrationItemRepository#findByMigrationScheduledFalseOrderById}... except
  * {@code migrationScheduled} was already flipped to {@code true} in
- * {@link MigrationService#enqueueMigration}, so a permanently-failing item currently just sits
+ * {@link MigrationService#scheduleMigration}, so a permanently-failing item currently just sits
  * there for an operator to notice and investigate, the same as before this change. Fixing that
  * retry gap is out of scope for this sketch.
  */

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemJobRequestHandler.java
@@ -9,10 +9,13 @@
  * ****************************************************************************** */
 package org.eclipse.openvsx.migration;
 
+import java.time.Instant;
+
 import org.jobrunr.jobs.annotations.Job;
 import org.jobrunr.jobs.lambdas.JobRequestHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
@@ -22,12 +25,24 @@ import org.eclipse.openvsx.settings.SettingsService;
 @Component
 public class MigrationItemJobRequestHandler implements JobRequestHandler<HandlerJobRequest<?>> {
 
+    // How far apart consecutive items in a batch are spread out, so the batch doesn't all become
+    // due at the exact same instant -- see MigrationService.enqueueMigration for why that matters.
+    // Not configurable: it only controls how gently a single batch trickles in, whereas batchSize
+    // and the recurring schedule (see MigrationScheduler) are what actually determine throughput.
+    private static final long STAGGER_MILLIS = 200;
+
     protected final Logger logger = LoggerFactory.getLogger(MigrationItemJobRequestHandler.class);
 
     private final SettingsService settings;
     private final RepositoryService repositories;
     private final MigrationService migrations;
     private final MigrationScheduler scheduler;
+
+    // Default of 200 keeps a batch's worst-case spread (batchSize * STAGGER_MILLIS = 40s) comfortably
+    // inside the default 15-minute recurring interval, while still bounding how many migration jobs
+    // can ever be due ahead of a real, user-triggered job at once -- down from the previous 25000.
+    @Value("${ovsx.migrations.batch-size:200}")
+    int batchSize;
 
     public MigrationItemJobRequestHandler(
             SettingsService settings,
@@ -48,12 +63,24 @@ public class MigrationItemJobRequestHandler implements JobRequestHandler<Handler
             return;
         }
 
-        var items = repositories.findNotMigratedItems(PageRequest.ofSize(25000));
+        var items = repositories.findNotMigratedItems(PageRequest.ofSize(batchSize));
+        var now = Instant.now();
+        var index = 0;
         for (var item : items) {
-            migrations.enqueueMigration(item);
+            migrations.enqueueMigration(item, now.plusMillis(index++ * STAGGER_MILLIS));
         }
 
-        logger.info("Scheduled migration items: {}", items.getNumberOfElements());
+        if (items.getNumberOfElements() > 0) {
+            // With a small batchSize, draining a large backlog now takes many recurring runs instead
+            // of one -- log how much is left after this batch so that's visible across all of them,
+            // not just a repeated "scheduled N items" with no sense of overall progress until the
+            // last run. Skipped entirely when nothing was found: an empty slice means hasNext() is
+            // already false too (see below), so there's nothing to report and no remaining count
+            // worth an extra query for -- it can only be zero.
+            var remaining = repositories.countNotMigratedItems();
+            logger.info("Scheduled {} migration items ({} remaining)", items.getNumberOfElements(), remaining);
+        }
+
         if (!items.hasNext()) {
             logger.info("Migration completed, deleting recurring job");
             scheduler.deleteScheduleMigrationItemsJob();

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationItemJobRequestHandler.java
@@ -11,6 +11,7 @@ package org.eclipse.openvsx.migration;
 
 import java.time.Instant;
 
+import jakarta.annotation.PostConstruct;
 import org.jobrunr.jobs.annotations.Job;
 import org.jobrunr.jobs.lambdas.JobRequestHandler;
 import org.slf4j.Logger;
@@ -56,6 +57,17 @@ public class MigrationItemJobRequestHandler implements JobRequestHandler<Handler
         this.scheduler = scheduler;
     }
 
+    // PageRequest.ofSize(...) throws IllegalArgumentException for a size below 1, which would make
+    // the recurring job fail on every single run for a misconfigured ovsx.migrations.batch-size --
+    // clamp instead, so a bad value degrades to "very slow" rather than "never runs at all".
+    @PostConstruct
+    void validateBatchSize() {
+        if (batchSize < 1) {
+            logger.warn("ovsx.migrations.batch-size must be at least 1, but was {} -- using 1 instead", batchSize);
+            batchSize = 1;
+        }
+    }
+
     @Override
     @Job(name = "Migration item processing", retries = 0)
     public void run(HandlerJobRequest<?> jobRequest) throws Exception {
@@ -67,7 +79,7 @@ public class MigrationItemJobRequestHandler implements JobRequestHandler<Handler
         var now = Instant.now();
         var index = 0;
         for (var item : items) {
-            migrations.enqueueMigration(item, now.plusMillis(index++ * STAGGER_MILLIS));
+            migrations.scheduleMigration(item, now.plusMillis(index++ * STAGGER_MILLIS));
         }
 
         if (items.getNumberOfElements() > 0) {

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationScheduler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationScheduler.java
@@ -12,7 +12,6 @@ package org.eclipse.openvsx.migration;
 import org.jobrunr.jobs.annotations.Job;
 import org.jobrunr.jobs.lambdas.JobRequestHandler;
 import org.jobrunr.scheduling.JobRequestScheduler;
-import org.jobrunr.scheduling.cron.Cron;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -26,6 +25,12 @@ public class MigrationScheduler implements JobRequestHandler<HandlerJobRequest<?
 
     @Value("${ovsx.data.mirror.enabled:false}")
     boolean mirrorEnabled;
+
+    // Default matches JobRunr's Cron.every15minutes(). Configurable so a deployment that's
+    // bothered by migration-item bursts crowding out real-time jobs (see
+    // MigrationItemJobRequestHandler) can spread them out further without a code change.
+    @Value("${ovsx.migrations.cron:*/15 * * * *}")
+    String migrationItemsCron;
 
     public MigrationScheduler(
             OrphanNamespaceMigration orphanNamespaceMigration,
@@ -45,7 +50,7 @@ public class MigrationScheduler implements JobRequestHandler<HandlerJobRequest<?
 
         scheduler.scheduleRecurrently(
                 SCHEDULE_MIGRATION_ITEMS_JOB,
-                Cron.every15minutes(),
+                migrationItemsCron,
                 new HandlerJobRequest<>(MigrationItemJobRequestHandler.class));
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationScheduler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationScheduler.java
@@ -12,6 +12,8 @@ package org.eclipse.openvsx.migration;
 import org.jobrunr.jobs.annotations.Job;
 import org.jobrunr.jobs.lambdas.JobRequestHandler;
 import org.jobrunr.scheduling.JobRequestScheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +21,8 @@ import org.springframework.stereotype.Component;
 public class MigrationScheduler implements JobRequestHandler<HandlerJobRequest<?>> {
 
     private final static String SCHEDULE_MIGRATION_ITEMS_JOB = "schedule-migration-items";
+
+    private final Logger logger = LoggerFactory.getLogger(MigrationScheduler.class);
 
     private final OrphanNamespaceMigration orphanNamespaceMigration;
     private final JobRequestScheduler scheduler;
@@ -29,7 +33,7 @@ public class MigrationScheduler implements JobRequestHandler<HandlerJobRequest<?
     // Default matches JobRunr's Cron.every15minutes(). Configurable so a deployment that's
     // bothered by migration-item bursts crowding out real-time jobs (see
     // MigrationItemJobRequestHandler) can spread them out further without a code change.
-    @Value("${ovsx.migrations.cron:*/15 * * * *}")
+    @Value("${ovsx.migrations.cron:0 */15 * * * *}")
     String migrationItemsCron;
 
     public MigrationScheduler(
@@ -47,6 +51,8 @@ public class MigrationScheduler implements JobRequestHandler<HandlerJobRequest<?
         if (!mirrorEnabled) {
             scheduler.enqueue(new HandlerJobRequest<>(GenerateKeyPairJobRequestHandler.class));
         }
+
+        logger.info("Scheduling migration item job with schedule '{}'", this.migrationItemsCron);
 
         scheduler.scheduleRecurrently(
                 SCHEDULE_MIGRATION_ITEMS_JOB,

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
@@ -10,6 +10,7 @@
 package org.eclipse.openvsx.migration;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Map;
 
 import jakarta.persistence.EntityManager;
@@ -77,14 +78,22 @@ public class MigrationService {
         this.uuidService = uuidService;
     }
 
+    /**
+     * Schedules {@code item}'s job to become due at {@code scheduledAt}, rather than immediately.
+     * {@link MigrationItemJobRequestHandler} spreads a batch's items across a handful of seconds
+     * instead of making them all due at once -- JobRunr processes every ENQUEUED/due job across the
+     * whole server in one strict FIFO queue ordered by due time, so a large batch that's all due
+     * "now" would sit ahead of any real, user-triggered job that happens to get enqueued around the
+     * same time, delaying it until the whole batch drains.
+     */
     @Transactional
-    public void enqueueMigration(MigrationItem item) {
+    public void enqueueMigration(MigrationItem item, Instant scheduledAt) {
         item = entityManager.merge(item);
         var jobIdText = item.getJobName() + "->itemId=" + item.getId();
         var jobId = uuidService.generateFromName(jobIdText);
         var handler = JOB_HANDLERS.get(item.getJobName());
-        scheduler.enqueue(jobId, new MigrationJobRequest<>(handler, item.getEntityId(), item.getId()));
-        logger.info("Enqueued migration {}", jobIdText);
+        scheduler.schedule(jobId, scheduledAt, new MigrationJobRequest<>(handler, item.getEntityId(), item.getId()));
+        logger.info("Scheduled migration {} for {}", jobIdText, scheduledAt);
         item.setMigrationScheduled(true);
     }
 

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
@@ -87,7 +87,7 @@ public class MigrationService {
      * same time, delaying it until the whole batch drains.
      */
     @Transactional
-    public void enqueueMigration(MigrationItem item, Instant scheduledAt) {
+    public void scheduleMigration(MigrationItem item, Instant scheduledAt) {
         item = entityManager.merge(item);
         var jobIdText = item.getJobName() + "->itemId=" + item.getId();
         var jobId = uuidService.generateFromName(jobIdText);

--- a/server/src/main/java/org/eclipse/openvsx/repositories/MigrationItemRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/MigrationItemRepository.java
@@ -19,5 +19,7 @@ public interface MigrationItemRepository extends Repository<MigrationItem, Long>
 
     Slice<MigrationItem> findByMigrationScheduledFalseOrderById(Pageable page);
 
+    long countByMigrationScheduledFalse();
+
     Slice<MigrationItem> findByJobName(String jobName, Pageable page);
 }

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -822,6 +822,10 @@ public class RepositoryService {
         return migrationItemRepo.findByMigrationScheduledFalseOrderById(page);
     }
 
+    public long countNotMigratedItems() {
+        return migrationItemRepo.countByMigrationScheduledFalse();
+    }
+
     public double getAverageReviewRating() {
         return extensionReviewRepo.averageRatingAndActiveTrue();
     }

--- a/server/src/test/java/org/eclipse/openvsx/migration/MigrationItemJobRequestHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/migration/MigrationItemJobRequestHandlerTest.java
@@ -44,6 +44,16 @@ class MigrationItemJobRequestHandlerTest {
     }
 
     @Test
+    void validateBatchSize_clampsNonPositiveValuesToOne() {
+        var handler = new MigrationItemJobRequestHandler(settings, repositories, migrations, scheduler);
+        ReflectionTestUtils.setField(handler, "batchSize", 0);
+
+        handler.validateBatchSize();
+
+        assertThat((int) ReflectionTestUtils.getField(handler, "batchSize")).isEqualTo(1);
+    }
+
+    @Test
     void run_requestsThePageSizeConfiguredAsBatchSize() throws Exception {
         when(repositories.findNotMigratedItems(any())).thenReturn(new SliceImpl<>(List.of()));
 
@@ -62,10 +72,10 @@ class MigrationItemJobRequestHandlerTest {
         newHandler(200).run(new HandlerJobRequest<>(MigrationItemJobRequestHandler.class));
 
         var scheduledAt = ArgumentCaptor.forClass(Instant.class);
-        verify(migrations, org.mockito.Mockito.times(3)).enqueueMigration(any(), scheduledAt.capture());
+        verify(migrations, org.mockito.Mockito.times(3)).scheduleMigration(any(), scheduledAt.capture());
         var times = scheduledAt.getAllValues();
         // Strictly increasing and evenly spaced, not all equal to the same "now" -- that's the whole
-        // point of staggering (see MigrationService.enqueueMigration for why).
+        // point of staggering (see MigrationService.scheduleMigration for why).
         assertThat(times.get(1)).isAfter(times.get(0));
         assertThat(times.get(2)).isAfter(times.get(1));
         var firstGap = java.time.Duration.between(times.get(0), times.get(1));

--- a/server/src/test/java/org/eclipse/openvsx/migration/MigrationItemJobRequestHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/migration/MigrationItemJobRequestHandlerTest.java
@@ -1,0 +1,129 @@
+package org.eclipse.openvsx.migration;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import org.eclipse.openvsx.entities.MigrationItem;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.settings.SettingsService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MigrationItemJobRequestHandlerTest {
+
+    @Mock
+    SettingsService settings;
+    @Mock
+    RepositoryService repositories;
+    @Mock
+    MigrationService migrations;
+    @Mock
+    MigrationScheduler scheduler;
+
+    @Test
+    void run_doesNothingWhenReadOnly() throws Exception {
+        when(settings.isReadOnly()).thenReturn(true);
+
+        newHandler(200).run(new HandlerJobRequest<>(MigrationItemJobRequestHandler.class));
+
+        verify(repositories, never()).findNotMigratedItems(any());
+    }
+
+    @Test
+    void run_requestsThePageSizeConfiguredAsBatchSize() throws Exception {
+        when(repositories.findNotMigratedItems(any())).thenReturn(new SliceImpl<>(List.of()));
+
+        newHandler(37).run(new HandlerJobRequest<>(MigrationItemJobRequestHandler.class));
+
+        var pageable = ArgumentCaptor.forClass(Pageable.class);
+        verify(repositories).findNotMigratedItems(pageable.capture());
+        assertThat(pageable.getValue().getPageSize()).isEqualTo(37);
+    }
+
+    @Test
+    void run_staggersEachItemsScheduledTimeInsteadOfMakingThemAllDueAtOnce() throws Exception {
+        var items = List.of(migrationItem(1), migrationItem(2), migrationItem(3));
+        when(repositories.findNotMigratedItems(any())).thenReturn(new SliceImpl<>(items));
+
+        newHandler(200).run(new HandlerJobRequest<>(MigrationItemJobRequestHandler.class));
+
+        var scheduledAt = ArgumentCaptor.forClass(Instant.class);
+        verify(migrations, org.mockito.Mockito.times(3)).enqueueMigration(any(), scheduledAt.capture());
+        var times = scheduledAt.getAllValues();
+        // Strictly increasing and evenly spaced, not all equal to the same "now" -- that's the whole
+        // point of staggering (see MigrationService.enqueueMigration for why).
+        assertThat(times.get(1)).isAfter(times.get(0));
+        assertThat(times.get(2)).isAfter(times.get(1));
+        var firstGap = java.time.Duration.between(times.get(0), times.get(1));
+        var secondGap = java.time.Duration.between(times.get(1), times.get(2));
+        assertThat(firstGap).isEqualTo(secondGap);
+    }
+
+    @Test
+    void run_queriesTheRemainingBacklogAfterSchedulingSoItCanBeLogged() throws Exception {
+        when(repositories.findNotMigratedItems(any()))
+                .thenReturn(new SliceImpl<>(List.of(migrationItem(1)), Pageable.unpaged(), true));
+        when(repositories.countNotMigratedItems()).thenReturn(4823L);
+
+        newHandler(200).run(new HandlerJobRequest<>(MigrationItemJobRequestHandler.class));
+
+        verify(repositories).countNotMigratedItems();
+    }
+
+    @Test
+    void run_skipsTheRemainingBacklogQueryWhenNothingWasFound() throws Exception {
+        when(repositories.findNotMigratedItems(any())).thenReturn(new SliceImpl<>(List.of()));
+
+        newHandler(200).run(new HandlerJobRequest<>(MigrationItemJobRequestHandler.class));
+
+        verify(repositories, never()).countNotMigratedItems();
+    }
+
+    @Test
+    void run_deletesTheRecurringJobOnceTheresNothingLeftToMigrate() throws Exception {
+        when(repositories.findNotMigratedItems(any()))
+                .thenReturn(new SliceImpl<>(List.of(migrationItem(1)), Pageable.unpaged(), false));
+
+        newHandler(200).run(new HandlerJobRequest<>(MigrationItemJobRequestHandler.class));
+
+        verify(scheduler).deleteScheduleMigrationItemsJob();
+    }
+
+    @Test
+    void run_keepsTheRecurringJobWhileMoreItemsRemain() throws Exception {
+        when(repositories.findNotMigratedItems(any()))
+                .thenReturn(new SliceImpl<>(List.of(migrationItem(1)), Pageable.unpaged(), true));
+
+        newHandler(200).run(new HandlerJobRequest<>(MigrationItemJobRequestHandler.class));
+
+        verify(scheduler, never()).deleteScheduleMigrationItemsJob();
+    }
+
+    private MigrationItem migrationItem(long id) {
+        var item = new MigrationItem();
+        item.setId(id);
+        item.setJobName("FileResourceSizeMigration");
+        item.setEntityId(id);
+        return item;
+    }
+
+    private MigrationItemJobRequestHandler newHandler(int batchSize) {
+        var handler = new MigrationItemJobRequestHandler(settings, repositories, migrations, scheduler);
+        ReflectionTestUtils.setField(handler, "batchSize", batchSize);
+        return handler;
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/migration/MigrationSchedulerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/migration/MigrationSchedulerTest.java
@@ -1,0 +1,32 @@
+package org.eclipse.openvsx.migration;
+
+import org.jobrunr.scheduling.JobRequestScheduler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MigrationSchedulerTest {
+
+    @Mock
+    OrphanNamespaceMigration orphanNamespaceMigration;
+    @Mock
+    JobRequestScheduler scheduler;
+
+    @Test
+    void run_schedulesMigrationItemProcessingUsingTheConfiguredCron() throws Exception {
+        var migrationScheduler = new MigrationScheduler(orphanNamespaceMigration, scheduler);
+        ReflectionTestUtils.setField(migrationScheduler, "migrationItemsCron", "0 * * * *");
+        ReflectionTestUtils.setField(migrationScheduler, "mirrorEnabled", true);
+
+        migrationScheduler.run(new HandlerJobRequest<>(MigrationScheduler.class));
+
+        verify(scheduler).scheduleRecurrently(eq("schedule-migration-items"), eq("0 * * * *"), any());
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -365,6 +365,7 @@ class RepositoryServiceSmokeTest extends AbstractPostgresContainerTest {
                 () -> repositories.findDeprecatedExtensions(extension),
                 () -> repositories.findLatestReplacement(1L, null, false, false),
                 () -> repositories.findNotMigratedItems(page),
+                () -> repositories.countNotMigratedItems(),
                 () -> repositories.findRemoveFileResourceTypeResourceMigrationItems(0, 1),
                 () -> repositories.findTargetPlatformsGroupedByVersion(extension, userData),
                 () -> repositories.findVersionPublishedWithUser(


### PR DESCRIPTION
## What

`MigrationItemJobRequestHandler` used to pull up to 25000 not-yet-migrated `migration_item` rows every 15 minutes and `enqueue()` all of them immediately (due "now"). I confirmed by inspecting JobRunr's own polling code (`Paging.AmountBasedList.ascOnUpdatedAt`, used by `OnboardNewWorkTask`) that every ENQUEUED/due job across the whole server sits in one strict FIFO queue ordered by due time — there's no per-job-type priority in open-source JobRunr. So a burst of 25000 jobs all due "now" meant any real, user-triggered job (extension published, signature generated, etc.) enqueued around the same time would sort in behind however many of those 25000 came first, delaying it until the burst drained.

## How

- `MigrationItemJobRequestHandler.batchSize`: configurable via `ovsx.migrations.batch-size` (default `200`, down from the hardcoded `25000`) — directly bounds how many migration jobs can ever be due ahead of a real job at once.
- Each item in a batch is now `scheduler.schedule()`d at a staggered offset (200ms apart) instead of `enqueue()`d all for "now" — a full batch at the default size spreads over ~40s, comfortably inside the default 15-minute recurring interval.
- `MigrationScheduler`'s recurring cron: configurable via `ovsx.migrations.cron` (default `*/15 * * * *`, identical to the previous hardcoded `Cron.every15minutes()`).
- `MigrationService.enqueueMigration` now takes the target `Instant` and calls `scheduler.schedule(...)` instead of `scheduler.enqueue(...)` so the staggering above actually takes effect.
- Logging: now reports how many items remain after each batch (new `RepositoryService.countNotMigratedItems()`), since draining a large backlog can now take many recurring runs instead of one, and the old per-batch count alone gave no sense of overall progress. Skipped entirely when a batch finds nothing to do, so it doesn't log a pointless "scheduled 0 items" line (and doesn't run the count query behind it) on ticks where there's nothing left — an empty slice already means `hasNext()` is false too, so the "migration completed" branch still fires correctly on its own.

## Testing

- `MigrationItemJobRequestHandlerTest` (new): read-only short-circuit, configured batch size is honored, items get strictly-increasing evenly-spaced schedule times, remaining-count query runs only when items were found, recurring-job deletion logic in both directions.
- `MigrationSchedulerTest` (new): configured cron is passed through to `scheduleRecurrently`.
- Full `unitTests` suite passes (957 tests).

## Note

I also looked into detecting "the current batch has fully drained" and immediately scheduling the next one, instead of relying on the cron interval at all. That's possible but needs a schema change (a way to distinguish "still in flight" from "permanently failed and parked for investigation", which currently look identical in `migration_item`) — happy to pursue as a follow-up if the cron-based approach here turns out not to be responsive enough in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)