### PR TITLE
feat: some user-settings ajustments

### DIFF
--- a/webui/AGENTS.md
+++ b/webui/AGENTS.md
@@ -126,3 +126,13 @@ Rules:
 
 - All new entries go under `## [next]`. Read the full section first and append to existing subsections; never duplicate them; if subsection does not exist yet add it.
 - Released version sections (e.g. `## [0.5.0]`) are immutable; never modify them.
+- **Never describe a change against something that is itself unreleased.** If your
+  work modifies behaviour introduced by an entry already under `## [next]`, edit
+  that entry to describe the final state instead of adding a second one. Readers
+  of the released notes never saw the intermediate version, so "replaced X with
+  Y" is noise when X never shipped. Adding a genuinely new behaviour still earns
+  its own entry — just phrase it as the end state, not as a delta.
+- The same test applies to public API: a signature introduced under `## [next]`
+  and changed again before release is one entry describing the final signature,
+  not a change entry. Only a signature that has actually shipped is a breaking
+  change worth calling out.

--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log covers only the frontend library (webui) of Open VSX.
 
 - Redesign the user settings: a sidebar (a pill strip below `md`) navigating profile, access tokens, trusted publishers, extensions and rate limiting, with the user's namespaces listed alongside it and each one deep-linkable at `/user-settings/namespaces/:namespace`. Every view is rebuilt on the cards, grids, placeholders and theme shape tokens the rest of the site uses, and the namespace detail is now a single component shared with the admin dashboard
 - Revoking a single access token asks for confirmation first, like every other destructive action
+- Present the unsigned publisher agreement on the access tokens page as a warning notice with a link to sign it, instead of a plain paragraph
 - Mark a removed extension version in red across its row — version number, status pill and timeline dot — and disable its delete action. Every version of a rejected extension is marked too, and "Latest" is reserved for extensions the registry actually serves, so one that is inactive or removed has no version marked latest
 - Add an `outlinedWarning` style to `MuiButton`, so a warning-toned outlined button follows the theme like the secondary and error ones instead of MUI's default half-opacity border
 - **Breaking:** `elements.claimNamespace` now receives `{ namespace, extension?, sx? }` instead of `{ extension, sx? }`. The namespace settings page offers the same claim action and has no extension to pass, so implementations must read the namespace from `namespace` rather than `extension.namespace`

