### PR TITLE
fix: keep a type on the rate limit headers under OpenAPI 3.1

### DIFF
--- a/server/src/dev/resources/application.yml
+++ b/server/src/dev/resources/application.yml
@@ -96,6 +96,10 @@ management:
 
 springdoc:
   model-and-view-allowed: true
+  api-docs:
+    # springdoc 3.x defaults to OpenAPI 3.1, whose mapper in swagger-core writes a single schema type as
+    # a bare string but cannot read one back, so springdoc warns on every schema it tries to clone.
+    version: openapi_3_0
   swagger-ui:
     path: /swagger-ui
     docExpansion: list

--- a/server/src/main/java/org/eclipse/openvsx/web/DocumentationConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/DocumentationConfig.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
@@ -135,20 +136,26 @@ public class DocumentationConfig {
         };
     }
 
+    /**
+     * Schemas must be built through the typed subclasses rather than {@code new Schema<>().type(...)}.
+     * The latter only sets the legacy string {@code type}, which an OpenAPI 3.1 document does not
+     * serialize at all - springdoc 3.x emits 3.1 by default - leaving the header with no type. The
+     * typed subclasses populate both that field and the 3.1 {@code types} set.
+     */
     @Bean
     public OpenApiCustomizer addRateLimitResponse() {
         var limitLimitHeader = new Header()
                 .description("Number of requests that can be made in a given amount of time")
-                .schema(new Schema<>().type("integer").format("int32"));
+                .schema(new IntegerSchema().format("int32"));
         var limitRemainingHeader = new Header()
                 .description("Remaining number of requests left in the current time window")
-                .schema(new Schema<>().type("integer").format("int32"));
+                .schema(new IntegerSchema().format("int32"));
         var limitResetHeader = new Header()
                 .description("Number of seconds until the rate limit tokens will be fully filled to its maximum")
-                .schema(new Schema<>().type("integer").format("int32"));
+                .schema(new IntegerSchema().format("int32"));
         var retryAfterHeader = new Header()
                 .description("Number of seconds to wait after receiving a 429 response")
-                .schema(new Schema<>().type("integer").format("int32"));
+                .schema(new IntegerSchema().format("int32"));
 
         var response = new ApiResponse()
                 .description("A client has sent too many requests in a given amount of time")

--- a/server/src/test/java/org/eclipse/openvsx/web/DocumentationConfigTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/DocumentationConfigTest.java
@@ -14,7 +14,12 @@ package org.eclipse.openvsx.web;
 
 import java.lang.reflect.Method;
 
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Json31;
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.method.HandlerMethod;
 
@@ -57,6 +62,29 @@ class DocumentationConfigTest {
 
         assertThat(operation.getSummary()).isEqualTo("[Preview] Provides a feed");
         assertThat(operation.getDescription()).containsOnlyOnce("**Preview**");
+    }
+
+    // springdoc 3.x emits OpenAPI 3.1 by default, which does not serialize the legacy string `type` a
+    // bare `new Schema<>().type(...)` sets - the header then documents no type at all. The rate limit
+    // headers have to survive both spec versions, since which one is emitted is a springdoc default.
+    @Test
+    void shouldGiveTheRateLimitHeadersATypeInEitherSpecVersion() throws Exception {
+        var openApi = new OpenAPI().paths(
+                new Paths().addPathItem("/api/-/search", new PathItem().get(new Operation())));
+
+        new DocumentationConfig().addRateLimitResponse().customise(openApi);
+
+        var schema = openApi.getPaths()
+                .get("/api/-/search")
+                .getGet()
+                .getResponses()
+                .get("429")
+                .getHeaders()
+                .get("X-RateLimit-Limit")
+                .getSchema();
+
+        assertThat(Json.mapper().writeValueAsString(schema)).contains("\"type\":\"integer\"");
+        assertThat(Json31.mapper().writeValueAsString(schema)).contains("\"type\":\"integer\"");
     }
 
     private void customize(Operation operation, String methodName) {


### PR DESCRIPTION
Accessing api-docs logs:

```
o.springdoc.core.utils.SpringDocUtils : Json Processing Exception occurred: Cannot construct instance
of `java.util.HashSet` (although at least one Creator exists): no String-argument constructor/factory
method to deserialize from String value ('integer')
 (through reference chain: io.swagger.v3.oas.models.media.JsonSchema["type"])
```

Chasing it turned up a second, silent problem in our own document. Both come from the same change.

## What changed

46335e75b (#2112) bumped springdoc 2.8.13 to 3.1.0. springdoc 3.x defaults `springdoc.api-docs.version` to `OPENAPI_3_1`; 2.8.13 defaulted to `OPENAPI_3_0`. The emitted spec version flipped as a side effect of the bump.

## The silent bug, fixed here

`new Schema<>().type("integer")` sets only the legacy string `type` and leaves the 3.1 `types` set null, and a 3.1 document does not serialize the former:

```
type()           write31={"format":"int32"}                     <- no type at all
IntegerSchema    write31={"type":"integer","format":"int32"}
```

So all four rate limit headers have been documented with **no type** since the upgrade. `IntegerSchema` populates both fields and is correct under either spec version, so this is fixed independently of which version we emit.

## The logged warning

swagger-core 2.2.52's 3.1 mapper writes a single schema type as a bare string but only reads an array back:

```
IntegerSchema        write31={"type":"integer",...}            read31=FAIL (HashSet from String 'integer')
IntegerSchema+null   write31={"type":["integer","null"],...}   read31=OK
```

`SpringDocUtils.cloneViaJson` cannot re-read what it just wrote. It logs at `warn` and returns the original object instead of a copy, so **api-docs still render** — the cost is a shared schema instance where a clone was intended. A two-typed schema round-trips fine, which is why only some schemas trip it.

Nothing in this repository can fix that asymmetry, so the dev configuration pins `api-docs` back to `openapi_3_0`. That restores the document as it was before #2112 and silences the warning, since the 3.0 mapper is symmetric on string `type`. Verified the key actually binds — a mistyped property would bind silently — resolving to `OPENAPI_3_0` / spec `3.0.1`.

The pin is dev-only, as requested. Deployments that want it will need it in their own configuration; `deploy/openshift/application.yml` and `deploy/docker/configuration/application.yml` are untouched.

## Tests

`shouldGiveTheRateLimitHeadersATypeInEitherSpecVersion` asserts the header schema serializes with `"type":"integer"` under both the 3.0 and 3.1 mappers, so it holds whichever version springdoc defaults to next. Fail-first checked: red with `new Schema<>().type(...)` restored.

Full server suite passes, 1132 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)