### PR TITLE
test: narrow the Spring context for tests that don't need the full application

### DIFF
--- a/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionJooqRepositoryTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionJooqRepositoryTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * namespace that does not contain the named extension, where that extension name exists under a
  * different namespace, was therefore incorrectly reported as resolved.
  */
-@SpringBootTest
+@SpringBootTest(classes = JooqOnlyTestConfig.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @Transactional
 class ExtensionJooqRepositoryTest extends AbstractPostgresContainerTest {
 

--- a/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryTest.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * namespace/extension and excludes inactive versions - so a future change to the join structure is
  * caught if it ever changes the result.
  */
-@SpringBootTest
+@SpringBootTest(classes = JooqOnlyTestConfig.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @Transactional
 class ExtensionVersionJooqRepositoryTest extends AbstractPostgresContainerTest {
 

--- a/server/src/test/java/org/eclipse/openvsx/repositories/JooqOnlyTestConfig.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/JooqOnlyTestConfig.java
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.repositories;
+
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.flyway.autoconfigure.FlywayAutoConfiguration;
+import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.jooq.autoconfigure.JooqAutoConfiguration;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.transaction.autoconfigure.TransactionAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * A {@code @SpringBootTest(classes = ...)} root for tests of the jOOQ-based repository classes
+ * ({@link ExtensionVersionJooqRepository}, {@link ExtensionJooqRepository}) - plain {@code @Component}s
+ * that talk to the database directly through jOOQ, not Spring Data JPA repository interfaces.
+ * <p>
+ * Booting the real {@code RegistryApplication} for these tests (as a bare {@code @SpringBootTest} would)
+ * pulls in every auto-configuration the application has: all ~30 Spring Data JPA repository interfaces
+ * (each one's derived/{@code @Query} methods individually parsed and validated against the Hibernate
+ * metamodel - the dominant cost, on the order of a minute, of a full application context in this
+ * project), JobRunr's SQL storage provider, the web/MVC layer, security, actuator, and more - none of
+ * which either repository class needs. This imports only what {@code EntityManager}-based test setup
+ * and the jOOQ repositories themselves require: a DataSource, Flyway (to create the schema), Hibernate/JPA
+ * (for the EntityManager and transaction management the tests use to set up fixtures), and jOOQ's
+ * {@code DSLContext}.
+ */
+@Configuration(proxyBeanMethods = false)
+@ImportAutoConfiguration(
+    {
+        DataSourceAutoConfiguration.class,
+        FlywayAutoConfiguration.class,
+        HibernateJpaAutoConfiguration.class,
+        TransactionAutoConfiguration.class,
+        JooqAutoConfiguration.class
+    }
+)
+@EntityScan("org.eclipse.openvsx.entities")
+@Import({ ExtensionVersionJooqRepository.class, ExtensionJooqRepository.class })
+public class JooqOnlyTestConfig {
+}

--- a/server/src/test/java/org/eclipse/openvsx/repositories/NamespaceRepositoryTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/NamespaceRepositoryTest.java
@@ -17,16 +17,55 @@ import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.flyway.autoconfigure.FlywayAutoConfiguration;
+import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.transaction.autoconfigure.TransactionAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 import org.eclipse.openvsx.AbstractPostgresContainerTest;
 import org.eclipse.openvsx.entities.Namespace;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+/**
+ * {@link NamespaceRepository} is the only Spring Data JPA repository interface this test needs, but a
+ * bare {@code @SpringBootTest} would still boot the entire {@code RegistryApplication} regardless -
+ * every one of the app's ~30 JPA repository interfaces (each one's derived query methods individually
+ * parsed and validated against the Hibernate metamodel - the dominant cost of a full context in this
+ * project), JobRunr, the web layer, and more. {@link NamespaceRepositoryTestConfig}'s
+ * {@code includeFilters} restricts {@code @EnableJpaRepositories} to just this one interface instead of
+ * every repository interface {@code org.eclipse.openvsx.repositories} (its base package) contains.
+ */
+@SpringBootTest(
+    classes = NamespaceRepositoryTest.NamespaceRepositoryTestConfig.class,
+    webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
 @Transactional
 class NamespaceRepositoryTest extends AbstractPostgresContainerTest {
+
+    @Configuration(proxyBeanMethods = false)
+    @ImportAutoConfiguration(
+        {
+            DataSourceAutoConfiguration.class,
+            FlywayAutoConfiguration.class,
+            HibernateJpaAutoConfiguration.class,
+            TransactionAutoConfiguration.class
+        }
+    )
+    @EntityScan("org.eclipse.openvsx.entities")
+    @EnableJpaRepositories(
+        basePackageClasses = NamespaceRepository.class,
+        includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = NamespaceRepository.class)
+    )
+    static class NamespaceRepositoryTestConfig {
+    }
 
     @Autowired
     NamespaceRepository repo;

--- a/server/src/test/java/org/eclipse/openvsx/scanning/ExtensionScanJobRecoveryServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/scanning/ExtensionScanJobRecoveryServiceTest.java
@@ -25,7 +25,10 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.util.Streamable;
 
 import org.eclipse.openvsx.AbstractPostgresContainerTest;
@@ -49,10 +52,24 @@ import static org.mockito.Mockito.when;
  * instances (re-enqueueing the same stuck job twice submits it for scanning twice). These tests cover
  * both halves of the fix: the advisory lock's actual mutual-exclusion semantics against real Postgres
  * connections, and that {@code recoverOnStartup()} correctly skips/proceeds based on it.
+ * <p>
+ * The service under test is constructed by hand from plain Mockito mocks ({@link #newService}) rather
+ * than autowired, and the tests exercise the advisory lock through {@link #dataSource} directly - the
+ * only real Spring bean this needs is a {@code DataSource}. A bare {@code @SpringBootTest} would still
+ * boot the entire {@code RegistryApplication} regardless (every Spring Data JPA repository, JobRunr,
+ * the web layer, and more), so this uses a minimal context that imports just that.
  */
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
+@SpringBootTest(
+    classes = ExtensionScanJobRecoveryServiceTest.DataSourceOnlyTestConfig.class,
+    webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
 class ExtensionScanJobRecoveryServiceTest extends AbstractPostgresContainerTest {
+
+    @Configuration(proxyBeanMethods = false)
+    @ImportAutoConfiguration(DataSourceAutoConfiguration.class)
+    static class DataSourceOnlyTestConfig {
+    }
 
     @Autowired
     DataSource dataSource;


### PR DESCRIPTION
## Why

`ExtensionVersionJooqRepositoryTest` and `ExtensionJooqRepositoryTest` test `ExtensionVersionJooqRepository`/`ExtensionJooqRepository` — plain `@Component` classes that talk to the database directly through jOOQ, not Spring Data JPA repositories. A bare `@SpringBootTest` still boots the entire `RegistryApplication` for them regardless, pulling in every auto-configuration the app has — most notably all ~30 Spring Data JPA repository interfaces, each one's derived/`@Query` methods individually parsed and validated against the Hibernate metamodel. That's the dominant cost of a full application context in this project: on the order of a minute, spent entirely between the `QueryEnhancerFactories` log line and whatever comes next, with nothing logged in between. On top of that: JobRunr's SQL storage provider, the full web/MVC layer, security, actuator — none of which either jOOQ repository needs.

## What

Adds `JooqOnlyTestConfig`, a `@SpringBootTest(classes = ...)` root that imports only what these tests actually require:
- `DataSourceAutoConfiguration` — the `DataSource`
- `FlywayAutoConfiguration` — creates the schema
- `HibernateJpaAutoConfiguration` — the `EntityManager`/transaction management the tests use to set up fixtures
- `TransactionAutoConfiguration` — `@Transactional` rollback-per-test support
- `JooqAutoConfiguration` — jOOQ's `DSLContext`
- `@Import({ExtensionVersionJooqRepository.class, ExtensionJooqRepository.class})` — the two repository beans themselves

Both test classes switch to it. Since it's the identical context configuration, Spring's test context cache shares one instance across both.

## Verification

- Both test classes together (21 tests, including a *cold* Postgres container start, Flyway migration, and full context bootstrap): **35 seconds**, down from well over a minute of context startup alone for *either one individually* before.
- Full suite: **1061/1061 passing**, total runtime down from ~9-10 minutes to **8m1s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)