### PR TITLE
fix: read the real namespace and extension ids out of a lateral join

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
@@ -1779,22 +1779,27 @@ public class ExtensionVersionJooqRepository {
     }
 
     /**
-     * Maps a field belonging to its original (static) table onto the equivalent field of the given
-     * derived table - e.g. remaps {@code EXTENSION_VERSION.ID} onto {@code latest.field(EXTENSION_VERSION.ID)}
+     * Maps a field of {@link Tables#EXTENSION_VERSION} onto the equivalent field of the given derived
+     * table - e.g. remaps {@code EXTENSION_VERSION.ID} onto {@code latest.field(EXTENSION_VERSION.ID)} -
      * so a caller can read a row of {@code latest} using the familiar static-table field constants.
      * <p>
      * {@code toExtensionVersionCommon} runs every field it reads through the same mapper, including
-     * fields of unrelated tables that were selected as-is rather than through {@code table} (e.g.
-     * {@code NAMESPACE.ID}, {@code EXTENSION.ID}) - {@link Table#field(Field)} returns {@code null}
-     * for those (they have no lineage relationship to {@code table}), so such a field is returned
-     * unchanged rather than as a null field that would blow up the subsequent {@code row.get(...)}.
+     * fields of other tables that were selected as-is rather than through {@code table} (e.g.
+     * {@code NAMESPACE.ID}, {@code EXTENSION.ID}). Those must be left alone, which is why only fields
+     * of the derived table's own source table are remapped: {@link Table#field(Field)} resolves by
+     * name, not by lineage, so asking it for {@code NAMESPACE.ID} hands back the derived table's own
+     * {@code id} - the version's - and the caller reads a version id where it wanted a namespace id.
+     * That is silent: the value has the right type, and only its meaning is wrong.
+     * <p>
      * A field that already belongs to {@code table}, or isn't a plain table field at all (e.g. an
-     * already-computed expression), is likewise returned unchanged - remapping it would be a no-op.
+     * already-computed expression), is returned unchanged - remapping it would be a no-op.
      */
     private record TableFieldMapper(Table<Record> table) implements FieldMapper {
         @Override
         public <T> Field<T> map(Field<T> field) {
-            if (field instanceof TableField<?, ?> tableField && tableField.getTable() != table) {
+            if (field instanceof TableField<?, ?> tableField
+                    && tableField.getTable() == EXTENSION_VERSION
+                    && tableField.getTable() != table) {
                 var remapped = table.field(field);
                 return remapped != null ? remapped : field;
             }

--- a/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryIdMappingTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryIdMappingTest.java
@@ -66,20 +66,22 @@ class ExtensionVersionJooqRepositoryIdMappingTest extends AbstractPostgresContai
     void findLatestByUserReportsTheRealNamespaceAndExtensionIds() {
         var ids = persistOneVersionWithDistinctIds();
 
-        new TransactionTemplate(txManager).executeWithoutResult(status -> {
-            var user = em.find(UserData.class, ids.user());
-            var found = repositories.findLatestVersions(user);
+        try {
+            new TransactionTemplate(txManager).executeWithoutResult(status -> {
+                var user = em.find(UserData.class, ids.user());
+                var found = repositories.findLatestVersions(user);
 
-            assertThat(found).hasSize(1);
-            var version = found.getFirst();
-            assertThat(version.getId()).isEqualTo(ids.version());
-            // these two used to come back as the version's id, which made UserAPI's namespace membership
-            // filter match nothing and emptied the user's extension list
-            assertThat(version.getExtension().getId()).isEqualTo(ids.extension());
-            assertThat(version.getExtension().getNamespace().getId()).isEqualTo(ids.namespace());
-        });
-
-        cleanUp(ids);
+                assertThat(found).hasSize(1);
+                var version = found.getFirst();
+                assertThat(version.getId()).isEqualTo(ids.version());
+                // these two used to come back as the version's id, which made UserAPI's namespace membership
+                // filter match nothing and emptied the user's extension list
+                assertThat(version.getExtension().getId()).isEqualTo(ids.extension());
+                assertThat(version.getExtension().getNamespace().getId()).isEqualTo(ids.namespace());
+            });
+        } finally {
+            cleanUp(ids);
+        }
     }
 
     @Test

--- a/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryIdMappingTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryIdMappingTest.java
@@ -164,7 +164,9 @@ class ExtensionVersionJooqRepositoryIdMappingTest extends AbstractPostgresContai
                     .executeUpdate();
             em.createQuery("delete from Extension e where e.namespace.id = :id").setParameter("id", ids.namespace())
                     .executeUpdate();
-            em.createQuery("delete from Namespace n where n.name like 'id-mapping-%'").executeUpdate();
+            em.createQuery("delete from Namespace n where n.id = :nsId or n.name like 'id-mapping-filler-ns-%'")
+                    .setParameter("nsId", ids.namespace())
+                    .executeUpdate();
             em.createQuery("delete from UserData u where u.id = :id").setParameter("id", ids.user()).executeUpdate();
         });
     }

