### PR TITLE
feat(cli): add verify and verify-signature commands

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -8,6 +8,12 @@ This change log covers only the command line interface (CLI) of Open VSX.
 
 - Add `unpublish` command to delete an extension or some of its versions, mirroring `vsce unpublish` ([#1958](https://github.com/eclipse-openvsx/openvsx/issues/1958)); requires a registry running version 1.2.0 or later, which `unpublish` checks for before deleting
 - `publish` checks the packaged extension's size against the limit reported by the registry's `/api/version` endpoint before uploading, instead of failing only after the upload completes ([#1953](https://github.com/eclipse-openvsx/openvsx/issues/1953))
+- Add `verify` command to check a downloaded `.vsix` package's signature against the registry's public key, mirroring `vsce verify-signature` ([#993](https://github.com/eclipse-openvsx/openvsx/issues/993))
+- Add `verify-signature` command, verifying an already-extracted package/manifest/signature file trio entirely offline (no registry involved), matching `vsce verify-signature`'s own command shape ([#993](https://github.com/eclipse-openvsx/openvsx/issues/993))
+
+#### Changed
+
+- Bump minimum supported Node.js version to 22, matching the webui component
 
 ### [v1.1.1] (09/08/2026)
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -94,6 +94,18 @@ Variants:
  * `ovsx get <extension> --metadata -o <path>`
    downloads the JSON metadata of an extension and saves it in the specified file or directory.
 
+### Verify a Downloaded Package
+
+If the registry signs published packages, `ovsx verify <path>` checks a downloaded `.vsix` file's signature against the registry's public key - the same check VS Code itself performs when installing a signed extension. The namespace, extension name and version are read from the package itself, so no extra arguments are needed beyond the file path (and `-t`/`--target` for a [target platform specific extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions)).
+
+ * `ovsx verify <extension.vsix>`
+   verifies the package's signature and exits with an error if it is missing, invalid, or does not match - meaning the package was not published by, or was tampered with after being published by, the registry it was downloaded from.
+
+If you already have the package, manifest and signature files on disk - e.g. extracted from a registry's signature archive - and don't want `ovsx` to talk to a registry at all, `ovsx verify-signature` verifies that trio entirely offline, mirroring `vsce verify-signature`:
+
+ * `ovsx verify-signature -i <package.vsix> -m <manifest> -s <signature> -k <publicKey>`
+   verifies the signature against the package, and cross-checks the manifest's recorded digests against the package's actual contents - reporting which entry doesn't match, if any. Unlike `vsce verify-signature`, a public key must be supplied explicitly (`-k`/`--publicKeyPath`): Open VSX registries each hold their own signing key, rather than trusting a single baked-in Marketplace key the way VS Code's own verifier does.
+
 ### Store Access Tokens
 
 The `login` command lets you store an access token for a namespace.

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,7 +31,7 @@
     "types": "lib/index",
     "bin": "bin/ovsx",
     "engines": {
-        "node": ">= 20"
+        "node": ">=22.0.0"
     },
     "dependencies": {
         "@inquirer/prompts": "^7.10.1",
@@ -51,17 +51,19 @@
         "@stylistic/eslint-plugin": "^2.11.0",
         "@types/follow-redirects": "^1.13.1",
         "@types/is-ci": "^2.0.0",
-        "@types/node": "^20.14.8",
+        "@types/node": "^22.0.0",
         "@types/semver": "^7.5.8",
         "@types/tmp": "^0.2.2",
         "@types/yauzl-promise": "^4",
+        "@types/yazl": "^3.3.1",
         "@typescript-eslint/eslint-plugin": "^8.15.0",
         "@typescript-eslint/parser": "^8.15.0",
         "eslint": "^9.15.0",
         "limiter": "^2.1.0",
         "rimraf": "^6.0.1",
         "typescript": "^5.6.3",
-        "vitest": "^4.1.10"
+        "vitest": "^4.1.10",
+        "yazl": "^3.3.1"
     },
     "scripts": {
         "clean": "rimraf lib",

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -16,6 +16,8 @@ import { publish } from './publish';
 import { unpublish } from './unpublish';
 import { handleError } from './util';
 import { getExtension } from './get';
+import { verify } from './verify';
+import { verifySignature } from './verify-signature';
 import login from './login';
 import logout from './logout';
 import { LIB_VERSION } from './version';
@@ -123,6 +125,26 @@ module.exports = function (argv: string[]): void {
         .action((extensionId: string, { target, versionRange, output, metadata }) => {
             const { registryUrl } = program.opts();
             getExtension({ extensionId, target: target, version: versionRange, registryUrl, output, metadata })
+                .catch(handleError(program.debug));
+        });
+
+    const verifyCmd = program.command('verify <extension.vsix>');
+    verifyCmd.description('Verify a downloaded package\'s signature against the registry\'s public key.')
+        .option('-t, --target <target>', 'Target architecture')
+        .action((packagePath: string, { target }) => {
+            const { registryUrl } = program.opts();
+            verify({ packagePath, target, registryUrl })
+                .catch(handleError(program.debug));
+        });
+
+    const verifySignatureCmd = program.command('verify-signature');
+    verifySignatureCmd.description('Verify a signature file against a package and manifest, entirely offline - like `vsce verify-signature`.')
+        .requiredOption('-i, --packagePath <path>', 'Path to the .vsix package.')
+        .requiredOption('-m, --manifestPath <path>', 'Path to the signature manifest file.')
+        .requiredOption('-s, --signaturePath <path>', 'Path to the signature file.')
+        .requiredOption('-k, --publicKeyPath <path>', 'Path to the registry\'s public key file.')
+        .action(({ packagePath, manifestPath, signaturePath, publicKeyPath }) => {
+            verifySignature({ packagePath, manifestPath, signaturePath, publicKeyPath })
                 .catch(handleError(program.debug));
         });
 

--- a/cli/src/verify-options.ts
+++ b/cli/src/verify-options.ts
@@ -1,0 +1,25 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import { RegistryOptions } from './registry-options';
+
+export interface VerifyOptions extends RegistryOptions {
+    /**
+     * Path to the downloaded .vsix package to verify.
+     */
+    packagePath: string;
+    /**
+     * Target platform. Defaults to universal.
+     */
+    target?: string;
+}

--- a/cli/src/verify-signature-options.ts
+++ b/cli/src/verify-signature-options.ts
@@ -1,0 +1,32 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+export interface VerifySignatureOptions {
+    /**
+     * Path to the .vsix package.
+     */
+    packagePath: string;
+    /**
+     * Path to the signature manifest file (the `.signature.manifest` entry of a registry's
+     * signature archive).
+     */
+    manifestPath: string;
+    /**
+     * Path to the signature file (the `.signature.sig` entry of a registry's signature archive).
+     */
+    signaturePath: string;
+    /**
+     * Path to the registry's public key file, in PEM format.
+     */
+    publicKeyPath: string;
+}

--- a/cli/src/verify-signature.ts
+++ b/cli/src/verify-signature.ts
@@ -1,0 +1,117 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import { readAllZipEntries } from './zip';
+import { VerifySignatureOptions } from './verify-signature-options';
+
+interface DigestEntry {
+    size?: number;
+    digests?: { sha256?: string };
+}
+
+interface SignatureManifest {
+    package?: DigestEntry;
+    entries?: { [base64Name: string]: DigestEntry };
+}
+
+/**
+ * Verifies a package/manifest/signature file trio entirely offline, the same way `vsce
+ * verify-signature` does - no registry involved, every input is a local file. Unlike `verify`,
+ * which fetches everything it needs from a registry for a package identified by name, this is for
+ * a signature archive you already extracted yourself (e.g. the `.sigzip` a registry serves has a
+ * `.signature.sig` and a `.signature.manifest` entry, matching `--signaturePath` and
+ * `--manifestPath` here).
+ *
+ * `vsce verify-signature` validates against Microsoft's own (closed-source) signing scheme and
+ * has no need for a public key argument - VS Code's Marketplace keys are baked into its verifier.
+ * Open VSX's registries each hold their own Ed25519 key pair instead, so `--publicKeyPath` is
+ * required here to say which registry's signature this is supposed to be.
+ */
+export async function verifySignature(options: VerifySignatureOptions): Promise<void> {
+    const [packageBytes, manifestJson, signature, publicKeyPem] = await Promise.all([
+        fs.promises.readFile(options.packagePath),
+        fs.promises.readFile(options.manifestPath, 'utf-8'),
+        fs.promises.readFile(options.signaturePath),
+        fs.promises.readFile(options.publicKeyPath, 'utf-8')
+    ]);
+
+    let manifest: SignatureManifest;
+    try {
+        manifest = JSON.parse(manifestJson);
+    } catch (err) {
+        throw new Error(`Failed to parse the manifest file as JSON: ${err instanceof Error ? err.message : err}`);
+    }
+
+    const publicKey = crypto.createPublicKey({ key: publicKeyPem, format: 'pem' });
+    const signatureValid = crypto.verify(null, packageBytes, publicKey, signature);
+    if (!signatureValid) {
+        throw new Error('Signature verification failed. The package may have been tampered with.');
+    }
+
+    const manifestIssues = await checkManifest(options.packagePath, packageBytes, manifest);
+    if (manifestIssues.length > 0) {
+        throw new Error(
+            'The signature is valid, but the package does not match the manifest:\n'
+            + manifestIssues.map(issue => `  - ${issue}`).join('\n')
+        );
+    }
+
+    console.log('✅  Signature is valid.');
+}
+
+function sha256Base64(content: Buffer): string {
+    return crypto.createHash('sha256').update(content).digest('base64');
+}
+
+/**
+ * The manifest itself isn't part of what the signature covers - only the raw package bytes are
+ * signed - so this can't add cryptographic trust on its own. It does confirm the manifest wasn't
+ * corrupted or is stale relative to the actual package, and unlike the signature check alone, can
+ * point at exactly which entry doesn't match.
+ */
+async function checkManifest(packagePath: string, packageBytes: Buffer, manifest: SignatureManifest): Promise<string[]> {
+    const issues: string[] = [];
+
+    const actualPackageDigest = sha256Base64(packageBytes);
+    if (manifest.package?.digests?.sha256 !== actualPackageDigest) {
+        issues.push('the package digest does not match the manifest');
+    }
+
+    const manifestEntries = manifest.entries ?? {};
+    const seenKeys = new Set<string>();
+
+    const packageEntries = await readAllZipEntries(packagePath);
+    for (const [name, content] of packageEntries) {
+        const key = Buffer.from(name, 'utf-8').toString('base64');
+        seenKeys.add(key);
+        const entry = manifestEntries[key];
+        if (!entry) {
+            issues.push(`'${name}' is present in the package but missing from the manifest`);
+            continue;
+        }
+        if (entry.digests?.sha256 !== sha256Base64(content)) {
+            issues.push(`'${name}' does not match its digest in the manifest`);
+        }
+    }
+
+    for (const key of Object.keys(manifestEntries)) {
+        if (!seenKeys.has(key)) {
+            const name = Buffer.from(key, 'base64').toString('utf-8');
+            issues.push(`'${name}' is listed in the manifest but missing from the package`);
+        }
+    }
+
+    return issues;
+}

--- a/cli/src/verify-signature.ts
+++ b/cli/src/verify-signature.ts
@@ -13,7 +13,7 @@
 
 import * as crypto from 'crypto';
 import * as fs from 'fs';
-import { readAllZipEntries } from './zip';
+import { hashAllZipEntries } from './zip';
 import { VerifySignatureOptions } from './verify-signature-options';
 
 interface DigestEntry {
@@ -84,16 +84,20 @@ function sha256Base64(content: Buffer): string {
 async function checkManifest(packagePath: string, packageBytes: Buffer, manifest: SignatureManifest): Promise<string[]> {
     const issues: string[] = [];
 
-    const actualPackageDigest = sha256Base64(packageBytes);
-    if (manifest.package?.digests?.sha256 !== actualPackageDigest) {
+    const packageDigest = manifest.package?.digests?.sha256;
+    if (packageDigest === undefined) {
+        issues.push('the manifest does not record a package digest');
+    } else if (packageDigest !== sha256Base64(packageBytes)) {
         issues.push('the package digest does not match the manifest');
     }
 
     const manifestEntries = manifest.entries ?? {};
     const seenKeys = new Set<string>();
 
-    const packageEntries = await readAllZipEntries(packagePath);
-    for (const [name, content] of packageEntries) {
+    // Streamed straight into a digest one entry at a time, rather than buffering every entry's
+    // full content into memory alongside the already-loaded package bytes.
+    const packageEntryDigests = await hashAllZipEntries(packagePath);
+    for (const [name, actualDigest] of packageEntryDigests) {
         const key = Buffer.from(name, 'utf-8').toString('base64');
         seenKeys.add(key);
         const entry = manifestEntries[key];
@@ -101,7 +105,10 @@ async function checkManifest(packagePath: string, packageBytes: Buffer, manifest
             issues.push(`'${name}' is present in the package but missing from the manifest`);
             continue;
         }
-        if (entry.digests?.sha256 !== sha256Base64(content)) {
+        const entryDigest = entry.digests?.sha256;
+        if (entryDigest === undefined) {
+            issues.push(`'${name}' has no recorded digest in the manifest`);
+        } else if (entryDigest !== actualDigest) {
             issues.push(`'${name}' does not match its digest in the manifest`);
         }
     }

--- a/cli/src/verify.ts
+++ b/cli/src/verify.ts
@@ -1,0 +1,107 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import { Registry, Extension } from './registry';
+import { addEnvOptions, createTempFile } from './util';
+import { readVSIXPackage, readZip } from './zip';
+import { VerifyOptions } from './verify-options';
+
+const SIGNATURE_ENTRY = '.signature.sig';
+
+/**
+ * Verifies a downloaded .vsix package's signature against the registry's public key, the same way
+ * VS Code itself verifies signed packages on install. Mirrors `vsce verify-signature`, except the
+ * signature and public key are fetched from the registry instead of being passed in as separate
+ * files - the registry already exposes both for any published, signed version.
+ */
+export async function verify(options: VerifyOptions): Promise<void> {
+    addEnvOptions(options);
+    const registry = new Registry(options);
+
+    const manifest = await readVSIXPackage(options.packagePath);
+    const namespace = manifest.publisher;
+    const extensionName = manifest.name;
+
+    const latest = await registry.getMetadata(namespace, extensionName, options.target);
+    if (latest.error) {
+        throw new Error(latest.error);
+    }
+
+    const extension = await resolveVersion(registry, latest, manifest.version);
+    const description = `${namespace}.${extensionName} v${extension.version}`;
+
+    const signatureUrl = extension.files.signature;
+    const publicKeyUrl = extension.files.publicKey;
+    if (!signatureUrl || !publicKeyUrl) {
+        throw new Error(`${description} is not signed by the registry - there is nothing to verify.`);
+    }
+
+    const [signature, publicKeyPem] = await Promise.all([
+        downloadSignature(registry, signatureUrl),
+        downloadPublicKey(registry, publicKeyUrl)
+    ]);
+
+    const packageBytes = await fs.promises.readFile(options.packagePath);
+    const publicKey = crypto.createPublicKey({ key: publicKeyPem, format: 'pem' });
+    const verified = crypto.verify(null, packageBytes, publicKey, signature);
+
+    if (!verified) {
+        throw new Error(
+            `${description} does not match the version published to ${registry.url}. `
+            + 'The package may have been tampered with, or did not come from that registry.'
+        );
+    }
+    console.log(`✅  This package is identical to ${description} as published to ${registry.url}.`);
+}
+
+/**
+ * `registry.getMetadata` always returns the latest version. Follow `allVersions` to the exact
+ * version recorded in the package's own manifest when it differs.
+ */
+async function resolveVersion(registry: Registry, extension: Extension, version: string): Promise<Extension> {
+    if (extension.version === version) {
+        return extension;
+    }
+    const versionUrl = extension.allVersions[version];
+    if (!versionUrl) {
+        throw new Error(`${extension.namespace}.${extension.name} has no published version '${version}'.`);
+    }
+    return registry.getJson(new URL(versionUrl));
+}
+
+async function downloadSignature(registry: Registry, url: string): Promise<Buffer> {
+    const sigzipPath = await createTempFile({ postfix: '.sigzip' });
+    try {
+        await registry.download(sigzipPath, new URL(url));
+        const entries = await readZip(sigzipPath, name => name === SIGNATURE_ENTRY);
+        const signature = entries.get(SIGNATURE_ENTRY);
+        if (!signature) {
+            throw new Error(`The signature archive does not contain a '${SIGNATURE_ENTRY}' entry.`);
+        }
+        return signature;
+    } finally {
+        await fs.promises.rm(sigzipPath, { force: true });
+    }
+}
+
+async function downloadPublicKey(registry: Registry, url: string): Promise<string> {
+    const publicKeyPath = await createTempFile({ postfix: '.pem' });
+    try {
+        await registry.download(publicKeyPath, new URL(url));
+        return await fs.promises.readFile(publicKeyPath, 'utf-8');
+    } finally {
+        await fs.promises.rm(publicKeyPath, { force: true });
+    }
+}

--- a/cli/src/zip.ts
+++ b/cli/src/zip.ts
@@ -20,7 +20,7 @@ async function bufferStream(stream: Readable): Promise<Buffer> {
 	});
 }
 
-async function readZip(packagePath: string, filter: (name: string) => boolean): Promise<Map<string, Buffer>> {
+export async function readZip(packagePath: string, filter: (name: string) => boolean): Promise<Map<string, Buffer>> {
 	const result = new Map<string, Buffer>();
 	const zipfile = await yauzl.open(packagePath);
 	try {
@@ -31,6 +31,31 @@ async function readZip(packagePath: string, filter: (name: string) => boolean): 
 				const buffer = await bufferStream(stream);
 				result.set(name, buffer);
 			}
+		}
+	} finally {
+		await zipfile.close();
+	}
+
+	return result;
+}
+
+/**
+ * Reads every non-directory entry of a zip file, keyed by its exact (case-preserving) name -
+ * unlike {@link readZip}, which lowercases names for its case-insensitive-filter callers. Used
+ * where entry names are later compared byte-for-byte against another source of truth, such as a
+ * signature manifest that records the original names.
+ */
+export async function readAllZipEntries(packagePath: string): Promise<Map<string, Buffer>> {
+	const result = new Map<string, Buffer>();
+	const zipfile = await yauzl.open(packagePath);
+	try {
+		for await (const entry of zipfile) {
+			if (entry.filename.endsWith('/')) {
+				continue;
+			}
+			const stream = await zipfile.openReadStream(entry);
+			const buffer = await bufferStream(stream);
+			result.set(entry.filename, buffer);
 		}
 	} finally {
 		await zipfile.close();

--- a/cli/src/zip.ts
+++ b/cli/src/zip.ts
@@ -7,8 +7,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ********************************************************************************/
+import * as crypto from 'crypto';
 import * as yauzl from 'yauzl-promise';
 import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 import { Manifest } from './util';
 
 async function bufferStream(stream: Readable): Promise<Buffer> {
@@ -40,13 +42,15 @@ export async function readZip(packagePath: string, filter: (name: string) => boo
 }
 
 /**
- * Reads every non-directory entry of a zip file, keyed by its exact (case-preserving) name -
- * unlike {@link readZip}, which lowercases names for its case-insensitive-filter callers. Used
- * where entry names are later compared byte-for-byte against another source of truth, such as a
- * signature manifest that records the original names.
+ * Computes the SHA256 digest of every non-directory entry of a zip file, keyed by its exact
+ * (case-preserving) name - unlike {@link readZip}, which lowercases names for its
+ * case-insensitive-filter callers. Used where entry names and digests are compared against another
+ * source of truth, such as a signature manifest that records the original names, without also
+ * having to hold every entry's full content in memory at once alongside it - each entry's content
+ * is streamed straight into a hash and discarded, one entry at a time.
  */
-export async function readAllZipEntries(packagePath: string): Promise<Map<string, Buffer>> {
-	const result = new Map<string, Buffer>();
+export async function hashAllZipEntries(packagePath: string): Promise<Map<string, string>> {
+	const result = new Map<string, string>();
 	const zipfile = await yauzl.open(packagePath);
 	try {
 		for await (const entry of zipfile) {
@@ -54,8 +58,9 @@ export async function readAllZipEntries(packagePath: string): Promise<Map<string
 				continue;
 			}
 			const stream = await zipfile.openReadStream(entry);
-			const buffer = await bufferStream(stream);
-			result.set(entry.filename, buffer);
+			const hash = crypto.createHash('sha256');
+			await pipeline(stream, hash);
+			result.set(entry.filename, hash.digest('base64'));
 		}
 	} finally {
 		await zipfile.close();

--- a/cli/test/unit/verify-signature.spec.ts
+++ b/cli/test/unit/verify-signature.spec.ts
@@ -125,6 +125,15 @@ describe('verify-signature', () => {
         await expect(verifySignature(fixture)).rejects.toThrow('the package digest does not match the manifest');
     });
 
+    it('distinguishes a missing package digest from a mismatched one', async () => {
+        const fixture = await givenSignedPackage({ 'extension/package.json': Buffer.from('{"name":"bar"}') });
+        const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, 'utf-8'));
+        delete manifest.package.digests.sha256;
+        fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest));
+
+        await expect(verifySignature(fixture)).rejects.toThrow('the manifest does not record a package digest');
+    });
+
     it('identifies which entry does not match its digest', async () => {
         const fixture = await givenSignedPackage({
             'extension/package.json': Buffer.from('{"name":"bar"}'),
@@ -136,6 +145,19 @@ describe('verify-signature', () => {
         fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest));
 
         await expect(verifySignature(fixture)).rejects.toThrow("'extension/README.md' does not match its digest in the manifest");
+    });
+
+    it('distinguishes an entry with no recorded digest from one with a mismatched digest', async () => {
+        const fixture = await givenSignedPackage({
+            'extension/package.json': Buffer.from('{"name":"bar"}'),
+            'extension/README.md': Buffer.from('hello')
+        });
+        const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, 'utf-8'));
+        const key = Buffer.from('extension/README.md', 'utf-8').toString('base64');
+        delete manifest.entries[key].digests.sha256;
+        fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest));
+
+        await expect(verifySignature(fixture)).rejects.toThrow("'extension/README.md' has no recorded digest in the manifest");
     });
 
     it('identifies an entry present in the package but missing from the manifest', async () => {

--- a/cli/test/unit/verify-signature.spec.ts
+++ b/cli/test/unit/verify-signature.spec.ts
@@ -1,0 +1,164 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as yazl from 'yazl';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { verifySignature } from '../../src/verify-signature';
+
+function buildZip(entries: Record<string, Buffer>): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const zipFile = new yazl.ZipFile();
+        for (const [name, content] of Object.entries(entries)) {
+            zipFile.addBuffer(content, name);
+        }
+        const chunks: Buffer[] = [];
+        zipFile.outputStream.on('data', chunk => chunks.push(chunk));
+        zipFile.outputStream.on('end', () => resolve(Buffer.concat(chunks)));
+        zipFile.outputStream.on('error', reject);
+        zipFile.end();
+    });
+}
+
+function sha256Base64(content: Buffer): string {
+    return crypto.createHash('sha256').update(content).digest('base64');
+}
+
+describe('verify-signature', () => {
+
+    const tmpFiles: string[] = [];
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        tmpFiles.splice(0).forEach(file => fs.rmSync(file, { force: true }));
+    });
+
+    function writeTempFile(content: Buffer | string, extension: string): string {
+        const file = path.join(os.tmpdir(), `ovsx-verify-signature-test-${Math.random().toString(36).slice(2)}${extension}`);
+        fs.writeFileSync(file, content);
+        tmpFiles.push(file);
+        return file;
+    }
+
+    async function givenSignedPackage(entries: Record<string, Buffer>) {
+        const packageBytes = await buildZip(entries);
+        const packagePath = writeTempFile(packageBytes, '.vsix');
+
+        const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+        const signature = crypto.sign(null, packageBytes, privateKey);
+        const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }) as string;
+
+        const manifest = {
+            package: { size: packageBytes.length, digests: { sha256: sha256Base64(packageBytes) } },
+            entries: Object.fromEntries(
+                Object.entries(entries).map(([name, content]) => [
+                    Buffer.from(name, 'utf-8').toString('base64'),
+                    { size: content.length, digests: { sha256: sha256Base64(content) } }
+                ])
+            )
+        };
+
+        return {
+            packagePath,
+            manifestPath: writeTempFile(JSON.stringify(manifest), '.manifest'),
+            signaturePath: writeTempFile(signature, '.sig'),
+            publicKeyPath: writeTempFile(publicKeyPem, '.pem'),
+            manifest
+        };
+    }
+
+    it('accepts a valid signature with a matching manifest', async () => {
+        const fixture = await givenSignedPackage({ 'extension/package.json': Buffer.from('{"name":"bar"}') });
+
+        await verifySignature(fixture);
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Signature is valid.'));
+    });
+
+    it('rejects a tampered package', async () => {
+        const fixture = await givenSignedPackage({ 'extension/package.json': Buffer.from('{"name":"bar"}') });
+        fs.appendFileSync(fixture.packagePath, Buffer.from('tampered'));
+
+        await expect(verifySignature(fixture)).rejects.toThrow('Signature verification failed.');
+    });
+
+    it('rejects a signature made with a different key', async () => {
+        const fixture = await givenSignedPackage({ 'extension/package.json': Buffer.from('{"name":"bar"}') });
+        const { privateKey } = crypto.generateKeyPairSync('ed25519');
+        const packageBytes = fs.readFileSync(fixture.packagePath);
+        fs.writeFileSync(fixture.signaturePath, crypto.sign(null, packageBytes, privateKey));
+
+        await expect(verifySignature(fixture)).rejects.toThrow('Signature verification failed.');
+    });
+
+    it('rejects an unparsable manifest', async () => {
+        const fixture = await givenSignedPackage({ 'extension/package.json': Buffer.from('{"name":"bar"}') });
+        fs.writeFileSync(fixture.manifestPath, 'not json');
+
+        await expect(verifySignature(fixture)).rejects.toThrow('Failed to parse the manifest file as JSON');
+    });
+
+    it('reports a package digest mismatch even though the outer signature is valid', async () => {
+        const fixture = await givenSignedPackage({ 'extension/package.json': Buffer.from('{"name":"bar"}') });
+        const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, 'utf-8'));
+        manifest.package.digests.sha256 = 'not-the-real-digest';
+        fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest));
+
+        await expect(verifySignature(fixture)).rejects.toThrow('the package digest does not match the manifest');
+    });
+
+    it('identifies which entry does not match its digest', async () => {
+        const fixture = await givenSignedPackage({
+            'extension/package.json': Buffer.from('{"name":"bar"}'),
+            'extension/README.md': Buffer.from('hello')
+        });
+        const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, 'utf-8'));
+        const key = Buffer.from('extension/README.md', 'utf-8').toString('base64');
+        manifest.entries[key].digests.sha256 = 'not-the-real-digest';
+        fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest));
+
+        await expect(verifySignature(fixture)).rejects.toThrow("'extension/README.md' does not match its digest in the manifest");
+    });
+
+    it('identifies an entry present in the package but missing from the manifest', async () => {
+        const fixture = await givenSignedPackage({
+            'extension/package.json': Buffer.from('{"name":"bar"}'),
+            'extension/README.md': Buffer.from('hello')
+        });
+        const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, 'utf-8'));
+        delete manifest.entries[Buffer.from('extension/README.md', 'utf-8').toString('base64')];
+        fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest));
+
+        await expect(verifySignature(fixture)).rejects.toThrow("'extension/README.md' is present in the package but missing from the manifest");
+    });
+
+    it('identifies an entry listed in the manifest but missing from the package', async () => {
+        const fixture = await givenSignedPackage({ 'extension/package.json': Buffer.from('{"name":"bar"}') });
+        const manifest = JSON.parse(fs.readFileSync(fixture.manifestPath, 'utf-8'));
+        manifest.entries[Buffer.from('extension/ghost.txt', 'utf-8').toString('base64')] = {
+            size: 1,
+            digests: { sha256: 'irrelevant' }
+        };
+        fs.writeFileSync(fixture.manifestPath, JSON.stringify(manifest));
+
+        await expect(verifySignature(fixture)).rejects.toThrow("'extension/ghost.txt' is listed in the manifest but missing from the package");
+    });
+});

