### PR TITLE
refactor: clarify namespace vs. per-publisher verification checks

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -162,7 +162,7 @@ public class LocalRegistryService implements IExtensionRegistry {
             extensionsMap.put(name, url);
         }
         json.setExtensions(extensionsMap);
-        json.setVerified(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER));
+        json.setVerified(repositories.isVerified(namespace));
         return json;
     }
 
@@ -578,7 +578,7 @@ public class LocalRegistryService implements IExtensionRegistry {
                 : null;
 
         var json = namespace.toNamespaceDetailsJson();
-        json.setVerified(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER));
+        json.setVerified(repositories.isVerified(namespace));
         json.setLogo(logo);
 
         var serverUrl = UrlUtil.getBaseUrl();

--- a/server/src/main/java/org/eclipse/openvsx/UserAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserAPI.java
@@ -517,7 +517,7 @@ public class UserAPI {
             json.setName(namespace.getName());
             json.setExtensions(extensions);
             var isOwner = membership.getRole().equals(NamespaceMembership.ROLE_OWNER);
-            json.setVerified(isOwner || repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER));
+            json.setVerified(isOwner || repositories.isVerified(namespace));
             if (isOwner) {
                 json.setMembersUrl(createApiUrl(serverUrl, "user", "namespace", namespace.getName(), "members"));
                 json.setRoleUrl(createApiUrl(serverUrl, "user", "namespace", namespace.getName(), "role"));

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -494,17 +494,23 @@ public class RepositoryService {
         return membershipJooqRepo.hasMembership(user, namespace);
     }
 
-    public boolean isVerified(Namespace namespace, UserData user) {
-        return membershipJooqRepo.isVerified(namespace, user);
+    /**
+     * Whether {@code namespace} itself is verified, i.e. has at least one owner. Unlike
+     * {@link #isVerifiedPublisher(Namespace, UserData)}, this says nothing about any particular user.
+     */
+    public boolean isVerified(Namespace namespace) {
+        return hasMemberships(namespace, NamespaceMembership.ROLE_OWNER);
     }
 
     /**
      * Whether {@code user} counts as a verified publisher for {@code namespace}: a privileged user
-     * bypasses per-namespace verification entirely; otherwise this defers to
-     * {@link #isVerified(Namespace, UserData)} (member of a namespace with at least one owner).
+     * bypasses per-namespace verification entirely; otherwise they must currently be a member of the
+     * namespace (any role) and the namespace itself must have at least one owner. Namespace ownership
+     * alone does not make every user a verified publisher for it, only members of it (or the
+     * privileged).
      */
     public boolean isVerifiedPublisher(Namespace namespace, UserData user) {
-        return user.isPrivileged() || isVerified(namespace, user);
+        return user.isPrivileged() || membershipJooqRepo.isVerified(namespace, user);
     }
 
     /**

--- a/server/src/main/java/org/eclipse/openvsx/scanning/NamespaceOwnershipCheckScanner.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/NamespaceOwnershipCheckScanner.java
@@ -134,9 +134,7 @@ public class NamespaceOwnershipCheckScanner implements Scanner {
             }
         }
 
-        var publishedWith = extVersion.getPublishedWith();
-        var user = publishedWith != null ? publishedWith.getUser() : null;
-        if (user != null && repositories.isVerifiedPublisher(namespace, user)) {
+        if (repositories.isVerified(namespace)) {
             return new Scanner.Invocation.Completed(
                     Scanner.Result.clean(
                             "Namespace '" + namespace.getName()

--- a/server/src/main/java/org/eclipse/openvsx/search/RelevanceService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/RelevanceService.java
@@ -104,7 +104,7 @@ public class RelevanceService {
         logger.debug("[{}] VALUES: {} | {} | {}", extensionId, ratingValue, downloadsValue, timestampValue);
 
         // Reduce the relevance value of unverified extensions
-        if (!isVerified(latest)) {
+        if (!repositories.isVerifiedPublisher(latest)) {
             relevance *= unverifiedRelevance;
             logger.debug("[{}] UNVERIFIED: {} * {}", extensionId, relevance, unverifiedRelevance);
         }
@@ -133,15 +133,6 @@ public class RelevanceService {
 
     private double limit(double value) {
         return Math.clamp(value, 0.0, 1.0);
-    }
-
-    private boolean isVerified(ExtensionVersion extVersion) {
-        if (extVersion.getPublishedWith() == null) {
-            return false;
-        }
-        var user = extVersion.getPublishedWith().getUser();
-        var namespace = extVersion.getExtension().getNamespace();
-        return repositories.isVerified(namespace, user);
     }
 
     public static class SearchStats {

--- a/server/src/main/java/org/eclipse/openvsx/search/SimilarityCheckService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/SimilarityCheckService.java
@@ -91,7 +91,7 @@ public class SimilarityCheckService implements PublishCheck {
 
         if (config.isSkipIfPublisherVerified()) {
             var namespace = repositories.findNamespace(namespaceName);
-            if (namespace != null && repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER)) {
+            if (namespace != null && repositories.isVerified(namespace)) {
                 return PublishCheck.Result.pass();
             }
         }

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -168,7 +168,7 @@ class RegistryAPITest {
     @Test
     void testPublicNamespace() throws Exception {
         var namespace = mockNamespace();
-        Mockito.when(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER))
+        Mockito.when(repositories.isVerified(namespace))
                 .thenReturn(false);
 
         mockMvc.perform(get("/api/{namespace}", "foobar"))
@@ -182,7 +182,7 @@ class RegistryAPITest {
     @Test
     void testVerifiedNamespace() throws Exception {
         var namespace = mockNamespace();
-        Mockito.when(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER))
+        Mockito.when(repositories.isVerified(namespace))
                 .thenReturn(true);
 
         mockMvc.perform(get("/api/{namespace}", "foobar"))
@@ -3006,7 +3006,7 @@ class RegistryAPITest {
                 .thenReturn(Streamable.of(extVersion));
         Mockito.when(repositories.findActiveExtensions(namespace))
                 .thenReturn(Streamable.of(extension));
-        Mockito.when(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER))
+        Mockito.when(repositories.isVerified(namespace))
                 .thenReturn(false);
         Mockito.when(repositories.countActiveReviews(extension))
                 .thenReturn(0L);
@@ -3389,7 +3389,7 @@ class RegistryAPITest {
             ownerMem.setRole(NamespaceMembership.ROLE_OWNER);
             Mockito.when(repositories.findMemberships(namespace, NamespaceMembership.ROLE_OWNER))
                     .thenReturn(Streamable.of(ownerMem));
-            Mockito.when(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER))
+            Mockito.when(repositories.isVerified(namespace))
                     .thenReturn(true);
             Mockito.when(repositories.canPublishInNamespace(token.getUser(), namespace))
                     .thenReturn(true);
@@ -3443,7 +3443,7 @@ class RegistryAPITest {
             ownerMem.setRole(NamespaceMembership.ROLE_OWNER);
             Mockito.when(repositories.findMemberships(namespace, NamespaceMembership.ROLE_OWNER))
                     .thenReturn(Streamable.of(ownerMem));
-            Mockito.when(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER))
+            Mockito.when(repositories.isVerified(namespace))
                     .thenReturn(true);
             if (mode.equals("privileged")) {
                 token.getUser().setRole(UserData.Role.PRIVILEGED);
@@ -3462,7 +3462,7 @@ class RegistryAPITest {
         } else {
             Mockito.when(repositories.findMemberships(namespace, NamespaceMembership.ROLE_OWNER))
                     .thenReturn(Streamable.empty());
-            Mockito.when(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER))
+            Mockito.when(repositories.isVerified(namespace))
                     .thenReturn(false);
             // Mock findMemberships(user) for similarity check - default to empty
             Mockito.when(repositories.findMemberships(token.getUser()))

--- a/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
@@ -1043,7 +1043,7 @@ class UserAPITest {
                 .thenReturn(namespace);
         Mockito.when(repositories.findActiveExtensions(namespace))
                 .thenReturn(Streamable.empty());
-        Mockito.when(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER))
+        Mockito.when(repositories.isVerified(namespace))
                 .thenReturn(false);
         return namespace;
     }

--- a/server/src/test/java/org/eclipse/openvsx/admin/AdminAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/admin/AdminAPITest.java
@@ -2291,12 +2291,12 @@ class AdminAPITest {
         when(repositories.findActiveExtensions(namespace))
                 .thenReturn(Streamable.empty());
         if (numberOfMembers == 0) {
-            when(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER))
+            when(repositories.isVerified(namespace))
                     .thenReturn(false);
             when(repositories.findMemberships(namespace))
                     .thenReturn(Streamable.empty());
         } else {
-            when(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER))
+            when(repositories.isVerified(namespace))
                     .thenReturn(true);
             var memberships = new ArrayList<NamespaceMembership>(numberOfMembers);
 

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -198,7 +198,7 @@ class RepositoryServiceSmokeTest extends AbstractPostgresContainerTest {
                 () -> repositories.countReviews(userData),
                 () -> repositories.countExtensions(),
                 () -> repositories.hasMemberships(namespace, "role"),
-                () -> repositories.isVerified(namespace, userData),
+                () -> repositories.isVerified(namespace),
                 () -> repositories.isVerifiedPublisher(namespace, userData),
                 () -> repositories.isVerifiedPublisher(extVersion),
                 () -> repositories.countNamespaces(),

--- a/server/src/test/java/org/eclipse/openvsx/scanning/NamespaceOwnershipCheckScannerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/NamespaceOwnershipCheckScannerTest.java
@@ -26,8 +26,6 @@ import org.eclipse.openvsx.adapter.ExtensionQueryResult;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.ExtensionVersion;
 import org.eclipse.openvsx.entities.Namespace;
-import org.eclipse.openvsx.entities.PersonalAccessToken;
-import org.eclipse.openvsx.entities.UserData;
 import org.eclipse.openvsx.repositories.RepositoryService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -115,7 +113,7 @@ class NamespaceOwnershipCheckScannerTest {
                 scannerRegistry);
     }
 
-    private ExtensionVersion extensionVersion(UserData publisher) {
+    private ExtensionVersion extensionVersion() {
         var namespace = new Namespace();
         namespace.setName("acme");
 
@@ -125,17 +123,12 @@ class NamespaceOwnershipCheckScannerTest {
 
         var extVersion = new ExtensionVersion();
         extVersion.setExtension(extension);
-        if (publisher != null) {
-            var token = new PersonalAccessToken();
-            token.setUser(publisher);
-            extVersion.setPublishedWith(token);
-        }
         return extVersion;
     }
 
     @Test
     void startScan_throws_whenEnforcedAndUpstreamIsDown() {
-        var extVersion = extensionVersion(new UserData());
+        var extVersion = extensionVersion();
         when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
         when(restTemplate.postForObject(anyString(), any(), any())).thenThrow(new RestClientException("whatever"));
 
@@ -144,7 +137,7 @@ class NamespaceOwnershipCheckScannerTest {
 
     @Test
     void startScan_isClean_whenNotEnforcedAndUpstreamIsDown() throws Exception {
-        var extVersion = extensionVersion(new UserData());
+        var extVersion = extensionVersion();
         when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
         when(restTemplate.postForObject(anyString(), any(), any())).thenThrow(new RestClientException("whatever"));
 
@@ -155,7 +148,7 @@ class NamespaceOwnershipCheckScannerTest {
 
     @Test
     void startScan_isClean_whenNamespaceDoesNotExistUpstream() throws Exception {
-        var extVersion = extensionVersion(new UserData());
+        var extVersion = extensionVersion();
         when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
         when(restTemplate.postForObject(anyString(), any(), any())).thenReturn(EMPTY);
 
@@ -163,14 +156,14 @@ class NamespaceOwnershipCheckScannerTest {
                 .startScan(new Scanner.Command(1L, "scan-1"));
 
         assertTrue(invocation.result().isClean());
-        verify(repositories, never()).isVerifiedPublisher(any(), any());
+        verify(repositories, never()).isVerified(any(Namespace.class));
     }
 
     @Test
     void startScan_isClean_whenSearchHitsAreFromUnrelatedPublishers() throws Exception {
         // The upstream search is loose (free text), so it may return extensions that merely mention
         // the namespace name without actually being published under it - those must not count.
-        var extVersion = extensionVersion(new UserData());
+        var extVersion = extensionVersion();
         when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
         when(restTemplate.postForObject(anyString(), any(), any())).thenReturn(UNRELATED_PUBLISHERS);
 
@@ -178,16 +171,15 @@ class NamespaceOwnershipCheckScannerTest {
                 .startScan(new Scanner.Command(1L, "scan-1"));
 
         assertTrue(invocation.result().isClean());
-        verify(repositories, never()).isVerifiedPublisher(any(), any());
+        verify(repositories, never()).isVerified(any(Namespace.class));
     }
 
     @Test
     void startScan_raisesThreat_whenNamespaceExistsUpstreamAndIsNotVerified() throws Exception {
-        var user = new UserData();
-        var extVersion = extensionVersion(user);
+        var extVersion = extensionVersion();
         when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
         when(restTemplate.postForObject(anyString(), any(), any())).thenReturn(NAMESPACE_MATCH);
-        when(repositories.isVerifiedPublisher(extVersion.getExtension().getNamespace(), user)).thenReturn(false);
+        when(repositories.isVerified(extVersion.getExtension().getNamespace())).thenReturn(false);
 
         var invocation = (Scanner.Invocation.Completed) newScanner(true, true)
                 .startScan(new Scanner.Command(1L, "scan-1"));
@@ -198,11 +190,10 @@ class NamespaceOwnershipCheckScannerTest {
 
     @Test
     void startScan_isClean_whenNamespaceExistsUpstreamAndIsVerified() throws Exception {
-        var user = new UserData();
-        var extVersion = extensionVersion(user);
+        var extVersion = extensionVersion();
         when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
         when(restTemplate.postForObject(anyString(), any(), any())).thenReturn(NAMESPACE_MATCH);
-        when(repositories.isVerifiedPublisher(extVersion.getExtension().getNamespace(), user)).thenReturn(true);
+        when(repositories.isVerified(extVersion.getExtension().getNamespace())).thenReturn(true);
 
         var invocation = (Scanner.Invocation.Completed) newScanner(true, true)
                 .startScan(new Scanner.Command(1L, "scan-1"));
@@ -215,11 +206,10 @@ class NamespaceOwnershipCheckScannerTest {
     void startScan_raisesThreat_whenNamespaceExistsUpstreamWithDifferentCasing() throws Exception {
         // Upstream publisher ids are case-insensitive, so "ACME" must still be recognized as a match
         // for the "acme" namespace being published to.
-        var user = new UserData();
-        var extVersion = extensionVersion(user);
+        var extVersion = extensionVersion();
         when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
         when(restTemplate.postForObject(anyString(), any(), any())).thenReturn(NAMESPACE_MATCH_DIFFERENT_CASE);
-        when(repositories.isVerifiedPublisher(extVersion.getExtension().getNamespace(), user)).thenReturn(false);
+        when(repositories.isVerified(extVersion.getExtension().getNamespace())).thenReturn(false);
 
         var invocation = (Scanner.Invocation.Completed) newScanner(true, true)
                 .startScan(new Scanner.Command(1L, "scan-1"));
@@ -229,25 +219,11 @@ class NamespaceOwnershipCheckScannerTest {
     }
 
     @Test
-    void startScan_raisesThreat_whenExistsUpstreamAndNoPublishingUserIsAttributed() throws Exception {
-        var extVersion = extensionVersion(null);
-        when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
-        when(restTemplate.postForObject(anyString(), any(), any())).thenReturn(NAMESPACE_MATCH);
-
-        var invocation = (Scanner.Invocation.Completed) newScanner(true, true)
-                .startScan(new Scanner.Command(1L, "scan-1"));
-
-        assertFalse(invocation.result().isClean());
-        verify(repositories, never()).isVerifiedPublisher(any(), any());
-    }
-
-    @Test
     void startScan_isClean_isActiveAndCheckActiveExtensions() throws Exception {
-        var user = new UserData();
-        var extVersion = extensionVersion(user);
+        var extVersion = extensionVersion();
         when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
         when(restTemplate.postForObject(anyString(), any(), any())).thenReturn(NAMESPACE_MATCH);
-        when(repositories.isVerifiedPublisher(extVersion.getExtension().getNamespace(), user)).thenReturn(true);
+        when(repositories.isVerified(extVersion.getExtension().getNamespace())).thenReturn(true);
         when(repositories.findActiveExtension(anyString(), anyString())).thenReturn(extVersion.getExtension());
 
         var invocation = (Scanner.Invocation.Completed) newScanner(true, true)
@@ -259,8 +235,7 @@ class NamespaceOwnershipCheckScannerTest {
 
     @Test
     void startScan_isClean_isActiveAndNotCheckActiveExtensions() throws Exception {
-        var user = new UserData();
-        var extVersion = extensionVersion(user);
+        var extVersion = extensionVersion();
         when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
         when(repositories.findActiveExtension(anyString(), anyString())).thenReturn(extVersion.getExtension());
 

--- a/server/src/test/java/org/eclipse/openvsx/search/DatabaseSearchServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/search/DatabaseSearchServiceTest.java
@@ -404,7 +404,7 @@ class DatabaseSearchServiceTest {
         var token = new PersonalAccessToken();
         token.setUser(user);
         extVer.setPublishedWith(token);
-        Mockito.when(repositories.isVerified(namespace, user)).thenReturn(false);
+        Mockito.when(repositories.isVerifiedPublisher(extVer)).thenReturn(false);
         Mockito.when(repositories.findLatestVersion(extension, null, false, true)).thenReturn(extVer);
         return extension;
     }

--- a/server/src/test/java/org/eclipse/openvsx/search/ElasticSearchServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/search/ElasticSearchServiceTest.java
@@ -270,7 +270,7 @@ class ElasticSearchServiceTest {
         extVer.setPublishedWith(token);
         Mockito.when(repositories.findLatestVersion(extension, null, false, true))
                 .thenReturn(extVer);
-        Mockito.when(repositories.isVerified(namespace, user))
+        Mockito.when(repositories.isVerifiedPublisher(extVer))
                 .thenReturn(!isUnverified && !isUnrelated);
         return extension;
     }

--- a/server/src/test/java/org/eclipse/openvsx/search/SimilarityCheckServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/search/SimilarityCheckServiceTest.java
@@ -195,19 +195,19 @@ class SimilarityCheckServiceTest {
 
     @Test
     void shouldSkipCheckForVerifiedPublisherWhenConfigured() {
-        // When configured to skip verified publishers, check if namespace has owner memberships.
+        // When configured to skip verified publishers, check if the namespace is verified.
         when(config.isOnlyCheckNewExtensions()).thenReturn(false);
         when(config.isSkipIfPublisherVerified()).thenReturn(true);
         var namespace = new Namespace();
         when(repositories.findNamespace("ns")).thenReturn(namespace);
-        when(repositories.hasMemberships(namespace, NamespaceMembership.ROLE_OWNER)).thenReturn(true);
+        when(repositories.isVerified(namespace)).thenReturn(true);
 
         var context = createContext("ns", "ext", "Display");
         var result = similarityCheckService.check(context);
 
         assertThat(result.passed()).isTrue();
         verify(repositories).findNamespace("ns");
-        verify(repositories).hasMemberships(namespace, NamespaceMembership.ROLE_OWNER);
+        verify(repositories).isVerified(namespace);
         verifyNoInteractions(similarityService);
     }
 


### PR DESCRIPTION
`RepositoryService` conflated two different questions under similarly-named methods: whether a **namespace itself** is verified (has an owner) vs. whether a **specific user** counts as a verified publisher for it (member of a namespace that has an owner, or privileged). That ambiguity had already caused a real bug and was an unnecessary dependency in a security scanner.

## Changes

- **Add `RepositoryService.isVerified(Namespace)`**: the namespace-only check, delegating to the existing `hasMemberships(namespace, ROLE_OWNER)`. Migrated every call site that only ever cared about the namespace itself — the namespace JSON's own `verified` badge in `LocalRegistryService` and `UserAPI`, and `SimilarityCheckService`'s verified-publisher skip — from `hasMemberships` to this more descriptive method.

- **Fix `RelevanceService`**: it had its own private `isVerified(ExtensionVersion)` that duplicated `RepositoryService.isVerifiedPublisher(ExtensionVersion)` almost line for line, but called `repositories.isVerified(...)` directly instead of `isVerifiedPublisher(...)` — silently dropping the privileged-user bypass every other verified-badge call site gets. A privileged user's extension version showed as verified everywhere *except* in search relevance scoring. Removed the duplicate; search now calls the real method.

- **Simplify `NamespaceOwnershipCheckScanner`**: it checked `isVerifiedPublisher(namespace, user)` using the specific publisher of the scanned version, but self-service namespace creation only ever grants the creator `CONTRIBUTOR` (never `OWNER`) — so a namespace can have contributors who can legitimately publish while having no owner at all, which is exactly the squatting scenario this scanner exists to catch. The scanner's own class doc already described the check as namespace-level ("has an owner, not only contributors"), so it now calls `isVerified(namespace)` directly. This also drops the `ExtensionVersion#getPublishedWith()` dependency, fixing a latent false-positive: a null publisher (e.g. mirrored/migrated data) used to force a threat regardless of whether the namespace was actually verified.

- **Remove the now-redundant `RepositoryService.isVerified(Namespace, UserData)`** public overload: after the above, its only remaining caller was `isVerifiedPublisher(Namespace, UserData)` itself. Keeping it exposed a privilege-unaware shortcut that invited exactly the kind of bug just fixed in `RelevanceService`. Inlined the single jOOQ delegation call directly into `isVerifiedPublisher` instead.

Tests updated throughout to match: `RegistryAPITest`, `UserAPITest`, `AdminAPITest`, `SimilarityCheckServiceTest`, `DatabaseSearchServiceTest`, `ElasticSearchServiceTest`, `NamespaceOwnershipCheckScannerTest`, and `RepositoryServiceSmokeTest`'s reflective method-coverage check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)