--- a/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryIdMappingTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepositoryIdMappingTest.java
@@ -1,0 +1,169 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.repositories;
+
+import jakarta.persistence.EntityManager;
+import org.jobrunr.scheduling.JobRequestScheduler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import org.eclipse.openvsx.AbstractPostgresContainerTest;
+import org.eclipse.openvsx.entities.Extension;
+import org.eclipse.openvsx.entities.ExtensionVersion;
+import org.eclipse.openvsx.entities.Namespace;
+import org.eclipse.openvsx.entities.UserData;
+import org.eclipse.openvsx.search.SearchUtilService;
+import org.eclipse.openvsx.util.TargetPlatform;
+import org.eclipse.openvsx.util.TimeUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The queries that read a version out of a {@code CROSS JOIN LATERAL} remap the static field constants
+ * onto the derived table. {@link org.jooq.Table#field(org.jooq.Field)} resolves by name rather than by
+ * lineage, so a field of another table that happens to share a name with one of the derived table's -
+ * {@code namespace.id} and {@code extension.id} against the version's own {@code id} - is answered with
+ * the derived table's column, and the caller silently reads a version id where it wanted a namespace id.
+ * <p>
+ * Every id here is deliberately forced to a different value. Written naively they all land on the same
+ * sequence number in a fresh database, and the assertions pass whether the mapping is right or wrong.
+ */
+@SpringBootTest
+class ExtensionVersionJooqRepositoryIdMappingTest extends AbstractPostgresContainerTest {
+
+    @Autowired
+    RepositoryService repositories;
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    PlatformTransactionManager txManager;
+
+    @MockitoBean
+    SearchUtilService search;
+
+    @MockitoBean
+    JobRequestScheduler scheduler;
+
+    private record Ids(long user, long namespace, long extension, long version) {}
+
+    @Test
+    void findLatestByUserReportsTheRealNamespaceAndExtensionIds() {
+        var ids = persistOneVersionWithDistinctIds();
+
+        new TransactionTemplate(txManager).executeWithoutResult(status -> {
+            var user = em.find(UserData.class, ids.user());
+            var found = repositories.findLatestVersions(user);
+
+            assertThat(found).hasSize(1);
+            var version = found.getFirst();
+            assertThat(version.getId()).isEqualTo(ids.version());
+            // these two used to come back as the version's id, which made UserAPI's namespace membership
+            // filter match nothing and emptied the user's extension list
+            assertThat(version.getExtension().getId()).isEqualTo(ids.extension());
+            assertThat(version.getExtension().getNamespace().getId()).isEqualTo(ids.namespace());
+        });
+
+        cleanUp(ids);
+    }
+
+    @Test
+    void findLatestByExtensionIdReportsTheRealNamespaceAndExtensionIds() {
+        var ids = persistOneVersionWithDistinctIds();
+
+        new TransactionTemplate(txManager).executeWithoutResult(status -> {
+            var found = repositories.findLatestVersions(java.util.List.of(ids.extension()));
+
+            assertThat(found).hasSize(1);
+            var version = found.getFirst();
+            // the search path keys its results by extension id; a version id here made every hit look
+            // absent from the database, and each search purged those entries from the index
+            assertThat(version.getExtension().getId()).isEqualTo(ids.extension());
+            assertThat(version.getExtension().getNamespace().getId()).isEqualTo(ids.namespace());
+        });
+
+        cleanUp(ids);
+    }
+
+    /**
+     * Pads each sequence by a different amount, so a namespace id can never be mistaken for an extension
+     * id or a version id.
+     */
+    private Ids persistOneVersionWithDistinctIds() {
+        return new TransactionTemplate(txManager).execute(status -> {
+            for (var i = 0; i < 3; i++) {
+                var filler = new Namespace();
+                filler.setName("id-mapping-filler-ns-" + i);
+                em.persist(filler);
+            }
+
+            var user = new UserData();
+            user.setLoginName("id-mapping-user");
+            user.setProvider("github");
+            em.persist(user);
+
+            var namespace = new Namespace();
+            namespace.setName("id-mapping-ns");
+            em.persist(namespace);
+            em.flush();
+
+            for (var i = 0; i < 7; i++) {
+                var filler = new Extension();
+                filler.setName("id-mapping-filler-ext-" + i);
+                filler.setNamespace(namespace);
+                filler.setActive(true);
+                em.persist(filler);
+            }
+
+            var extension = new Extension();
+            extension.setName("id-mapping-ext");
+            extension.setNamespace(namespace);
+            extension.setActive(true);
+            em.persist(extension);
+            em.flush();
+
+            var version = new ExtensionVersion();
+            version.setVersion("1.0.0");
+            version.setTargetPlatform(TargetPlatform.NAME_UNIVERSAL);
+            version.setExtension(extension);
+            version.setPublishedBy(user);
+            version.setActive(true);
+            version.setTimestamp(TimeUtil.getCurrentUTC());
+            em.persist(version);
+            em.flush();
+
+            var ids = new Ids(user.getId(), namespace.getId(), extension.getId(), version.getId());
+            assertThat(java.util.Set.of(ids.namespace(), ids.extension(), ids.version()))
+                    .describedAs("the ids have to differ or this test cannot tell a wrong mapping from a right one")
+                    .hasSize(3);
+            return ids;
+        });
+    }
+
+    /** The container is shared with every other test, so leave nothing of this one behind. */
+    private void cleanUp(Ids ids) {
+        new TransactionTemplate(txManager).executeWithoutResult(status -> {
+            em.createQuery("delete from ExtensionVersion v where v.id = :id").setParameter("id", ids.version())
+                    .executeUpdate();
+            em.createQuery("delete from Extension e where e.namespace.id = :id").setParameter("id", ids.namespace())
+                    .executeUpdate();
+            em.createQuery("delete from Namespace n where n.name like 'id-mapping-%'").executeUpdate();
+            em.createQuery("delete from UserData u where u.id = :id").setParameter("id", ids.user()).executeUpdate();
+        });
+    }
+}


### PR DESCRIPTION
Found while investigating a staging deployment where **search returned nothing and "My Extensions" was empty**. Both symptoms have this one cause, and it is not new — the defect dates from 2024, but only became visible when something started comparing the ids.

## The bug

`ExtensionVersionJooqRepository.TableFieldMapper` remaps static field constants onto the `CROSS JOIN LATERAL` derived table that carries an extension's latest version, so callers can read the row with the familiar `EXTENSION_VERSION.X` constants. It assumed `Table.field(Field)` answers `null` for a field belonging to another table — its javadoc said so explicitly, *"they have no lineage relationship"*.

**jOOQ resolves by name, not by lineage.** The lateral selects `EXTENSION_VERSION.ID`, so it has a column called `id`, and both `NAMESPACE.ID` and `EXTENSION.ID` were answered with it:

```
persisted   namespace=5  extension=9  version=2
returned    namespace=2  extension=2  version=2      ← all the version's id
```

Names and every other column map correctly. Only same-named columns collide, the value has the right type, and nothing throws — callers just read a version id where they asked for a namespace or extension id.

## Why two pages went empty

- **My Extensions** — `UserAPI:263` restricts a user's extensions to the namespaces they are a member of, comparing namespace ids. No version id is ever a member's namespace id, so the list is always empty. That filter arrived in #1983 (v1.1.0), which is what turned a latent fault into a visible one.
- **Search** — `getLatestVersions(result)` keys its results by extension id, so every hit looks absent from the database. `LocalRegistryService:970` then **deletes such hits from the search index**, so each search permanently removed the entries it could not resolve. A rebuild is needed after deploying this; the fix stops the bleeding but does not restore what was purged.

## The fix

Remap only fields that actually belong to the lateral's source table:

```java
if (field instanceof TableField<?, ?> tableField
        && tableField.getTable() == EXTENSION_VERSION
        && tableField.getTable() != table) {
```

## The test, and a warning about it

`ExtensionVersionJooqRepositoryIdMappingTest` covers both affected queries — `findLatest(UserData)` and `findLatest(Collection<Long>)` — asserting the namespace and extension ids are the persisted ones.

It pads each sequence by a different amount and asserts the three ids are distinct **before** testing anything. That guard is the point: my first version of this test passed with the bug present, because in a fresh database the namespace, extension and version all landed on id `2` and the assertions could not fail either way. Anyone editing this test should keep the ids apart.

Fail-first checked: reverting the mapper turns both cases red with `expected: 9L`.

Full suite green at 1126 tests.

## Follow-up worth considering separately

The purge at `LocalRegistryService:967-971` removes index entries whenever the database lookup comes back short, with nothing logged as unusual — so a code defect in that lookup silently destroyed data rather than degrading the display. Removing an entry only when the extension is genuinely absent would have made this incident a rendering bug instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)