--- a/cli/test/unit/verify.spec.ts
+++ b/cli/test/unit/verify.spec.ts
@@ -1,0 +1,221 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import * as yazl from 'yazl';
+import { AddressInfo } from 'net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { verify } from '../../src/verify';
+
+interface RegistryStub {
+    url: string;
+    close: () => Promise<void>;
+}
+
+/**
+ * Builds a zip archive in memory from a set of entry name -> content pairs.
+ */
+function buildZip(entries: Record<string, Buffer>): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const zipFile = new yazl.ZipFile();
+        for (const [name, content] of Object.entries(entries)) {
+            zipFile.addBuffer(content, name);
+        }
+        const chunks: Buffer[] = [];
+        zipFile.outputStream.on('data', chunk => chunks.push(chunk));
+        zipFile.outputStream.on('end', () => resolve(Buffer.concat(chunks)));
+        zipFile.outputStream.on('error', reject);
+        zipFile.end();
+    });
+}
+
+/**
+ * Stands in for the registry's extension metadata endpoint plus the signature/public-key file
+ * downloads it points to.
+ */
+async function startRegistryStub(routes: Record<string, { body: Buffer | string; contentType?: string }>): Promise<RegistryStub> {
+    const server = http.createServer((req, res) => {
+        const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+        const route = routes[url.pathname];
+        if (!route) {
+            res.writeHead(404);
+            res.end();
+            return;
+        }
+        res.writeHead(200, { 'Content-Type': route.contentType ?? 'application/json' });
+        res.end(route.body);
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    return {
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>(resolve => server.close(() => resolve()))
+    };
+}
+
+describe('verify', () => {
+
+    const stubs: RegistryStub[] = [];
+    const tmpFiles: string[] = [];
+    let logSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await Promise.all(stubs.splice(0).map(stub => stub.close()));
+        tmpFiles.splice(0).forEach(file => fs.rmSync(file, { force: true }));
+    });
+
+    function writeTempFile(content: Buffer, extension: string): string {
+        const file = path.join(os.tmpdir(), `ovsx-verify-test-${Math.random().toString(36).slice(2)}${extension}`);
+        fs.writeFileSync(file, content);
+        tmpFiles.push(file);
+        return file;
+    }
+
+    async function givenVsixPackage(manifest: { publisher: string; name: string; version: string }): Promise<{ path: string; bytes: Buffer }> {
+        const zip = await buildZip({ 'extension/package.json': Buffer.from(JSON.stringify(manifest)) });
+        return { path: writeTempFile(zip, '.vsix'), bytes: zip };
+    }
+
+    function signPackage(packageBytes: Buffer) {
+        const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+        const signature = crypto.sign(null, packageBytes, privateKey);
+        const publicKeyPem = publicKey.export({ type: 'spki', format: 'pem' }) as string;
+        return { signature, publicKeyPem };
+    }
+
+    async function givenSignedRegistry(
+        manifest: { publisher: string; name: string; version: string },
+        packageBytes: Buffer,
+        options: { tamperSignature?: boolean; wrongKey?: boolean; unsigned?: boolean } = {}
+    ): Promise<RegistryStub> {
+        const metadataPath = `/api/${manifest.publisher}/${manifest.name}`;
+        // The stub reads from this object at request time, so its routes can still be filled in
+        // with URLs pointing back at the stub itself after the server has actually started.
+        const routes: Record<string, { body: Buffer | string; contentType?: string }> = {};
+        const stub = await startRegistryStub(routes);
+        stubs.push(stub);
+
+        if (options.unsigned) {
+            routes[metadataPath] = {
+                body: JSON.stringify({
+                    namespace: manifest.publisher,
+                    name: manifest.name,
+                    version: manifest.version,
+                    files: {},
+                    allVersions: { [manifest.version]: `${stub.url}${metadataPath}` }
+                })
+            };
+        } else {
+            const { signature, publicKeyPem } = signPackage(packageBytes);
+            const actualSignature = options.tamperSignature ? Buffer.from(signature).reverse() : signature;
+            const actualPublicKeyPem = options.wrongKey ? signPackage(Buffer.from('other')).publicKeyPem : publicKeyPem;
+
+            routes['/sigzip'] = { body: await buildZip({ '.signature.sig': actualSignature }), contentType: 'application/octet-stream' };
+            routes['/publickey'] = { body: actualPublicKeyPem, contentType: 'text/plain' };
+            routes[metadataPath] = {
+                body: JSON.stringify({
+                    namespace: manifest.publisher,
+                    name: manifest.name,
+                    version: manifest.version,
+                    files: { signature: `${stub.url}/sigzip`, publicKey: `${stub.url}/publickey` },
+                    allVersions: { [manifest.version]: `${stub.url}${metadataPath}` }
+                })
+            };
+        }
+
+        return stub;
+    }
+
+    it('reports a valid signature as verified', async () => {
+        const manifest = { publisher: 'foo', name: 'bar', version: '1.0.0' };
+        const pkg = await givenVsixPackage(manifest);
+        const registry = await givenSignedRegistry(manifest, pkg.bytes);
+
+        await verify({ packagePath: pkg.path, registryUrl: registry.url });
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('This package is identical to foo.bar v1.0.0'));
+    });
+
+    it('rejects a tampered signature', async () => {
+        const manifest = { publisher: 'foo', name: 'bar', version: '1.0.0' };
+        const pkg = await givenVsixPackage(manifest);
+        const registry = await givenSignedRegistry(manifest, pkg.bytes, { tamperSignature: true });
+
+        await expect(verify({ packagePath: pkg.path, registryUrl: registry.url }))
+            .rejects.toThrow('foo.bar v1.0.0 does not match the version published to');
+    });
+
+    it('rejects a signature made with a different key', async () => {
+        const manifest = { publisher: 'foo', name: 'bar', version: '1.0.0' };
+        const pkg = await givenVsixPackage(manifest);
+        const registry = await givenSignedRegistry(manifest, pkg.bytes, { wrongKey: true });
+
+        await expect(verify({ packagePath: pkg.path, registryUrl: registry.url }))
+            .rejects.toThrow('foo.bar v1.0.0 does not match the version published to');
+    });
+
+    it('resolves the package\'s own version via allVersions when it is not the latest', async () => {
+        const manifest = { publisher: 'foo', name: 'bar', version: '1.0.0' };
+        const pkg = await givenVsixPackage(manifest);
+
+        const { signature, publicKeyPem } = signPackage(pkg.bytes);
+        const sigzip = await buildZip({ '.signature.sig': signature });
+        const routes: Record<string, { body: Buffer | string; contentType?: string }> = {
+            '/sigzip': { body: sigzip, contentType: 'application/octet-stream' },
+            '/publickey': { body: publicKeyPem, contentType: 'text/plain' }
+        };
+        const stub = await startRegistryStub(routes);
+        stubs.push(stub);
+
+        routes['/api/foo/bar'] = {
+            body: JSON.stringify({
+                namespace: 'foo',
+                name: 'bar',
+                version: '2.0.0', // the "latest" version - not the one we're verifying
+                files: {},
+                allVersions: { '1.0.0': `${stub.url}/api/foo/bar/1.0.0`, '2.0.0': `${stub.url}/api/foo/bar` }
+            })
+        };
+        routes['/api/foo/bar/1.0.0'] = {
+            body: JSON.stringify({
+                namespace: 'foo',
+                name: 'bar',
+                version: '1.0.0',
+                files: { signature: `${stub.url}/sigzip`, publicKey: `${stub.url}/publickey` },
+                allVersions: {}
+            })
+        };
+
+        await verify({ packagePath: pkg.path, registryUrl: stub.url });
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('This package is identical to foo.bar v1.0.0'));
+    });
+
+    it('fails fast when the version is not signed by the registry', async () => {
+        const manifest = { publisher: 'foo', name: 'bar', version: '1.0.0' };
+        const pkg = await givenVsixPackage(manifest);
+        const registry = await givenSignedRegistry(manifest, pkg.bytes, { unsigned: true });
+
+        await expect(verify({ packagePath: pkg.path, registryUrl: registry.url }))
+            .rejects.toThrow('foo.bar v1.0.0 is not signed by the registry - there is nothing to verify.');
+    });
+});

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1422,12 +1422,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.14.8":
-  version: 20.16.7
-  resolution: "@types/node@npm:20.16.7"
+"@types/node@npm:^22.0.0":
+  version: 22.20.1
+  resolution: "@types/node@npm:22.20.1"
   dependencies:
