### PR TITLE
fix: guard scan recovery on startup with a Postgres advisory lock

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanJobRecoveryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/scanning/ExtensionScanJobRecoveryService.java
@@ -20,6 +20,8 @@ import java.util.List;
 import org.jobrunr.jobs.annotations.Job;
 import org.jobrunr.jobs.lambdas.JobRequestHandler;
 import org.jobrunr.scheduling.JobRequestScheduler;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -50,6 +52,11 @@ public class ExtensionScanJobRecoveryService implements JobRequestHandler<Handle
     // Max jobs to process per watchdog cycle
     private static final int MAX_PER_CYCLE = 20;
 
+    // Arbitrary, fixed key for the Postgres advisory lock guarding startup recovery below. Only
+    // needs to be distinct from any other advisory lock key this application uses - there are none
+    // today.
+    private static final long RECOVERY_LOCK_KEY = 891_234_567_890_123L;
+
     private final ScannerJobRepository scanJobRepository;
     private final ScannerRegistry scannerRegistry;
     private final RepositoryService repositories;
@@ -60,6 +67,7 @@ public class ExtensionScanJobRecoveryService implements JobRequestHandler<Handle
     private final PublishExtensionVersionService publishService;
     private final ExtensionService extensionService;
     private final JobRequestScheduler jobScheduler;
+    private final DSLContext dsl;
 
     public ExtensionScanJobRecoveryService(
             ScannerJobRepository scanJobRepository,
@@ -71,7 +79,8 @@ public class ExtensionScanJobRecoveryService implements JobRequestHandler<Handle
             PublishCheckRunner publishCheckRunner,
             PublishExtensionVersionService publishService,
             ExtensionService extensionService,
-            JobRequestScheduler jobScheduler
+            JobRequestScheduler jobScheduler,
+            DSLContext dsl
     ) {
         this.scanJobRepository = scanJobRepository;
         this.scannerRegistry = scannerRegistry;
@@ -83,10 +92,21 @@ public class ExtensionScanJobRecoveryService implements JobRequestHandler<Handle
         this.publishService = publishService;
         this.extensionService = extensionService;
         this.jobScheduler = jobScheduler;
+        this.dsl = dsl;
     }
 
     /**
      * Recover all scan state on server startup.
+     * <p>
+     * {@code ApplicationReadyEvent} fires independently, un-coordinated, in every instance's own JVM -
+     * with multiple pods (e.g. during a rolling update) several of them can be starting up within the
+     * same window, each running this whole pass against the same database rows. Beyond the merely
+     * confusing duplicate log lines that produces, some of what recovery does is not idempotent across
+     * instances (e.g. re-enqueueing the same stuck job from two pods submits it for scanning twice), so
+     * a transaction-scoped Postgres advisory lock ensures only one instance actually performs recovery
+     * per acquisition window. {@code pg_try_advisory_xact_lock} never blocks - it returns immediately -
+     * and Postgres releases the lock automatically when this method's transaction ends (commit or
+     * rollback), so there is no explicit unlock and no risk of a lock leaking onto a pooled connection.
      */
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
@@ -95,11 +115,26 @@ public class ExtensionScanJobRecoveryService implements JobRequestHandler<Handle
             return;
         }
 
+        if (!tryAcquireRecoveryLock()) {
+            logger.debug("Another instance already holds the scan recovery lock, skipping");
+            return;
+        }
+
         logger.info("Starting scan recovery on server startup");
 
         recoverPendingJobs();
         recoverValidatingScans();
         recoverStaleScans();