--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -7,14 +7,16 @@ This change log covers only the frontend library (webui) of Open VSX.
 ### Added
 
 - Add a "Data Consistency" page to the admin dashboard (#1622): a live overview of every registered consistency check's finding count, with actions to refresh it and to fix findings one at a time or all at once
-- Show a "Namespace needs verification" hint on an extension card when it can't be activated because its namespace already exists in a referenced external gallery and hasn't been verified, in both the "My Extensions" and namespace member extension lists
-- Show an explanatory warning notice and a "Claim Namespace" action on the extension settings page when the extension has a namespace ownership conflict, making clear the namespace must be claimed (verified) before the extension can be activated: uses the deployment's configured `elements.claimNamespace`, falling back to the namespace access documentation when none is configured. The admin dashboard's extension and namespace views show the same explanation, but not the claim action, since claiming is the publisher's action to take, not an admin's on someone else's behalf
+- Show a "Namespace not verified" state on an extension card when it can't be activated because its namespace already exists in a referenced external gallery and hasn't been verified, in both the "My Extensions" and namespace member extension lists. The card keeps its colour and takes a warning-toned frame and icon, since this is the publisher's to fix rather than an extension that is simply switched off
+- Show a warning notice with a claim action wherever an unverified namespace is holding something back — the extension settings page when the extension has a namespace ownership conflict, and the namespace settings page for any unverified namespace — making clear the namespace must be claimed (verified) first. The action is the deployment's configured `elements.claimNamespace`, falling back to the namespace access documentation when none is configured. The admin dashboard's extension and namespace views show the same explanation without the claim action, since claiming is the publisher's action to take, not an admin's on someone else's behalf
 
 ### Changed
 
 - Redesign the user settings: a sidebar (a pill strip below `md`) navigating profile, access tokens, trusted publishers, extensions and rate limiting, with the user's namespaces listed alongside it and each one deep-linkable at `/user-settings/namespaces/:namespace`. Every view is rebuilt on the cards, grids, placeholders and theme shape tokens the rest of the site uses, and the namespace detail is now a single component shared with the admin dashboard
 - Revoking a single access token asks for confirmation first, like every other destructive action
-- Mark a removed extension version in red across its row — version number, status pill and timeline dot — and disable its delete action
+- Mark a removed extension version in red across its row — version number, status pill and timeline dot — and disable its delete action. Every version of a rejected extension is marked too, and "Latest" is reserved for extensions the registry actually serves, so one that is inactive or removed has no version marked latest
+- Add an `outlinedWarning` style to `MuiButton`, so a warning-toned outlined button follows the theme like the secondary and error ones instead of MUI's default half-opacity border
+- **Breaking:** `elements.claimNamespace` now receives `{ namespace, extension?, sx? }` instead of `{ extension, sx? }`. The namespace settings page offers the same claim action and has no extension to pass, so implementations must read the namespace from `namespace` rather than `extension.namespace`
 - `ExtensionCard` accepts an `Extension` as well as a `SearchEntry`, and takes optional `to`, `linkState`, `overlay`, `footerStart` and `dimmed` props so other surfaces can reuse it instead of copying it
 
 ### Fixed

--- a/webui/src/components/extension-card.tsx
+++ b/webui/src/components/extension-card.tsx
@@ -14,7 +14,7 @@
 import { forwardRef, FunctionComponent, memo, ReactNode } from 'react';
 import { Link as RouteLink } from 'react-router';
 import { Paper, Typography, Box, Fade, Skeleton } from '@mui/material';
-import { CSSObject, styled, Theme } from '@mui/material/styles';
+import { alpha, CSSObject, styled, Theme } from '@mui/material/styles';
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
 import VerifiedIcon from '@mui/icons-material/Verified';
 import { ExtensionDetailRoutes } from '../pages/extension-detail/extension-detail-routes';
@@ -129,11 +129,13 @@ export interface ExtensionCardProps extends Partial<Omit<GridItemProps, 'ref'>> 
     footerStart?: ReactNode;
     /** Dim and desaturate the card the way a deprecated extension is dimmed. */
     dimmed?: boolean;
+    /** Tint the card's frame and overlay to flag a state the viewer has to act on. */
+    tone?: 'warning';
 }
 
 export const ExtensionCard = memo(
     forwardRef<HTMLAnchorElement, ExtensionCardProps>(function ExtensionCard(
-        { extension, fadeDelayMs = 0, appear = true, to, linkState, overlay, footerStart, dimmed, ...linkProps },
+        { extension, fadeDelayMs = 0, appear = true, to, linkState, overlay, footerStart, dimmed, tone, ...linkProps },
         ref
     ) {
         const title = extension?.displayName ?? extension?.name;
@@ -154,11 +156,28 @@ export const ExtensionCard = memo(
                             style={{ textDecoration: 'none', height: '100%', display: 'block', outline: 'none' }}>
                             <CardRoot
                                 elevation={0}
-                                sx={
-                                    extension.deprecated || dimmed
-                                        ? { opacity: 0.5, filter: 'grayscale(100%)' }
-                                        : undefined
-                                }>
+                                sx={[
+                                    (extension.deprecated || dimmed) === true && {
+                                        opacity: 0.5,
+                                        filter: 'grayscale(100%)'
+                                    },
+                                    // The overlay is a quiet affordance by default; a toned card is
+                                    // flagging something, so it carries the tint at full strength.
+                                    tone === 'warning' &&
+                                        (theme => ({
+                                            borderColor: alpha(theme.palette.warningAccent, 0.55),
+                                            '& .extension-card-overlay': {
+                                                opacity: 1,
+                                                color: theme.palette.warningAccent
+                                            },
+                                            '@media (hover: hover)': {
+                                                '&:hover': { borderColor: theme.palette.warningAccent },
+                                                '&:hover .extension-card-overlay': {
+                                                    color: theme.palette.warningAccent
+                                                }
+                                            }
+                                        }))
+                                ]}>
                                 {overlay ? <span className='extension-card-overlay'>{overlay}</span> : null}
                                 <Box
                                     display='flex'

--- a/webui/src/components/extension/extension-detail-view.tsx
+++ b/webui/src/components/extension/extension-detail-view.tsx
@@ -11,11 +11,9 @@
  * SPDX-License-Identifier: EPL-2.0
  *****************************************************************************/
 
-import { FunctionComponent, ReactNode, useContext, useEffect, useState } from 'react';
+import { FunctionComponent, ReactNode, useEffect, useState } from 'react';
 import { Box, Button, Typography } from '@mui/material';
 import { alpha, styled } from '@mui/material/styles';
-import WarningIcon from '@mui/icons-material/Warning';
-import { MainContext } from '../../context';
 import { Extension, VERSION_ALIASES, VersionTargetPlatforms } from '../../extension-registry-types';
 import { ExtensionHeader } from './extension-header';
 import { ExtensionVersionTable } from './extension-version-table';
@@ -27,6 +25,8 @@ import { Eyebrow } from '../page-primitives';
 import { DetailRow, DetailsCard } from '../details-card';
 import { getExtensionStatus } from './extension-status';
 import { formatCompactNumber } from '../../utils';
+import { MONO_FONT } from '../../default/theme';
+import { NamespaceClaimNotice } from '../namespace/namespace-claim-notice';
 
 // One key/value row per line; on wide screens three cells per row with hairline separators.
 const GeneralGrid = styled(DetailsCard)(({ theme }) => ({
@@ -59,28 +59,9 @@ const DangerRow = styled(Box)({
     padding: '1rem 1.25rem'
 });
 
-// `claimNamespace` renders as a Link (its target action is pluggable, e.g. an external issue
-// template), styled here to sit as a button among the other actions in the Stack below.
-const claimNamespaceButtonStyle = {
-    display: 'inline-flex',
-    alignItems: 'center',
-    px: 2,
-    py: '5px',
-    border: '1px solid',
-    borderColor: 'warning.main',
-    borderRadius: 1,
-    fontWeight: 500,
-    fontSize: '0.875rem',
-    lineHeight: 1.75,
-    textTransform: 'uppercase',
-    '&:hover': { textDecoration: 'none' }
-};
-
 export const ExtensionDetailView: FunctionComponent<ExtensionDetailViewProps> = props => {
     const { extension, actions, onRemoveVersion, onVersionDeleted, onPurgeVersion } = props;
     const canPurge = !!onPurgeVersion;
-    const { pageSettings } = useContext(MainContext);
-    const ClaimNamespace = pageSettings.elements.claimNamespace;
 
     const [page, setPage] = useState(0);
     const [deleteDialogVersion, setDeleteDialogVersion] = useState<VersionTargetPlatforms | null>(null);
@@ -103,36 +84,26 @@ export const ExtensionDetailView: FunctionComponent<ExtensionDetailViewProps> = 
 
     // Single most relevant publishing state, shown with a colored dot in the general card.
     const status = getExtensionStatus(extension) ?? { label: 'Public', color: 'success.main' };
+    // "Latest" describes what the registry actually serves, so an extension the registry is holding
+    // back — inactive, or removed — has no latest version to mark.
+    const hasPublishedLatest = extension.active !== false && !extension.removed;
 
     return (
         <Box>
             <ExtensionHeader extension={extension} actions={actions} />
             {extension.namespaceOwnershipConflict && (
-                <Box sx={{ mb: '1.75rem' }}>
-                    <Typography
-                        variant='body2'
-                        sx={{ display: 'flex', alignItems: 'center', color: 'warning.main', mb: 1 }}>
-                        <WarningIcon fontSize='inherit' sx={{ mr: 0.5 }} />
-                        This namespace already exists in a referenced gallery and needs to be claimed (verified) before
-                        this extension can be activated.
-                    </Typography>
-                    {/* Claiming is the publisher's action to take, not an admin's on someone else's behalf. */}
-                    {!canPurge &&
-                        (ClaimNamespace ? (
-                            <ClaimNamespace extension={extension} sx={claimNamespaceButtonStyle} />
-                        ) : (
-                            // Fallback for a deployment that hasn't configured `elements.claimNamespace`:
-                            // point at the generic namespace-access docs instead of showing nothing.
-                            <Button
-                                variant='outlined'
-                                color='warning'
-                                href={pageSettings.urls.namespaceAccessInfo}
-                                target='_blank'
-                                rel='noopener'>
-                                Claim Namespace
-                            </Button>
-                        ))}
-                </Box>
+                <NamespaceClaimNotice
+                    namespace={extension.namespace}
+                    extension={extension}
+                    // Claiming is the publisher's action to take, not an admin's on someone else's behalf.
+                    showAction={!canPurge}
+                    sx={{ mb: '1.75rem' }}>
+                    <Typography component='code' sx={{ fontFamily: MONO_FONT, fontSize: 'inherit' }}>
+                        {extension.namespace}
+                    </Typography>{' '}
+                    already exists in another gallery, so this extension stays inactive until the namespace is claimed
+                    and ownership verified.
+                </NamespaceClaimNotice>
             )}
             <Eyebrow sx={{ mb: '0.75rem' }}>General</Eyebrow>
             <GeneralGrid>
@@ -179,7 +150,8 @@ export const ExtensionDetailView: FunctionComponent<ExtensionDetailViewProps> = 
             </Box>
             <ExtensionVersionTable
                 versions={allVersions}
-                latestVersion={extension.version}
+                latestVersion={hasPublishedLatest ? extension.version : undefined}
+                rejected={extension.reviewStatus === 'rejected'}
                 page={page}
                 onPageChange={setPage}
                 onDeleteVersion={setDeleteDialogVersion}

--- a/webui/src/components/extension/extension-version-table.tsx
+++ b/webui/src/components/extension/extension-version-table.tsx
@@ -55,7 +55,7 @@ const VersionChip = styled(TagChip)({
     fontSize: '0.5625rem'
 });
 
-const RemovedChip = styled(VersionChip)(({ theme }) => ({
+const ErrorChip = styled(VersionChip)(({ theme }) => ({
     backgroundColor: alpha(theme.palette.error.main, 0.12),
     color: theme.palette.error.main
 }));
@@ -176,6 +176,7 @@ const TimelineCell: FunctionComponent<TimelineCellProps> = ({ index, rowCount, h
 export const ExtensionVersionTable: FunctionComponent<ExtensionVersionTableProps> = ({
     versions,
     latestVersion,
+    rejected,
     page,
     onPageChange,
     onDeleteVersion,
@@ -255,7 +256,9 @@ export const ExtensionVersionTable: FunctionComponent<ExtensionVersionTableProps
                                 {v.version}
                             </Typography>
                             {removed ? (
-                                <RemovedChip>Removed</RemovedChip>
+                                <ErrorChip>Removed</ErrorChip>
+                            ) : rejected ? (
+                                <ErrorChip>Rejected</ErrorChip>
                             ) : isLatest ? (
                                 <VersionChip accent>Latest</VersionChip>
                             ) : preRelease ? (
@@ -352,6 +355,8 @@ export interface ExtensionVersionTableProps {
     versions: VersionTargetPlatforms[];
     /** Version that gets the "Latest" chip and accent bulb. */
     latestVersion?: string;
+    /** The review rejected the extension, which blocks every version it has. */
+    rejected?: boolean;
     page: number;
     onPageChange: (page: number) => void;
     onDeleteVersion: (version: VersionTargetPlatforms) => void;

--- a/webui/src/components/extension/manage-extension-card.tsx
+++ b/webui/src/components/extension/manage-extension-card.tsx
@@ -14,6 +14,7 @@
 import { FunctionComponent } from 'react';
 import { Typography } from '@mui/material';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { Extension } from '../../extension-registry-types';
 import { ExtensionCard } from '../extension-card';
 import { getExtensionStatus } from './extension-status';
@@ -31,13 +32,24 @@ export const ManageExtensionCard: FunctionComponent<ManageExtensionCardProps> = 
     linkState
 }) => {
     const status = getExtensionStatus(extension);
+    // The namespace is the user's to claim, so the card flags it rather than just looking switched off.
+    const needsAttention = Boolean(extension.namespaceOwnershipConflict);
     return (
         <ExtensionCard
             extension={extension}
             to={createRoute([routePrefix, extension.namespace, extension.name])}
             linkState={linkState}
-            dimmed={extension.active === false}
-            overlay={<SettingsOutlinedIcon sx={{ fontSize: '0.9375rem' }} />}
+            // Greyscale would swallow the warning colour, and this state is the user's to fix —
+            // it reads as actionable rather than switched off.
+            dimmed={extension.active === false && !extension.namespaceOwnershipConflict}
+            tone={needsAttention ? 'warning' : undefined}
+            overlay={
+                needsAttention ? (
+                    <WarningAmberIcon titleAccess='Needs attention' sx={{ fontSize: '0.9375rem' }} />
+                ) : (
+                    <SettingsOutlinedIcon sx={{ fontSize: '0.9375rem' }} />
+                )
+            }
             footerStart={
                 status ? (
                     <Typography component='span' sx={{ fontSize: '0.75rem', fontWeight: 600, color: status.color }}>

--- a/webui/src/components/namespace/namespace-claim-notice.tsx
+++ b/webui/src/components/namespace/namespace-claim-notice.tsx
@@ -1,0 +1,69 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import { FunctionComponent, ReactNode, useContext } from 'react';
+import { Alert, AlertTitle, Box, Link } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import { MainContext } from '../../context';
+import { Extension } from '../../extension-registry-types';
+
+/**
+ * The warning shown wherever an unverified namespace is holding something back — the extension
+ * settings page and the namespace settings page share it, so both read the same.
+ *
+ * The action is the deployment's `elements.claimNamespace` (typically an issue template), falling
+ * back to the namespace-access docs. It is a link rather than a button: the theme already styles
+ * links inside an alert, so it sits in the notice instead of competing with it.
+ */
+export const NamespaceClaimNotice: FunctionComponent<NamespaceClaimNoticeProps> = ({
+    namespace,
+    extension,
+    showAction = false,
+    sx,
+    children
+}) => {
+    const { pageSettings } = useContext(MainContext);
+    const ClaimNamespace = pageSettings.elements?.claimNamespace;
+
+    return (
+        <Alert severity='warning' sx={sx}>
+            <AlertTitle sx={{ fontWeight: 700 }}>Namespace not verified</AlertTitle>
+            {children}
+            {showAction ? (
+                <Box sx={{ mt: '0.75rem' }}>
+                    {ClaimNamespace ? (
+                        <ClaimNamespace namespace={namespace} extension={extension} />
+                    ) : (
+                        // Nothing configured for this deployment: point at the generic docs.
+                        <Link href={pageSettings.urls.namespaceAccessInfo} target='_blank' rel='noopener'>
+                            Claim ownership
+                            <ArrowForwardIcon sx={{ fontSize: '1.125rem' }} />
+                        </Link>
+                    )}
+                </Box>
+            ) : null}
+        </Alert>
+    );
+};
+
+export interface NamespaceClaimNoticeProps {
+    namespace: string;
+    /** Only the extension surface has one; forwarded to the deployment's claim element. */
+    extension?: Extension;
+    /** Claiming is the publisher's action, so a surface opts in; admin views show the explanation alone. */
+    showAction?: boolean;
+    sx?: SxProps<Theme>;
+    /** What being unverified means on this surface. */
+    children: ReactNode;
+}

--- a/webui/src/components/namespace/namespace-detail-view.tsx
+++ b/webui/src/components/namespace/namespace-detail-view.tsx
@@ -10,10 +10,11 @@
 
 import { FunctionComponent, ReactNode } from 'react';
 import { Link as RouteLink } from 'react-router';
-import { Alert, Box, Button, Link, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { FetchNamespaceExtension, NamespaceExtensionList } from './namespace-extension-list';
 import { NamespaceDetailRoutes } from '../../pages/namespace-detail/namespace-detail-routes';
+import { NamespaceClaimNotice } from './namespace-claim-notice';
 import { createRoute } from '../../utils';
 import { Namespace } from '../../extension-registry-types';
 import { NamespaceMemberList } from './namespace-member-list';
@@ -73,14 +74,17 @@ export const NamespaceDetailView: FunctionComponent<NamespaceDetailViewProps> = 
                     </Button>
                 </Box>
             </Box>
-            {!props.namespace.verified && props.namespaceAccessUrl ? (
-                <Alert severity='warning' sx={{ mb: '1.875rem' }}>
-                    This namespace is not verified.{' '}
-                    <Link href={props.namespaceAccessUrl} target='_blank' rel='noopener'>
-                        See the documentation
-                    </Link>{' '}
-                    to learn about claiming namespaces.
-                </Alert>
+            {!props.namespace.verified ? (
+                <NamespaceClaimNotice
+                    namespace={props.namespace.name}
+                    showAction={props.showClaimAction}
+                    sx={{ mb: '1.875rem' }}>
+                    Claiming{' '}
+                    <Typography component='code' sx={{ fontFamily: MONO_FONT, fontSize: 'inherit' }}>
+                        {props.namespace.name}
+                    </Typography>{' '}
+                    proves you own it. Until then extensions published here can stay inactive.
+                </NamespaceClaimNotice>
             ) : null}
             {/* All sections share the main column, the logo stands alone on the right. */}
             <MediaSidebarLayout sidebar={<NamespaceLogo namespace={props.namespace} />}>
@@ -119,6 +123,7 @@ export interface NamespaceDetailViewProps {
     // to the public registry API when omitted. The admin surface passes the admin endpoint so
     // inactive/soft-deleted extensions show up too.
     fetchExtension?: FetchNamespaceExtension;
-    // Documentation link for claiming namespaces, shown in the not-verified warning; omit to hide it.
-    namespaceAccessUrl?: string;
+    // Claiming is the publisher's action, so only the user surface offers it; the admin dashboard
+    // shows the same explanation without it.
+    showClaimAction?: boolean;
 }

--- a/webui/src/default/theme.tsx
+++ b/webui/src/default/theme.tsx
@@ -273,6 +273,14 @@ export default function createDefaultTheme(themeType: 'light' | 'dark'): Theme {
                             color: theme.palette.secondary.main
                         }
                     }),
+                    outlinedWarning: ({ theme }) => ({
+                        color: theme.palette.warningAccent,
+                        borderColor: alpha(theme.palette.warningAccent, 0.5),
+                        '&:hover': {
+                            borderColor: theme.palette.warningAccent,
+                            color: theme.palette.warningAccent
+                        }
+                    }),
                     outlinedError: ({ theme }) => ({
                         backgroundColor: theme.palette.surface2,
                         borderColor: theme.palette.divider,

--- a/webui/src/page-settings.ts
+++ b/webui/src/page-settings.ts
@@ -120,7 +120,7 @@ export interface PageSettings {
         home?: HomePageSettings;
         searchHeader?: ComponentType;
         reportAbuse?: ComponentType<{ extension: Extension; sx?: SxProps<Theme> }>;
-        claimNamespace?: ComponentType<{ extension: Extension; sx?: SxProps<Theme> }>;
+        claimNamespace?: ComponentType<{ namespace: string; extension?: Extension; sx?: SxProps<Theme> }>;
         downloadTerms?: ComponentType;
         additionalRoutes?: ReactNode;
         banner?: {

--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -412,7 +412,11 @@ export const ExtensionDetailOverview: FunctionComponent<ExtensionDetailOverviewP
                         </Box>
                     ) : null}
                     <Box mt={2}>
-                        {ClaimNamespace ? <ClaimNamespace extension={extension} sx={resourceLink} /> : ''}
+                        {ClaimNamespace ? (
+                            <ClaimNamespace namespace={extension.namespace} extension={extension} sx={resourceLink} />
+                        ) : (
+                            ''
+                        )}
                         {ReportAbuse ? <ReportAbuse extension={extension} sx={resourceLink} /> : ''}
                     </Box>
                 </Box>

--- a/webui/src/pages/user/namespaces/user-settings-namespaces.tsx
+++ b/webui/src/pages/user/namespaces/user-settings-namespaces.tsx
@@ -84,7 +84,7 @@ export const UserSettingsNamespaces: FunctionComponent<UserSettingsNamespacesPro
                 namespace={namespace}
                 setLoadingState={setDetailLoading}
                 extensionRoutePrefix={UserSettingsRoutes.EXTENSIONS}
-                namespaceAccessUrl={namespaceAccessUrl}
+                showClaimAction
                 // The public endpoint hides what a namespace member still needs to manage: an
                 // inactive extension, or one whose only versions are soft-deleted.
                 fetchExtension={(abortController, extension) =>

--- a/webui/src/pages/user/settings/user-settings-sidebar.tsx
+++ b/webui/src/pages/user/settings/user-settings-sidebar.tsx
@@ -120,9 +120,9 @@ export const UserSettingsSidebar: FunctionComponent = () => {
                 minWidth: 0,
                 position: 'sticky',
                 top: `calc(${NAVBAR_HEIGHT} + 1.625rem)`,
-                // Same z as the AppBar, later in the DOM: keeps the navbar's
-                // backdrop-blur fan from blurring the sidebar's top rows.
-                zIndex: 50
+                // Below the AppBar's z-index: at the same value this sticky column comes later in
+                // the DOM and would scroll out over the navbar instead of under it.
+                zIndex: 1
             }}>
             <Box
                 sx={{

--- a/webui/src/pages/user/tokens/user-settings-tokens.tsx
+++ b/webui/src/pages/user/tokens/user-settings-tokens.tsx
@@ -10,6 +10,8 @@
 
 import { FunctionComponent, ReactNode, useContext, useEffect, useState, useRef } from 'react';
 import {
+    Alert,
+    AlertTitle,
     Typography,
     Box,
     Button,
@@ -21,6 +23,7 @@ import {
     DialogActions
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import KeyOutlinedIcon from '@mui/icons-material/KeyOutlined';
 import { Link as RouteLink } from 'react-router';
 import { DelayedLoadIndicator } from '../../../components/delayed-load-indicator';
@@ -155,30 +158,32 @@ export const UserSettingsTokens: FunctionComponent = () => {
 
     const agreement = user?.publisherAgreement;
     if (agreement && (agreement.status === 'none' || agreement.status === 'outdated')) {
-        const publisherAgreementName = pageSettings?.publisherAgreement?.name ?? '';
         const publisherAgreementContact = pageSettings?.publisherAgreement?.email;
+        // The deployment may not name its agreement, so drop the empty slot rather than double-spacing.
+        const agreementName = [pageSettings?.publisherAgreement?.name, 'Publisher Agreement'].filter(Boolean).join(' ');
 
         return (
             <Box>
-                <SettingsHeader title='Access Tokens' />
-                <Typography variant='body1'>
-                    Access tokens cannot be created as you currently do not have an {publisherAgreementName} Publisher
-                    Agreement signed. Please return to your{' '}
-                    <Link color='secondary' underline='hover' component={RouteLink} to={UserSettingsRoutes.PROFILE}>
-                        Profile
-                    </Link>{' '}
-                    page to sign the Publisher Agreement.
+                <SettingsHeader
+                    title='Access Tokens'
+                    description='Personal access tokens let you publish extensions from the command line. Treat them like passwords.'
+                />
+                <Alert severity='warning'>
+                    <AlertTitle sx={{ fontWeight: 700 }}>Publisher agreement required</AlertTitle>
+                    Tokens can only be created once you have signed the {agreementName}.
+                    <Box sx={{ mt: '0.75rem' }}>
+                        <Link component={RouteLink} to={UserSettingsRoutes.PROFILE}>
+                            Sign it on your profile
+                            <ArrowForwardIcon sx={{ fontSize: '1.125rem' }} />
+                        </Link>
+                    </Box>
                     {publisherAgreementContact !== undefined && (
-                        <>
-                            {' '}
-                            Should you believe this is in error, please contact{' '}
-                            <Link color='secondary' underline='hover' href={`mailto:${publisherAgreementContact}`}>
-                                {publisherAgreementContact}
-                            </Link>
-                            .
-                        </>
+                        <Box sx={{ mt: '0.75rem', fontSize: '0.8125rem' }}>
+                            If you believe this is in error, contact{' '}
+                            <Link href={`mailto:${publisherAgreementContact}`}>{publisherAgreementContact}</Link>.
+                        </Box>
                     )}
-                </Typography>
+                </Alert>
             </Box>
         );
     }

--- a/webui/test/unit/components/extension/extension-detail-view.spec.tsx
+++ b/webui/test/unit/components/extension/extension-detail-view.spec.tsx
@@ -77,11 +77,9 @@ const dangerButton = (name: string) => screen.getByRole('button', { name });
 const noDangerButton = (name: string) => screen.queryByRole('button', { name });
 
 // Stands in for a deployment's configured `pageSettings.elements.claimNamespace`: this component's
-// own logic is only responsible for passing `extension`/`sx` through, not for what a given
+// own logic is only responsible for passing the namespace (and extension, where it has one)
 // implementation renders.
-const ClaimNamespaceStub: FunctionComponent<{ extension: Extension }> = ({ extension: ext }) => (
-    <span>Claim {ext.namespace}</span>
-);
+const ClaimNamespaceStub: FunctionComponent<{ namespace: string }> = ({ namespace }) => <span>Claim {namespace}</span>;
 
 describe('ExtensionDetailView', () => {
     it('keeps the purge affordances out of the way without a purge handler', () => {
@@ -124,6 +122,18 @@ describe('ExtensionDetailView', () => {
         expect(screen.queryByText('Danger Zone')).not.toBeInTheDocument();
     });
 
+    it('does not call any version "Latest" while the registry is holding the extension back', () => {
+        renderDetail([version()], undefined, { extension: { active: false } });
+
+        expect(screen.queryByText('Latest')).not.toBeInTheDocument();
+    });
+
+    it('marks the latest version of a live extension', () => {
+        renderDetail([version()], undefined, { extension: { active: true } });
+
+        expect(screen.getByText('Latest')).toBeInTheDocument();
+    });
+
     describe('namespace ownership conflict', () => {
         it('renders the configured claimNamespace element when there is a conflict', () => {
             renderDetail([], undefined, {
@@ -153,7 +163,7 @@ describe('ExtensionDetailView', () => {
             });
 
             expect(screen.queryByText('Claim foo')).not.toBeInTheDocument();
-            const link = screen.getByRole('link', { name: 'Claim Namespace' });
+            const link = screen.getByRole('link', { name: 'Claim ownership' });
             expect(link).toHaveAttribute('href', 'https://example.test/namespace-access');
         });
 
@@ -165,9 +175,9 @@ describe('ExtensionDetailView', () => {
             });
 
             expect(screen.queryByText('Claim foo')).not.toBeInTheDocument();
-            expect(screen.queryByRole('link', { name: 'Claim Namespace' })).not.toBeInTheDocument();
+            expect(screen.queryByRole('link', { name: 'Claim ownership' })).not.toBeInTheDocument();
             expect(
-                screen.getByText(/needs to be claimed \(verified\) before this extension can be activated/)
+                screen.getByText(/stays inactive until the namespace is claimed and ownership verified/)
             ).toBeInTheDocument();
         });
 
@@ -178,7 +188,7 @@ describe('ExtensionDetailView', () => {
             });
 
             expect(
-                screen.getByText(/needs to be claimed \(verified\) before this extension can be activated/)
+                screen.getByText(/stays inactive until the namespace is claimed and ownership verified/)
             ).toBeInTheDocument();
         });
 

--- a/webui/test/unit/components/extension/extension-version-table.spec.tsx
+++ b/webui/test/unit/components/extension/extension-version-table.spec.tsx
@@ -28,11 +28,16 @@ const removedVersion = version({
     targetPlatforms: [{ targetPlatform: 'universal', active: false, removed: true }]
 });
 
-const renderTable = (versions: VersionTargetPlatforms[], onPurgeVersion?: () => void) =>
+const renderTable = (
+    versions: VersionTargetPlatforms[],
+    onPurgeVersion?: () => void,
+    extra: { rejected?: boolean } = {}
+) =>
     renderWithProviders(
         <ExtensionVersionTable
             versions={versions}
             latestVersion='1.0.0'
+            rejected={extra.rejected}
             page={0}
             onPageChange={vi.fn()}
             onDeleteVersion={vi.fn()}
@@ -65,6 +70,20 @@ describe('ExtensionVersionTable', () => {
         renderTable([version()]);
 
         expect(screen.getByLabelText('Delete version 1.0.0')).toBeEnabled();
+    });
+
+    it('marks every version of a rejected extension', () => {
+        renderTable([version()], undefined, { rejected: true });
+
+        expect(screen.getByText('Rejected')).toBeInTheDocument();
+        expect(screen.queryByText('Latest')).not.toBeInTheDocument();
+    });
+
+    it('leaves a removed version marked as removed even when the extension is rejected', () => {
+        renderTable([removedVersion], undefined, { rejected: true });
+
+        expect(screen.getByText('Removed')).toBeInTheDocument();
+        expect(screen.queryByText('Rejected')).not.toBeInTheDocument();
     });
 
     it('offers the purge action only when a purge handler is supplied', () => {

--- a/webui/test/unit/components/extension/manage-extension-card.spec.tsx
+++ b/webui/test/unit/components/extension/manage-extension-card.spec.tsx
@@ -57,6 +57,16 @@ describe('ManageExtensionCard', () => {
         expect(await screen.findByText('Deactivated')).toBeInTheDocument();
     });
 
+    it('names the unverified namespace as the cause instead of just calling it deactivated', async () => {
+        renderCard(extension({ active: false, namespaceOwnershipConflict: true }));
+
+        // The status names the actual, actionable cause rather than just "Deactivated"; the card is
+        // left in colour to match (greyscale would swallow the warning tone).
+        expect(await screen.findByText('Namespace not verified')).toBeInTheDocument();
+        expect(screen.getByTitle('Needs attention')).toBeInTheDocument();
+        expect(screen.queryByText('Deactivated')).not.toBeInTheDocument();
+    });
+
     it('leaves the footer to the shared card when the extension is public', async () => {
         renderCard(extension());
 

--- a/webui/test/unit/components/namespace/namespace-detail-view.spec.tsx
+++ b/webui/test/unit/components/namespace/namespace-detail-view.spec.tsx
@@ -56,7 +56,10 @@ function renderView(namespace: Namespace, props: Partial<NamespaceDetailViewProp
             mainContext: {
                 service,
                 user: testUser,
-                pageSettings: { urls: { extensionDefaultIcon: '/icon.png' } } as PageSettings
+                pageSettings: {
+                    elements: {},
+                    urls: { extensionDefaultIcon: '/icon.png' }
+                } as unknown as PageSettings
             }
         }
     );
@@ -86,18 +89,25 @@ describe('NamespaceDetailView', () => {
         expect(screen.getByText('View public page')).toBeInTheDocument();
     });
 
-    it('warns about an unverified namespace only when given the documentation link', async () => {
-        renderView(testNamespace({ verified: false }), { namespaceAccessUrl: 'https://docs.test/claim' });
+    it('warns that an unverified namespace has to be claimed', async () => {
+        renderView(testNamespace({ verified: false }), { showClaimAction: true });
 
-        expect(await screen.findByText(/This namespace is not verified/)).toBeInTheDocument();
-        expect(screen.getByText('See the documentation')).toHaveAttribute('href', 'https://docs.test/claim');
+        expect(await screen.findByText('Namespace not verified')).toBeInTheDocument();
+        expect(screen.getByText(/proves you own it/)).toBeInTheDocument();
+    });
+
+    it('leaves the claim action to the publisher surface', async () => {
+        renderView(testNamespace({ verified: false }));
+
+        expect(await screen.findByText('Namespace not verified')).toBeInTheDocument();
+        expect(screen.queryByText('Claim ownership')).not.toBeInTheDocument();
     });
 
     it('stays quiet about verification when the namespace is verified', async () => {
-        renderView(testNamespace({ verified: true }), { namespaceAccessUrl: 'https://docs.test/claim' });
+        renderView(testNamespace({ verified: true }), { showClaimAction: true });
 
         expect(await screen.findByText('Extensions')).toBeInTheDocument();
-        expect(screen.queryByText(/This namespace is not verified/)).not.toBeInTheDocument();
+        expect(screen.queryByText('Namespace not verified')).not.toBeInTheDocument();
     });
 
     it('points the extension cards at the route prefix the host supplies', async () => {

--- a/webui/test/unit/pages/user/tokens/user-settings-tokens.spec.tsx
+++ b/webui/test/unit/pages/user/tokens/user-settings-tokens.spec.tsx
@@ -15,6 +15,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../../../support/test-providers';
+import { MainContext } from '../../../../../src/context';
 import { testUser } from '../../../support/trusted-publishing';
 import { UserSettingsTokens } from '../../../../../src/pages/user/tokens/user-settings-tokens';
 import { ExtensionRegistryService } from '../../../../../src/extension-registry-service';
@@ -28,7 +29,7 @@ const token: PersonalAccessToken = {
     deleteTokenUrl: ''
 };
 
-function renderTokens() {
+function renderTokens(mainContext: Partial<MainContext> = {}) {
     const deleteAccessToken = vi.fn().mockResolvedValue(undefined);
     const getAccessTokens = vi.fn().mockResolvedValue([token]);
     const service = {
@@ -37,10 +38,45 @@ function renderTokens() {
         getTrustedPublishingStatus: vi.fn().mockResolvedValue({ enabled: false, allowed: false })
     } as unknown as ExtensionRegistryService;
     renderWithProviders(<UserSettingsTokens />, {
-        mainContext: { service, user: testUser, pageSettings: {} as PageSettings }
+        mainContext: { service, user: testUser, pageSettings: {} as PageSettings, ...mainContext }
     });
-    return { deleteAccessToken };
+    return { deleteAccessToken, getAccessTokens };
 }
+
+describe('UserSettingsTokens — unsigned publisher agreement', () => {
+    const unsigned = { ...testUser, publisherAgreement: { status: 'none' as const } };
+
+    it('blocks token creation and points at the profile to sign', async () => {
+        renderTokens({
+            user: unsigned,
+            pageSettings: { publisherAgreement: { name: 'Eclipse' } } as PageSettings
+        });
+
+        expect(await screen.findByText('Publisher agreement required')).toBeInTheDocument();
+        expect(screen.getByText(/signed the Eclipse Publisher Agreement/)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /Sign it on your profile/ })).toHaveAttribute(
+            'href',
+            '/user-settings/profile'
+        );
+        // No list and no "Generate new token": the page is only the explanation.
+        expect(screen.queryByText('Generate new token')).not.toBeInTheDocument();
+    });
+
+    it('names the agreement without an empty gap when the deployment does not title it', async () => {
+        renderTokens({ user: unsigned });
+
+        expect(await screen.findByText(/signed the Publisher Agreement/)).toBeInTheDocument();
+    });
+
+    it('offers the contact address only when one is configured', async () => {
+        renderTokens({
+            user: unsigned,
+            pageSettings: { publisherAgreement: { email: 'help@example.test' } } as PageSettings
+        });
+
+        expect(await screen.findByText('help@example.test')).toBeInTheDocument();
+    });
+});
 
 describe('UserSettingsTokens', () => {
     it('revokes a token only after the confirmation is accepted', async () => {


### PR DESCRIPTION
The namespace-ownership work on `main` predates the settings redesign, so its UI didn't match the pages it appears on. This turns it into one shared `NamespaceClaimNotice`, used by both the extension and namespace settings pages, and updates the surrounding states that misreported an extension held back by an unverified namespace.

Also fixes the settings sidebar scrolling out over the navbar, and adds a changelog rule to `AGENTS.md`: never describe a change against something that is itself unreleased.