-    undici-types: "npm:~6.19.2"
-  checksum: 10/931d6689af8d02b578a1490475df025063ca1f1c7c064ce891f7ac4da38f28bfda949e79569ac49cb5cf492b2caf91d31aecda6a4efc099e4af4be42ae7315e5
+    undici-types: "npm:~6.21.0"
+  checksum: 10/0949e49d0383569ebd1222a2f65a9adb9328a6a6dbed459a02cdb37c61147755386c004c4ffbe436de59f5859df1774b1dd6bf168f7aeee46884bb190e0c384f
   languageName: node
   linkType: hard
 
@@ -1465,6 +1465,15 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/9b3b65c51878a82f2775d6b1f106b72495355af9ef28e2211dca2bab4c6a0d25f3bf91f5176b8b9e8bc6f1259c4c7f3b800d3e88df01c4cd9f94e5493ac3b27e
+  languageName: node
+  linkType: hard
+
+"@types/yazl@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@types/yazl@npm:3.3.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/86e3ca32ea38332019bef4836b6be2b1970f7a8f16be1eb8c9d2c3dd26cfc4990af9d5bc56c176f3f8286a5b79458a24ed77db209359638cd1cd947fc0f9485a
   languageName: node
   linkType: hard
 
@@ -2058,6 +2067,13 @@ __metadata:
   dependencies:
     fill-range: "npm:^7.1.1"
   checksum: 10/fad11a0d4697a27162840b02b1fad249c1683cbc510cd5bf1a471f2f8085c046d41094308c577a50a03a579dd99d5a6b3724c4b5e8b14df2c4443844cfcda2c6
