### PR TITLE
fix: do not reference a one-time token from the version it published

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -250,7 +250,12 @@ public class PublishExtensionVersionHandler {
         extVersion.setPublishedBy(au.userData());
         if (au instanceof AccessTokenAuthentication ata) {
             extVersion.setPublishedWithTt(ata.type());
-            extVersion.setPublishedWithId(ata.tokenId());
+            // A one-time token is deleted as it is used, which happens before this row is written, so
+            // the reference could never be satisfied and the foreign key rejects the insert outright.
+            // What identifies such a publish is the workflow it came from, held in published_provenance.
+            if (!ata.type().isOneTime()) {
+                extVersion.setPublishedWithId(ata.tokenId());
+            }
             extVersion.setPublishedProvenance(ata.claims());
         }
         extVersion.setActive(false);

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerTest.java
@@ -179,6 +179,43 @@ class PublishExtensionVersionHandlerTest {
             var result = handler.createExtensionVersion(processor, ata, LocalDateTime.now(), false);
 
             assertThat(result.getPublishedWithTt()).isEqualTo(PersonalAccessTokenType.TPT);
+            // A one-time token is deleted as it is used, before this row is written, so referencing it
+            // makes the insert fail on extension_version_published_with_id_fkey. The publish is
+            // identified by the workflow claims in published_provenance instead.
+            assertThat(result.getPublishedWithId()).isNull();
+        }
+    }
+
+    // A long-lived token is only ever deactivated, never deleted, so the reference is safe to record and
+    // is what answers "what did this credential publish" after it leaks.
+    @Test
+    void recordsTheTokenALongLivedPublishUsed() throws IOException {
+        try (var processor = org.mockito.Mockito.mock(ExtensionProcessor.class)) {
+            var metadata = mockExtensionVersion("publisher", "demo", "2.0.0", null, processor);
+
+            when(processor.getExtensionDependencies()).thenReturn(List.of());
+            when(processor.getBundledExtensions()).thenReturn(List.of());
+            when(processor.getPackageMetadata()).thenReturn(
+                    new ExtensionProcessor.PackageMetadata(
+                            "publisher",
+                            "demo",
+                            "2.0.0",
+                            "Demo OK"));
+
+            var namespace = buildNamespace("publisher");
+            var user = new UserData();
+            var ata = new AccessTokenAuthentication(user, PersonalAccessTokenType.LLT, 42L, null);
+
+            when(repositories.findNamespace("publisher")).thenReturn(namespace);
+            when(users.hasPublishPermission(user, namespace)).thenReturn(true);
+            when(validator.validateExtensionVersion("2.0.0")).thenReturn(Optional.empty());
+            when(validator.validateExtensionName("demo")).thenReturn(Optional.empty());
+            when(validator.validateMetadata(metadata)).thenReturn(List.of());
+            when(repositories.findExtensionForUpdate("demo", "publisher")).thenReturn(null);
+
+            var result = handler.createExtensionVersion(processor, ata, LocalDateTime.now(), false);
+
+            assertThat(result.getPublishedWithId()).isEqualTo(42L);
         }
     }
 


### PR DESCRIPTION
Publishing with a trusted publishing token fails outright on staging:

```
ERROR: insert or update on table "extension_version" violates foreign key constraint
"extension_version_published_with_id_fkey"
Detail: Key (published_with_id)=(408819) is not present in table "personal_access_token".
```

## Cause

`AccessTokenService.useAccessToken` runs in `REQUIRES_NEW` and deletes a one-time token as it is used, committing before the publish writes anything. By the time `createExtensionVersion` inserts the version, the token it points at is already gone, and the foreign key rejects the insert. Every trusted publishing publish fails.

Introduced in a2e7a1ffe, which started recording `published_with_id` for all token types.

## Fix

`published_with_id` is only set for token types that survive their use:

```java
if (!ata.type().isOneTime()) {
    extVersion.setPublishedWithId(ata.tokenId());
}
```

`isOneTime()` covers `TPT` and the deprecated `OTT`. `LLT` is deactivated, never deleted, so its reference stays valid and still answers "what did this credential publish" after a leak.

A trusted publishing version therefore has `published_with_id` NULL permanently. That is unavoidable while one-time tokens are deleted on use — the alternative is soft-deleting them, which keeps the hashed secret around forever. What identifies such a publish is the workflow it came from, already recorded in `published_provenance`.

## Notes

- No migration change. `V1_72`'s `ON DELETE SET NULL` is still needed, now for an `LLT` deleted later rather than for the one-time case, and its comment still reads correctly. Editing it would change the checksum on databases that have already applied it.
- Nothing reads `published_with_id` outside the entity, so no consumer changes.
- No dangling rows to clean up: the FK prevented the insert, so the publish failed rather than writing bad data.

## Tests

Both fail-first checked — with the guard removed `shouldRecordTheTokenTypeUsedToPublish` goes red and the long-lived test stays green, so they are pinned to the guard and not to the setup.

Full server suite: 1132 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)