### PR TITLE
fix: stop adding to the inverse versions collection when publishing

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -289,7 +289,9 @@ public class PublishExtensionVersionHandler {
         }
 
         extension.setLastUpdatedDate(extVersion.getTimestamp());
-        extension.getVersions().add(extVersion);
+        // Only the owning side is set. Extension.versions is mappedBy this field and has no cascade, so
+        // adding to it persists nothing; on an existing extension the collection is lazy and untouched,
+        // making the add a queued operation Hibernate discards at commit (HHH90030005).
         extVersion.setExtension(extension);
 
         validateLicense(processor, extVersion);


### PR DESCRIPTION
Every publish that adds a version to an existing extension logs:

```
HHH90030005: Detaching an uninitialized collection with queued operations from a session:
[Extension.versions with owner id '400296']
```

## Why the add does nothing

`Extension.versions` is `@OneToMany(mappedBy = "extension")` — inverse side, no cascade. It contributes nothing to persistence; the row is written entirely by `extVersion.setExtension(extension)` plus `entityManager.persist(extVersion)`.

On an existing extension the collection is lazy and never initialized inside the transaction, so `.add()` is a queued operation that Hibernate discards at commit. The warning is reporting an add that already had no effect. Reordering cannot help — the transaction ends when `createExtensionVersion` returns, so the add queues wherever it sits.

## Why removing it is worth doing

Queued operations are applied when the collection is eventually initialized. Nothing initializes it today, but a read added to this transaction later would load the versions — including the row just flushed — and then apply the queued add on top. `versions` is a `List`, not a `Set`, so the new version would appear twice.

The alternative, `Hibernate.initialize(extension.getVersions())` before the add, silences the warning but loads every version row of the extension on each publish, for a collection nothing reads.

## Scope

The new-extension branch is the one case where the add currently does something: there `versions` is a plain `ArrayList` from the getter's null-guard, so it is not lazy and no warning is issued. The transaction ends immediately after and nothing reads the collection in between, so dropping it is unobservable there too.

Every other `getVersions()` caller — `CacheService`, `ExtensionService`, `DataMirrorService`, `DatabaseSearchService` — is on a different path and loads the collection from the database itself.

## Tests

No new test: this removes an in-memory no-op with no observable behaviour to assert, and a test pinning the absence of a discarded operation would be asserting the implementation rather than the behaviour. The existing coverage of the publish path is the guard — full server suite passes, 1131 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)