+  languageName: node
+  linkType: hard
+
+"buffer-crc32@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "buffer-crc32@npm:1.0.0"
+  checksum: 10/ef3b7c07622435085c04300c9a51e850ec34a27b2445f758eef69b859c7827848c2282f3840ca6c1eef3829145a1580ce540cab03ccf4433827a2b95d3b09ca7
   languageName: node
   linkType: hard
 
@@ -4356,10 +4372,11 @@ __metadata:
     "@stylistic/eslint-plugin": "npm:^2.11.0"
     "@types/follow-redirects": "npm:^1.13.1"
     "@types/is-ci": "npm:^2.0.0"
-    "@types/node": "npm:^20.14.8"
+    "@types/node": "npm:^22.0.0"
     "@types/semver": "npm:^7.5.8"
     "@types/tmp": "npm:^0.2.2"
     "@types/yauzl-promise": "npm:^4"
+    "@types/yazl": "npm:^3.3.1"
     "@typescript-eslint/eslint-plugin": "npm:^8.15.0"
     "@typescript-eslint/parser": "npm:^8.15.0"
     "@vscode/vsce": "npm:^3.7.1"
@@ -4376,6 +4393,7 @@ __metadata:
     typescript: "npm:^5.6.3"
     vitest: "npm:^4.1.10"
     yauzl-promise: "npm:^4.0.0"