+    }
+
+    // Package-private so a test can stub it via a spy without needing two real database connections
+    // to exercise recoverOnStartup()'s branching; the lock's own semantics are covered separately by
+    // ExtensionScanJobRecoveryServiceTest against a real Postgres instance.
+    boolean tryAcquireRecoveryLock() {
+        return Boolean.TRUE.equals(
+                dsl.fetchValue(
+                        DSL.select(
+                                DSL.function("pg_try_advisory_xact_lock", Boolean.class, DSL.val(RECOVERY_LOCK_KEY)))));
     }
 
     /**

--- a/server/src/test/java/org/eclipse/openvsx/scanning/ExtensionScanJobRecoveryServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/ExtensionScanJobRecoveryServiceTest.java
@@ -1,0 +1,162 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.scanning;
+
+import javax.sql.DataSource;
+
+import org.jobrunr.scheduling.JobRequestScheduler;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.util.Streamable;
+
+import org.eclipse.openvsx.AbstractPostgresContainerTest;
+import org.eclipse.openvsx.ExtensionService;
+import org.eclipse.openvsx.publish.PublishExtensionVersionService;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.repositories.ScannerJobRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code recoverOnStartup()} fires independently in every instance's own JVM on
+ * {@code ApplicationReadyEvent}. With multiple pods (e.g. mid rolling-update) several can start within
+ * the same window and each would otherwise run the whole recovery pass redundantly - not just noisy
+ * duplicate logging, but genuinely duplicate work for the parts that are not idempotent across
+ * instances (re-enqueueing the same stuck job twice submits it for scanning twice). These tests cover
+ * both halves of the fix: the advisory lock's actual mutual-exclusion semantics against real Postgres
+ * connections, and that {@code recoverOnStartup()} correctly skips/proceeds based on it.
+ */
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+class ExtensionScanJobRecoveryServiceTest extends AbstractPostgresContainerTest {
+
+    @Autowired
+    DataSource dataSource;
+
+    @Mock
+    ScannerJobRepository scanJobRepository;
+    @Mock
+    ScannerRegistry scannerRegistry;
+    @Mock
+    RepositoryService repositories;
+    @Mock
+    ExtensionScanPersistenceService persistenceService;
+    @Mock
+    ExtensionScanService scanService;
+    @Mock
+    ExtensionScanCompletionService completionService;
+    @Mock
+    PublishCheckRunner publishCheckRunner;
+    @Mock
+    PublishExtensionVersionService publishService;
+    @Mock
+    ExtensionService extensionService;
+    @Mock
+    JobRequestScheduler jobScheduler;
+    @Mock
+    DSLContext dsl;
+
+    private ExtensionScanJobRecoveryService newService(DSLContext dslContext) {
+        return new ExtensionScanJobRecoveryService(
+                scanJobRepository,
+                scannerRegistry,
+                repositories,
+                persistenceService,
+                scanService,
+                completionService,
+                publishCheckRunner,
+                publishService,
+                extensionService,
+                jobScheduler,
+                dslContext);
+    }
+
+    // Proves the actual Postgres mechanism recoverOnStartup() relies on: two separate connections
+    // (standing in for two pods) contend for the same key, the second fails while the first's
+    // transaction is still open, and the lock becomes available again the instant the first commits -
+    // with no explicit unlock call anywhere.
+    @Test
+    void tryAcquireRecoveryLock_isMutuallyExclusiveAcrossConnectionsAndReleasedOnCommit() throws Exception {
+        try (var conn1 = dataSource.getConnection(); var conn2 = dataSource.getConnection()) {
+            conn1.setAutoCommit(false);
+            conn2.setAutoCommit(false);
+
+            var service1 = newService(DSL.using(conn1, SQLDialect.POSTGRES));
+            var service2 = newService(DSL.using(conn2, SQLDialect.POSTGRES));
+
+            assertThat(service1.tryAcquireRecoveryLock())
+                    .as("first connection acquires the lock")
+                    .isTrue();
+            assertThat(service2.tryAcquireRecoveryLock())
+                    .as("second connection must not acquire it while the first transaction is open")
+                    .isFalse();
+
+            conn1.commit();
+
+            assertThat(service2.tryAcquireRecoveryLock())
+                    .as("lock is released automatically once the holder's transaction commits")
+                    .isTrue();
+
+            conn2.commit();
+        }
+    }
+
+    @Test
+    void recoverOnStartup_skipsRecoveryWhenAnotherInstanceHoldsTheLock() {
+        var service = Mockito.spy(newService(dsl));
+        when(scanService.isEnabled()).thenReturn(true);
+        doReturn(false).when(service).tryAcquireRecoveryLock();
+
+        service.recoverOnStartup();
+
+        verifyNoInteractions(scanJobRepository, repositories, persistenceService, completionService);
+    }
+
+    @Test
+    void recoverOnStartup_runsRecoveryWhenLockIsAcquired() {
+        var service = Mockito.spy(newService(dsl));
+        when(scanService.isEnabled()).thenReturn(true);
+        doReturn(true).when(service).tryAcquireRecoveryLock();
+        // Nothing to recover in any state - just proving the recovery pass actually ran.
+        when(repositories.findExtensionScansByStatus(ArgumentMatchers.any())).thenReturn(Streamable.empty());
+
+        service.recoverOnStartup();
+
+        // recoverPendingJobs() is the first thing a successful acquisition leads to.
+        verify(scanJobRepository).findByStatusIn(ArgumentMatchers.anyList());
+    }
+
+    @Test
+    void recoverOnStartup_doesNotEvenCheckTheLockWhenScanningIsDisabled() {
+        var service = Mockito.spy(newService(dsl));
+        when(scanService.isEnabled()).thenReturn(false);
+
+        service.recoverOnStartup();
+
+        verify(service, never()).tryAcquireRecoveryLock();
+    }
+}


### PR DESCRIPTION
## What

`ExtensionScanJobRecoveryService.recoverOnStartup()` fires independently in every instance's own JVM on `ApplicationReadyEvent`, with no cross-pod coordination. During a rolling update with several pods starting in the same window, each one runs the whole recovery pass, which causes:

- Duplicate log lines (the symptom reported in #2082).
- Genuine duplicate work: `recoverPendingJobs()` can re-enqueue the same `QUEUED` sync scanner job twice, and `recoverValidatingScan()` can submit the same `VALIDATING` scan for scanning twice.

## How

Guards the whole `recoverOnStartup()` pass with a Postgres **transaction-scoped advisory lock** (`pg_try_advisory_xact_lock`). Only the instance that acquires the lock runs recovery; the rest skip with a debug log and rely on the winner. Chose the transaction-scoped variant over the session-scoped one to avoid lock-leak risk under HikariCP connection pooling - it releases automatically on commit/rollback, with no explicit unlock call needed.

## Testing

Added `ExtensionScanJobRecoveryServiceTest`, covering:
- The actual Postgres lock mechanism against two real, separate JDBC connections (standing in for two pods): mutual exclusion while one holds the lock, and automatic release on commit.
- `recoverOnStartup()`'s control flow: skips recovery when the lock can't be acquired, runs it when it can, and doesn't even attempt the lock when scanning is disabled.

`./gradlew test --tests 'org.eclipse.openvsx.scanning.*'` passes locally.

Fixes #2082