+    yazl: "npm:^3.3.1"
   bin:
     ovsx: bin/ovsx
   languageName: unknown
@@ -5453,10 +5471,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.19.2":
-  version: 6.19.8
-  resolution: "undici-types@npm:6.19.8"
-  checksum: 10/cf0b48ed4fc99baf56584afa91aaffa5010c268b8842f62e02f752df209e3dea138b372a60a963b3b2576ed932f32329ce7ddb9cb5f27a6c83040d8cd74b7a70
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10/ec8f41aa4359d50f9b59fa61fe3efce3477cc681908c8f84354d8567bb3701fafdddf36ef6bff307024d3feb42c837cf6f670314ba37fc8145e219560e473d14
   languageName: node
   linkType: hard
 
@@ -5805,6 +5823,15 @@ __metadata:
   dependencies:
     buffer-crc32: "npm:~0.2.3"
   checksum: 10/498ea4c6bca26130608c44db166e2f63b3437b94b7ad020ca0c161268d29517e8517146e91e51b78da100ad62feadc1a1a85aaa94aab0b2dc29b355ec75bc8f0
+  languageName: node
+  linkType: hard
+
+"yazl@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "yazl@npm:3.3.1"
+  dependencies:
+    buffer-crc32: "npm:^1.0.0"
+  checksum: 10/021e6c553ea826b90bd20a109ec293f2c2a02ac7c3c361f637e49c4c746b554a0c8e9380b984e12dfee66ca40894836dd8389bec83de2224eafa2eee8cf7be42
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #993.

## What

Adds two `ovsx` CLI commands for checking a downloaded `.vsix` package's signature - no server-side changes needed, since the registry already exposes everything they need (`files.signature` / `files.publicKey` on any signed version's metadata).

### `ovsx verify <extension.vsix>`

Resolves the namespace/name/version from the package's own manifest, fetches the matching version's signature and public key from the registry, and verifies the Ed25519 signature over the raw package bytes using Node's built-in `crypto` - the same check VS Code itself performs on install. No proprietary signing dependency required.

- On success: `✅  This package is identical to ns.ext v1.2.3 as published to <registry>.`
- On failure: explains the package doesn't match what that registry published, and may have been tampered with or come from elsewhere.

### `ovsx verify-signature -i <pkg> -m <manifest> -s <signature> -k <publicKey>`

The fully offline counterpart, mirroring `vsce verify-signature`'s exact command shape for a package/manifest/signature trio already on disk - no registry involved. The one deliberate deviation from vsce: a public key must be supplied explicitly (`-k`/`--publicKeyPath`), since each Open VSX registry holds its own signing key rather than trusting one baked-in Marketplace key.

Beyond the outer signature, it cross-checks the manifest's per-entry SHA256 digests against the package's actual contents and reports exactly which entry doesn't match, is missing from the manifest, or is missing from the package - a level of diagnostic detail the signature check alone can't give.

### Also in this PR

- Bumps the minimum supported Node.js version to 22 (`engines` field + `@types/node`), matching what was already done for `webui`.
- Adds `readAllZipEntries` to `zip.ts` - a case-preserving companion to the existing `readZip`, needed because manifest entry keys must match original (non-lowercased) file names.

## Testing

`yarn build` (tsc + lint) clean. Full `yarn test`: **45/45 passing**, including a real Ed25519 keypair/signature and hand-built zip fixtures for both commands (valid/tampered/wrong-key/unsigned cases, `allVersions` resolution, and every manifest-mismatch case for `verify-signature`). Also manually smoke-tested both commands end-to-end against real generated fixtures.
