### PR TITLE
feat: let one trusted publishing token publish every target platform

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log covers only the command line interface (CLI) of Open VSX.
 #### Changed
 
 - `publish --trusted-publishing` retries the token exchange when the registry answers that it could not verify the ID token (502, 503, 504), rather than failing the build on a blip reaching the identity provider. A refusal is never retried
+- `publish --trusted-publishing` requests a new token and retries once when the registry refuses the one it was publishing with. The issued token is short-lived and shared by every target platform of a release, so publishing a wide fan-out of large packages could outlive it and fail partway through. Targets that are refused together share one new token, and a token supplied with `--pat` is never retried
 - Bump minimum supported Node.js version to 22, matching the webui component
 
 ### [v1.1.1] (09/08/2026)

--- a/cli/src/publish.ts
+++ b/cli/src/publish.ts
@@ -10,12 +10,12 @@
 import * as fs from 'fs';
 import { createVSIX, IPackageOptions } from '@vscode/vsce';
 import { getPAT } from './pat';
-import { createTempFile, addEnvOptions, addTrustedPublishingEnvOptions, formatBytes } from './util';
+import { createTempFile, addEnvOptions, addTrustedPublishingEnvOptions, formatBytes, StatusError } from './util';
 import { Extension, Registry } from './registry';
 import { checkLicense } from './check-license';
 import { readVSIXPackage } from './zip';
 import { PublishOptions, PublishCommonOptions } from './publish-options';
-import { getTrustedPublishingToken, useTrustedPublishing } from './trusted-publishing';
+import { getTrustedPublishingToken, refreshTrustedPublishingToken, useTrustedPublishing } from './trusted-publishing';
 
 /**
  * Publishes an extension.
@@ -71,16 +71,22 @@ async function doPublish(options: InternalPublishOptions = {}): Promise<void> {
 
     await ensureWithinSizeLimit(options.extensionFile!, options.maxExtensionSize, registry.url);
 
+    // Set only when this publish obtained the token itself through trusted publishing, which is the one
+    // case where a refusal can be answered by asking for a new token.
+    let exchanged: { namespace: string; extension: string } | undefined;
     if (!options.pat) {
         const manifest = await readVSIXPackage(options.extensionFile!);
-        options.pat = useTrustedPublishing(options)
-            ? await getTrustedPublishingToken(registry, manifest.publisher, manifest.name, options)
-            : await getPAT(manifest.publisher, options);
+        if (useTrustedPublishing(options)) {
+            exchanged = { namespace: manifest.publisher, extension: manifest.name };
+            options.pat = await getTrustedPublishingToken(registry, manifest.publisher, manifest.name, options);
+        } else {
+            options.pat = await getPAT(manifest.publisher, options);
+        }
     }
 
     let extension: Extension | undefined;
     try {
-        extension = await registry.publish(options.extensionFile!, options.pat);
+        extension = await doRegistryPublish(registry, options, exchanged);
     } catch (err) {
         if (options.skipDuplicate && err.message.endsWith('is already published.')) {
             console.log(err.message + ' Skipping publish.');
@@ -102,6 +108,39 @@ async function doPublish(options: InternalPublishOptions = {}): Promise<void> {
     console.log(`\ud83d\ude80  Published ${description}`);
     if (extension.warning) {
         console.log(`\n!!  ${extension.warning}`);
+    }
+}
+
+/**
+ * Publishes the package, exchanging the ID token again if the registry refuses the trusted publishing
+ * token this was using. The issued token is short-lived and shared by every target platform of a
+ * release, so publishing a wide fan-out of large packages can outlive it and be refused partway
+ * through - having authorised the release and then failing it over an expiry would be the wrong call.
+ *
+ * Only ever retried once, and only for a token obtained here: nothing this can do makes a token the
+ * user supplied valid, and a second refusal means the token is not the problem.
+ */
+async function doRegistryPublish(
+    registry: Registry,
+    options: InternalPublishOptions,
+    exchanged: { namespace: string; extension: string } | undefined
+): Promise<Extension> {
+    try {
+        return await registry.publish(options.extensionFile!, options.pat!);
+    } catch (err) {
+        if (!exchanged || (err as StatusError)?.status !== 401) {
+            throw err;
+        }
+
+        console.log('The registry refused the publishing token, requesting a new one');
+        options.pat = await refreshTrustedPublishingToken(
+            registry,
+            exchanged.namespace,
+            exchanged.extension,
+            options,
+            options.pat!
+        );
+        return registry.publish(options.extensionFile!, options.pat);
     }
 }
 

--- a/cli/src/trusted-publishing.ts
+++ b/cli/src/trusted-publishing.ts
@@ -18,6 +18,10 @@ import { TrustedPublishingOptions } from './trusted-publishing-options';
 
 const tokens = new Map<string, Promise<string>>();
 
+// The value each cached exchange resolved to, so a token a publish was refused with can be told from one
+// another publish has already replaced. Cleared while an exchange is in flight.
+const issued = new Map<string, string>();
+
 /**
  * Whether the given options ask for trusted publishing. If the user did not decide explicitly,
  * it is used whenever the surrounding CI system can provide an OIDC ID token.
@@ -38,12 +42,49 @@ export function getTrustedPublishingToken(
 ): Promise<string> {
     // publishing fans out over targets and package paths, but one token is enough per extension
     const key = `${namespace}.${extension}`;
-    let token = tokens.get(key);
-    if (!token) {
-        token = requestToken(registry, namespace, extension, options);
-        tokens.set(key, token);
+    return tokens.get(key) ?? exchange(key, registry, namespace, extension, options);
+}
+
+/**
+ * Exchanges the ID token again after the registry refused the one this extension was publishing with.
+ * The issued token is short-lived and shared by every target platform of a release, so a slow fan-out
+ * can outlive it and be refused partway through.
+ *
+ * `stale` is the token that was refused. If the cache no longer holds it, another target has already
+ * replaced it and that exchange is awaited instead, so one expiry costs one exchange however many
+ * targets hit it at once.
+ */
+export function refreshTrustedPublishingToken(
+    registry: Registry,
+    namespace: string,
+    extension: string,
+    options: TrustedPublishingOptions,
+    stale: string
+): Promise<string> {
+    const key = `${namespace}.${extension}`;
+    const current = tokens.get(key);
+    if (current && issued.get(key) !== stale) {
+        return current;
     }
 
+    return exchange(key, registry, namespace, extension, options);
+}
+
+function exchange(
+    key: string,
+    registry: Registry,
+    namespace: string,
+    extension: string,
+    options: TrustedPublishingOptions
+): Promise<string> {
+    // Dropped up front, so a refresh that is still in flight does not look like the stale token to the
+    // next caller and start a second exchange of its own.
+    issued.delete(key);
+    const token = requestToken(registry, namespace, extension, options).then(value => {
+        issued.set(key, value);
+        return value;
+    });
+    tokens.set(key, token);
     return token;
 }
 

--- a/cli/test/unit/publish.spec.ts
+++ b/cli/test/unit/publish.spec.ts
@@ -246,4 +246,29 @@ describe('publish', () => {
         expect(registry.publishRequests).toHaveLength(2);
         expect(registry.tokenRequests).toBe(2);
     });
+
+    // What a multi target release looks like: one package per target platform, published in a single
+    // invocation. The point is the token - the identity is exchanged once and every package publishes
+    // with it, which is what the registry has to accept.
+    it('publishes every package of a release with one exchanged token', async () => {
+        const registry = await givenRegistry();
+        const packagePath = await Promise.all([
+            givenVsixFile('foo', 'fanned-out'),
+            givenVsixFile('foo', 'fanned-out'),
+            givenVsixFile('foo', 'fanned-out')
+        ]);
+
+        const results = await publish({
+            packagePath,
+            registryUrl: registry.url,
+            trustedPublishing: true,
+            idToken: 'an-id-token'
+        });
+
+        expect(results.map(result => result.status)).toEqual(['fulfilled', 'fulfilled', 'fulfilled']);
+        expect(registry.publishRequests).toHaveLength(3);
+        expect(registry.tokenRequests).toBe(1);
+        expect(registry.publishRequests.map(request => request.query.get('token')))
+            .toEqual(['token-1', 'token-1', 'token-1']);
+    });
 });

--- a/cli/test/unit/publish.spec.ts
+++ b/cli/test/unit/publish.spec.ts
@@ -18,6 +18,7 @@ import * as path from 'path';
 import { AddressInfo } from 'net';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { publish } from '../../src/publish';
+import { buildZip } from './support/zip';
 
 interface RecordedRequest {
     pathname: string;
@@ -27,6 +28,7 @@ interface RecordedRequest {
 interface RegistryStub {
     url: string;
     publishRequests: RecordedRequest[];
+    tokenRequests: number;
     close: () => Promise<void>;
 }
 
@@ -35,7 +37,11 @@ interface RegistryStub {
  */
 async function startRegistryStub(
     version: { status?: number; body?: unknown } = {},
-    publishResponse: { status?: number; body?: unknown } = {}
+    publishResponse: {
+        status?: number;
+        body?: unknown;
+        attempts?: Array<{ status: number; body: unknown }>;
+    } = {}
 ): Promise<RegistryStub> {
     const publishRequests: RecordedRequest[] = [];
     const versionStatus = version.status ?? 200;
@@ -47,6 +53,10 @@ async function startRegistryStub(
         version: '1.0.0',
         targetPlatform: 'universal'
     };
+    // Answers the nth publish with the nth entry, the last one repeating, so a first attempt can be
+    // refused and the retry accepted.
+    const publishAttempts = publishResponse.attempts;
+    const state = { tokenRequests: 0 };
     const server = http.createServer((req, res) => {
         const url = new URL(req.url ?? '/', 'http://127.0.0.1');
         req.on('data', () => undefined);
@@ -54,10 +64,15 @@ async function startRegistryStub(
             if (url.pathname === '/api/version') {
                 res.writeHead(versionStatus, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify(versionBody));
+            } else if (url.pathname === '/api/-/trusted-publishing/token') {
+                state.tokenRequests++;
+                res.writeHead(201, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ value: `token-${state.tokenRequests}` }));
             } else {
+                const attempt = publishAttempts?.[Math.min(publishRequests.length, publishAttempts.length - 1)];
                 publishRequests.push({ pathname: url.pathname, query: url.searchParams });
-                res.writeHead(publishStatus, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify(publishBody));
+                res.writeHead(attempt?.status ?? publishStatus, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(attempt?.body ?? publishBody));
             }
         });
     });
@@ -66,6 +81,9 @@ async function startRegistryStub(
     return {
         url: `http://127.0.0.1:${port}`,
         publishRequests,
+        get tokenRequests() {
+            return state.tokenRequests;
+        },
         close: () => new Promise<void>(resolve => server.close(() => resolve()))
     };
 }
@@ -88,11 +106,28 @@ describe('publish', () => {
 
     async function givenRegistry(
         version?: { status?: number; body?: unknown },
-        publishResponse?: { status?: number; body?: unknown }
+        publishResponse?: {
+            status?: number;
+            body?: unknown;
+            attempts?: Array<{ status: number; body: unknown }>;
+        }
     ): Promise<RegistryStub> {
         const stub = await startRegistryStub(version, publishResponse);
         stubs.push(stub);
         return stub;
+    }
+
+    // A real .vsix, because trusted publishing reads the manifest to learn which extension to ask a
+    // token for. The publisher/name must differ per test: the token cache is module level and lives
+    // for the process.
+    async function givenVsixFile(publisher: string, name: string): Promise<string> {
+        const zip = await buildZip({
+            'extension/package.json': Buffer.from(JSON.stringify({ publisher, name, version: '1.0.0' }))
+        });
+        const file = path.join(os.tmpdir(), `ovsx-publish-test-${Math.random().toString(36).slice(2)}.vsix`);
+        fs.writeFileSync(file, zip);
+        tmpFiles.push(file);
+        return file;
     }
 
     function givenExtensionFile(sizeInBytes: number): string {
@@ -143,5 +178,72 @@ describe('publish', () => {
 
         expect(result.status).toBe('fulfilled');
         expect(registry.publishRequests).toHaveLength(1);
+    });
+
+    // The trusted publishing token is short-lived and shared by every target platform of a release, so
+    // a slow fan-out can outlive it and be refused partway through. Failing a release that was
+    // authorised, over an expiry, would be the wrong call.
+    it('asks for a new token and retries when the registry refuses the one it was publishing with', async () => {
+        const registry = await givenRegistry(
+            {},
+            {
+                attempts: [
+                    { status: 401, body: { error: 'Invalid access token.' } },
+                    { status: 200, body: { namespace: 'foo', name: 'retried', version: '1.0.0', targetPlatform: 'universal' } }
+                ]
+            }
+        );
+        const extensionFile = await givenVsixFile('foo', 'retried');
+
+        const [result] = await publish({
+            extensionFile,
+            registryUrl: registry.url,
+            trustedPublishing: true,
+            idToken: 'an-id-token'
+        });
+
+        expect(result.status).toBe('fulfilled');
+        expect(registry.publishRequests).toHaveLength(2);
+        // the retry carries the replacement, not the token that was just refused
+        expect(registry.publishRequests[0].query.get('token')).toBe('token-1');
+        expect(registry.publishRequests[1].query.get('token')).toBe('token-2');
+        expect(registry.tokenRequests).toBe(2);
+    });
+
+    // Nothing the CLI can do makes a token the user supplied valid. An ID token is offered here as
+    // well, so that only the token's origin - not the absence of a CI identity to exchange - can be
+    // what stops the retry.
+    it('does not retry a refusal when the token came from the user', async () => {
+        const registry = await givenRegistry({}, { status: 401, body: { error: 'Invalid access token.' } });
+        const extensionFile = await givenVsixFile('foo', 'user-pat');
+
+        const [result] = await publish({
+            extensionFile,
+            pat: 'the.pat',
+            registryUrl: registry.url,
+            idToken: 'an-id-token'
+        });
+
+        expect(result.status).toBe('rejected');
+        expect(registry.publishRequests).toHaveLength(1);
+        expect(registry.tokenRequests).toBe(0);
+    });
+
+    // A second refusal is not an expiry: the token is not the problem, and retrying forever would hide
+    // whatever is.
+    it('gives up when the replacement token is refused too', async () => {
+        const registry = await givenRegistry({}, { status: 401, body: { error: 'Invalid access token.' } });
+        const extensionFile = await givenVsixFile('foo', 'refused-twice');
+
+        const [result] = await publish({
+            extensionFile,
+            registryUrl: registry.url,
+            trustedPublishing: true,
+            idToken: 'an-id-token'
+        });
+
+        expect(result.status).toBe('rejected');
+        expect(registry.publishRequests).toHaveLength(2);
+        expect(registry.tokenRequests).toBe(2);
     });
 });

--- a/cli/test/unit/support/zip.ts
+++ b/cli/test/unit/support/zip.ts
@@ -1,0 +1,32 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import * as yazl from 'yazl';
+
+/**
+ * Builds a zip in memory from entry name to content, for the specs that need a real package to hand
+ * to code that reads one - a `.vsix` is a zip with an `extension/package.json` in it.
+ */
+export function buildZip(entries: Record<string, Buffer>): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const zipFile = new yazl.ZipFile();
+        for (const [name, content] of Object.entries(entries)) {
+            zipFile.addBuffer(content, name);
+        }
+        const chunks: Buffer[] = [];
+        zipFile.outputStream.on('data', chunk => chunks.push(chunk));
+        zipFile.outputStream.on('end', () => resolve(Buffer.concat(chunks)));
+        zipFile.outputStream.on('error', reject);
+        zipFile.end();
+    });
+}

--- a/cli/test/unit/trusted-publishing.spec.ts
+++ b/cli/test/unit/trusted-publishing.spec.ts
@@ -15,7 +15,7 @@ import * as http from 'http';
 import { AddressInfo } from 'net';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Registry } from '../../src/registry';
-import { getTrustedPublishingToken } from '../../src/trusted-publishing';
+import { getTrustedPublishingToken, refreshTrustedPublishingToken } from '../../src/trusted-publishing';
 
 interface FakeRegistry {
     url: string;
@@ -84,5 +84,64 @@ describe('trusted publishing token exchange', () => {
         ).rejects.toThrow('No trusted publisher matches the presented token.');
 
         expect(registry.exchanges).toBe(1);
+    });
+
+    // The issued token is short-lived and shared by every target platform of a release, so a slow
+    // fan-out can outlive it. Refusing it must be answerable with a new one rather than failing a
+    // release that was authorised.
+    it('exchanges again when the token it was publishing with is refused', async () => {
+        const registry = await startRegistry(
+            { status: 201, body: { value: 'first-token' } },
+            { status: 201, body: { value: 'second-token' } }
+        );
+        const options = { idToken: 'an-id-token' };
+        const client = new Registry({ registryUrl: registry.url });
+
+        const first = await getTrustedPublishingToken(client, 'expiring', 'ext', options);
+        const second = await refreshTrustedPublishingToken(client, 'expiring', 'ext', options, first);
+
+        expect(first).toBe('first-token');
+        expect(second).toBe('second-token');
+        expect(registry.exchanges).toBe(2);
+        // and the replacement is what every later target platform picks up
+        expect(await getTrustedPublishingToken(client, 'expiring', 'ext', options)).toBe('second-token');
+    });
+
+    // Target platforms publish concurrently, so they hit one expiry together. Exchanging per refusal
+    // would ask the identity provider once per target and hand out tokens the others discard.
+    it('exchanges once when every target platform is refused at the same time', async () => {
+        const registry = await startRegistry(
+            { status: 201, body: { value: 'first-token' } },
+            { status: 201, body: { value: 'second-token' } }
+        );
+        const options = { idToken: 'an-id-token' };
+        const client = new Registry({ registryUrl: registry.url });
+
+        const stale = await getTrustedPublishingToken(client, 'concurrent', 'ext', options);
+        const refreshed = await Promise.all(
+            [0, 1, 2, 3].map(() =>
+                refreshTrustedPublishingToken(client, 'concurrent', 'ext', options, stale))
+        );
+
+        expect(refreshed).toEqual(['second-token', 'second-token', 'second-token', 'second-token']);
+        expect(registry.exchanges).toBe(2);
+    });
+
+    // A token already replaced is not stale twice: the caller that lost the race takes what is cached.
+    it('does not exchange again for a token that was already replaced', async () => {
+        const registry = await startRegistry(
+            { status: 201, body: { value: 'first-token' } },
+            { status: 201, body: { value: 'second-token' } },
+            { status: 201, body: { value: 'third-token' } }
+        );
+        const options = { idToken: 'an-id-token' };
+        const client = new Registry({ registryUrl: registry.url });
+
+        const stale = await getTrustedPublishingToken(client, 'replaced', 'ext', options);
+        await refreshTrustedPublishingToken(client, 'replaced', 'ext', options, stale);
+        const again = await refreshTrustedPublishingToken(client, 'replaced', 'ext', options, stale);
+
+        expect(again).toBe('second-token');
+        expect(registry.exchanges).toBe(2);
     });
 });

--- a/cli/test/unit/verify-signature.spec.ts
+++ b/cli/test/unit/verify-signature.spec.ts
@@ -15,23 +15,10 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import * as yazl from 'yazl';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { verifySignature } from '../../src/verify-signature';
+import { buildZip } from './support/zip';
 
-function buildZip(entries: Record<string, Buffer>): Promise<Buffer> {
-    return new Promise((resolve, reject) => {
-        const zipFile = new yazl.ZipFile();
-        for (const [name, content] of Object.entries(entries)) {
-            zipFile.addBuffer(content, name);
-        }
-        const chunks: Buffer[] = [];
-        zipFile.outputStream.on('data', chunk => chunks.push(chunk));
-        zipFile.outputStream.on('end', () => resolve(Buffer.concat(chunks)));
-        zipFile.outputStream.on('error', reject);
-        zipFile.end();
-    });
-}
 
 function sha256Base64(content: Buffer): string {
     return crypto.createHash('sha256').update(content).digest('base64');

--- a/cli/test/unit/verify.spec.ts
+++ b/cli/test/unit/verify.spec.ts
@@ -16,10 +16,10 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
-import * as yazl from 'yazl';
 import { AddressInfo } from 'net';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { verify } from '../../src/verify';
+import { buildZip } from './support/zip';
 
 interface RegistryStub {
     url: string;
@@ -29,19 +29,6 @@ interface RegistryStub {
 /**
  * Builds a zip archive in memory from a set of entry name -> content pairs.
  */
-function buildZip(entries: Record<string, Buffer>): Promise<Buffer> {
-    return new Promise((resolve, reject) => {
-        const zipFile = new yazl.ZipFile();
-        for (const [name, content] of Object.entries(entries)) {
-            zipFile.addBuffer(content, name);
-        }
-        const chunks: Buffer[] = [];
-        zipFile.outputStream.on('data', chunk => chunks.push(chunk));
-        zipFile.outputStream.on('end', () => resolve(Buffer.concat(chunks)));
-        zipFile.outputStream.on('error', reject);
-        zipFile.end();
-    });
-}
 
 /**
  * Stands in for the registry's extension metadata endpoint plus the signature/public-key file

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
@@ -310,7 +310,7 @@ public class AccessTokenService {
     /**
      * Retires every token that has expired.
      * <p>
-     * An ephemeral token is deleted rather than deactivated, the same as when a one-time one is used, when
+     * An ephemeral token is deleted rather than deactivated, the same as when a one-time token is used, when
      * a trusted publisher registration goes, or when an extension is purged: it can never be used again,
      * nothing reads the row afterwards, and one is minted per exchange. Keeping the expired ones while
      * deleting the used ones would retain exactly the rows nobody has a question about.

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
@@ -70,9 +70,9 @@ public class AccessTokenService {
     private static final Base64.Encoder TOKEN_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
     /** The token types that are retired by deleting the row rather than deactivating it. */
-    private static final List<PersonalAccessTokenType> ONE_TIME_TOKEN_TYPES = Arrays
+    private static final List<PersonalAccessTokenType> EPHEMERAL_TOKEN_TYPES = Arrays
             .stream(PersonalAccessTokenType.values())
-            .filter(PersonalAccessTokenType::isOneTime)
+            .filter(PersonalAccessTokenType::isEphemeral)
             .toList();
 
     private static final int TOKEN_VERSION_0 = 0;
@@ -189,7 +189,7 @@ public class AccessTokenService {
         var json = token.toAccessTokenJson();
         // Include the token raw value after creation so the user can copy it
         json.setValue(rawValue);
-        if (!type.isOneTime()) {
+        if (!type.isEphemeral()) {
             json.setDeleteTokenUrl(
                     createApiUrl(UrlUtil.getBaseUrl(), "user", "token", "delete", Long.toString(token.getId())));
         }
@@ -263,7 +263,7 @@ public class AccessTokenService {
         // findByExpiresTimestampLessThanEqual...: a token expiring at exactly `now` is expired.
         LocalDateTime now = TimeUtil.getCurrentUTC();
         if (token.getExpiresTimestamp() != null && !token.getExpiresTimestamp().isAfter(now)) {
-            if (token.getType().isOneTime()) {
+            if (token.getType().isEphemeral()) {
                 entityManager.remove(token);
             } else {
                 token.setActive(false);
@@ -273,7 +273,7 @@ public class AccessTokenService {
         // Deleting a registration takes its tokens with it, so this should not be reachable; kept as a
         // guard, because a TPT that lost its registration may only ever publish an extension it can no
         // longer be checked against. Removed rather than deactivated: it can never become valid again,
-        // and nothing reads the row afterwards - the same reasoning as for a one-time token below.
+        // and nothing reads the row afterwards - the same reasoning as for any ephemeral token.
         if (token.getType() == PersonalAccessTokenType.TPT && token.getTrustedPublisher() == null) {
             entityManager.remove(token);
             return null;
@@ -288,6 +288,9 @@ public class AccessTokenService {
             token.setAccessedTimestamp(now);
             if (token.getType().isOneTime()) {
                 // Deleted outright rather than deactivated: nothing reads the row again afterwards.
+                // A trusted publishing token is deliberately not one of these - it stays usable until it
+                // expires, so that the target platforms of one release can share the token they were
+                // issued rather than exchanging the CI identity again for each of them.
                 entityManager.remove(token);
             }
         }
@@ -307,10 +310,10 @@ public class AccessTokenService {
     /**
      * Retires every token that has expired.
      * <p>
-     * A one-time token is deleted rather than deactivated, the same as when one is used, when its trusted
-     * publisher registration goes, or when its extension is purged: it can never be used again, nothing
-     * reads the row afterwards, and one is minted per exchange. Keeping the unused ones while deleting the
-     * used ones would retain exactly the rows nobody has a question about.
+     * An ephemeral token is deleted rather than deactivated, the same as when a one-time one is used, when
+     * a trusted publisher registration goes, or when an extension is purged: it can never be used again,
+     * nothing reads the row afterwards, and one is minted per exchange. Keeping the expired ones while
+     * deleting the used ones would retain exactly the rows nobody has a question about.
      * <p>
      * Long-lived tokens stay as deactivated rows: a user is shown their own expired tokens, and the
      * expiry notification mails read them.
@@ -318,7 +321,7 @@ public class AccessTokenService {
     @Transactional
     public int expireAccessTokens() {
         var now = TimeUtil.getCurrentUTC();
-        var deletedAccessTokens = repositories.deleteExpiredPersonalAccessTokens(now, ONE_TIME_TOKEN_TYPES);
+        var deletedAccessTokens = repositories.deleteExpiredPersonalAccessTokens(now, EPHEMERAL_TOKEN_TYPES);
         var expiredAccessTokens = repositories.expirePersonalAccessTokens(now);
         if (config.isSendExpiredMailEnabled()) {
             for (var token : expiredAccessTokens) {

--- a/server/src/main/java/org/eclipse/openvsx/entities/PersonalAccessTokenType.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/PersonalAccessTokenType.java
@@ -19,25 +19,29 @@ public enum PersonalAccessTokenType {
     /**
      * Long-lived personal access token (classic).
      */
-    LLT("at_", false, true),
+    LLT("at_", false, false, true),
     /**
      * One time usable general personal access token.
      * Legacy: was used until 1.2.0; but is not anymore.
      */
     @Deprecated
-    OTT("ot_", true, false),
+    OTT("ot_", true, true, false),
     /**
-     * One time usable, trusted publishing issued access token.
+     * Trusted publishing issued access token. Short-lived and scoped to a single extension, but usable
+     * more than once within its lifetime: a release commonly publishes one version per target platform,
+     * and those are separate publish requests that share the one token the exchange issued.
      */
-    TPT("tp_", true, false);
+    TPT("tp_", false, true, false);
 
     private final String tokenMarker;
     private final boolean oneTime;
+    private final boolean ephemeral;
     private final boolean notify;
 
-    PersonalAccessTokenType(String tokenMarker, boolean oneTime, boolean notify) {
+    PersonalAccessTokenType(String tokenMarker, boolean oneTime, boolean ephemeral, boolean notify) {
         this.tokenMarker = tokenMarker;
         this.oneTime = oneTime;
+        this.ephemeral = ephemeral;
         this.notify = notify;
     }
 
@@ -50,8 +54,23 @@ public enum PersonalAccessTokenType {
         return tokenMarker;
     }
 
+    /**
+     * Whether using the token consumes it, so that it authenticates exactly one request.
+     */
     public boolean isOneTime() {
         return oneTime;
+    }
+
+    /**
+     * Whether the token is issued to a machine rather than managed by a user: it is deleted instead of
+     * being left as a deactivated row once it can no longer be used, and its owner is never offered a
+     * link to revoke it, because nothing shows it to them in the first place.
+     * <p>
+     * Every one-time token is ephemeral, but not every ephemeral one is single-use - a trusted
+     * publishing token may publish several times before it expires.
+     */
+    public boolean isEphemeral() {
+        return ephemeral;
     }
 
     public boolean isNotify() {

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -250,10 +250,13 @@ public class PublishExtensionVersionHandler {
         extVersion.setPublishedBy(au.userData());
         if (au instanceof AccessTokenAuthentication ata) {
             extVersion.setPublishedWithTt(ata.type());
-            // A one-time token is deleted as it is used, which happens before this row is written, so
-            // the reference could never be satisfied and the foreign key rejects the insert outright.
-            // What identifies such a publish is the workflow it came from, held in published_provenance.
-            if (!ata.type().isOneTime()) {
+            // An ephemeral token's row does not outlive its use: a one-time one is deleted before this
+            // row is even written, and a trusted publishing one is deleted the moment it expires, which
+            // for a slow publish can fall between authenticating the request and inserting this row.
+            // Either way the foreign key would reject the insert, so the reference is only recorded for
+            // tokens that stay. What identifies a trusted publish is the workflow it came from, held in
+            // published_provenance.
+            if (!ata.type().isEphemeral()) {
                 extVersion.setPublishedWithId(ata.tokenId());
             }
             extVersion.setPublishedProvenance(ata.claims());

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -250,8 +250,8 @@ public class PublishExtensionVersionHandler {
         extVersion.setPublishedBy(au.userData());
         if (au instanceof AccessTokenAuthentication ata) {
             extVersion.setPublishedWithTt(ata.type());
-            // An ephemeral token's row does not outlive its use: a one-time one is deleted before this
-            // row is even written, and a trusted publishing one is deleted the moment it expires, which
+            // An ephemeral token's row does not outlive its use: a one-time token is deleted before this
+            // row is even written, and a trusted publishing token is deleted the moment it expires, which
             // for a slow publish can fall between authenticating the request and inserting this row.
             // Either way the foreign key would reject the insert, so the reference is only recorded for
             // tokens that stay. What identifies a trusted publish is the workflow it came from, held in

--- a/server/src/main/java/org/eclipse/openvsx/repositories/PersonalAccessTokenRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/PersonalAccessTokenRepository.java
@@ -63,7 +63,7 @@ public interface PersonalAccessTokenRepository extends Repository<PersonalAccess
 
     /**
      * Deletes the expired tokens of the given types outright. An expired machine-issued token can never
-     * be used again, and nothing reads the row afterwards - the same reason using a one-time one deletes
+     * be used again, and nothing reads the row afterwards - the same reason using a one-time token deletes
      * it.
      */
     @Modifying

--- a/server/src/main/java/org/eclipse/openvsx/repositories/PersonalAccessTokenRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/PersonalAccessTokenRepository.java
@@ -62,8 +62,9 @@ public interface PersonalAccessTokenRepository extends Repository<PersonalAccess
     List<PersonalAccessToken> expireAccessTokens(LocalDateTime timestamp);
 
     /**
-     * Deletes the expired tokens of the given types outright. A one-time token that expired unused can
-     * never be used, and nothing reads the row afterwards - the same reason using one deletes it.
+     * Deletes the expired tokens of the given types outright. An expired machine-issued token can never
+     * be used again, and nothing reads the row afterwards - the same reason using a one-time one deletes
+     * it.
      */
     @Modifying
     @Query(

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenConcurrentWriteTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenConcurrentWriteTest.java
@@ -93,15 +93,15 @@ class AccessTokenConcurrentWriteTest extends AbstractPostgresContainerTest {
     // Using a one-time token deletes it, so keeping the ones that expired unused would retain exactly the
     // rows nobody has a question about - and one is minted per trusted publishing exchange.
     @Test
-    void expiryDeletesAOneTimeTokenAndOnlyDeactivatesALongLivedOne() {
+    void expiryDeletesAnEphemeralTokenAndOnlyDeactivatesALongLivedOne() {
         var expired = TimeUtil.getCurrentUTC().minusMinutes(1);
-        var oneTime = persistToken("expiry-tpt", PersonalAccessTokenType.TPT, 1, expired);
+        var ephemeral = persistToken("expiry-tpt", PersonalAccessTokenType.TPT, 1, expired);
         var longLived = persistToken("expiry-llt", PersonalAccessTokenType.LLT, 1, expired);
 
         new TransactionTemplate(txManager).executeWithoutResult(status -> accessTokens.expireAccessTokens());
 
         new TransactionTemplate(txManager).executeWithoutResult(status -> {
-            assertThat(em.find(PersonalAccessToken.class, oneTime)).isNull();
+            assertThat(em.find(PersonalAccessToken.class, ephemeral)).isNull();
             var kept = em.find(PersonalAccessToken.class, longLived);
             // a user is shown their own expired tokens, and the notification mails read them
             assertThat(kept).isNotNull();
@@ -109,7 +109,7 @@ class AccessTokenConcurrentWriteTest extends AbstractPostgresContainerTest {
         });
 
         cleanUp(longLived);
-        // the one-time token's own row is gone, but its user is not
+        // the ephemeral token's own row is gone, but its user is not
         cleanUpUser("expiry-tpt-user");
     }
 
@@ -140,7 +140,8 @@ class AccessTokenConcurrentWriteTest extends AbstractPostgresContainerTest {
     }
 
     // The link from a published artifact back to the workflow run is most of what trusted publishing buys
-    // over a token pasted into CI, and the token that carried it is deleted the moment it is used.
+    // over a token pasted into CI, and the token that carried it is deleted as soon as it expires - which
+    // is why the claims are copied onto the version rather than reached through the token.
     @Test
     void aVersionKeepsItsTrustedPublishingProvenanceAfterTheTokenIsGone() {
         var claims = Map.of(

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenConcurrentWriteTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenConcurrentWriteTest.java
@@ -90,8 +90,10 @@ class AccessTokenConcurrentWriteTest extends AbstractPostgresContainerTest {
         cleanUp(tokenId);
     }
 
-    // Using a one-time token deletes it, so keeping the ones that expired unused would retain exactly the
-    // rows nobody has a question about - and one is minted per trusted publishing exchange.
+    // A trusted publishing token is reusable within its lifetime but never past it, and nothing shows it
+    // to its owner, so there is no expired row for anyone to read - unlike a long-lived token, whose
+    // expired rows a user is shown and the notification mails read. One is minted per exchange, so keeping
+    // them would retain exactly the rows nobody has a question about.
     @Test
     void expiryDeletesAnEphemeralTokenAndOnlyDeactivatesALongLivedOne() {
         var expired = TimeUtil.getCurrentUTC().minusMinutes(1);

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
@@ -39,8 +39,10 @@ import org.eclipse.openvsx.mail.MailService;
 import org.eclipse.openvsx.repositories.RepositoryService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -207,5 +209,94 @@ class AccessTokenServiceTest {
         // carried to the publish that uses this token, which copies them onto the version
         assertThat(persisted.getValue().getClaims()).containsEntry("repository_id", "74");
         assertThat(json.getValue()).isNotNull();
+    }
+
+    private PersonalAccessToken trustedPublishingToken(UserData user) {
+        var namespace = new Namespace();
+        namespace.setName("foo");
+        var extension = new Extension();
+        extension.setName("bar");
+        extension.setNamespace(namespace);
+        var trustedPublisher = new TrustedPublisher();
+        trustedPublisher.setExtension(extension);
+        trustedPublisher.setCreatedBy(user);
+        trustedPublisher.setRegistration(Map.of());
+
+        var token = new PersonalAccessToken();
+        token.setActive(true);
+        token.setType(PersonalAccessTokenType.TPT);
+        token.setVersion(1);
+        token.setUser(user);
+        token.setTrustedPublisher(trustedPublisher);
+        token.setScopeExtension(extension);
+        return token;
+    }
+
+    // A release commonly publishes one version per target platform, and each is its own publish request.
+    // The CLI exchanges the CI identity once and shares the token across them (cli/src/trusted-publishing.ts
+    // caches it per extension), so consuming it on first use failed every target but one - and since the
+    // CLI publishes them concurrently, which ones failed was down to timing.
+    @Test
+    void keepsATrustedPublishingTokenUsableForEveryTargetPlatformOfARelease() {
+        var user = new UserData();
+        var token = trustedPublishingToken(user);
+        when(repositories.findPersonalAccessToken(anyString())).thenReturn(token);
+
+        for (var i = 0; i < 3; i++) {
+            var tau = accessTokenService
+                    .useAccessToken("tok", new AccessTokenAction.PublishVersion("foo", "bar"));
+
+            assertThat(tau).isNotNull();
+            assertThat(tau.type()).isEqualTo(PersonalAccessTokenType.TPT);
+        }
+
+        verify(entityManager, never()).remove(any());
+    }
+
+    // The deprecated one-time type keeps its meaning: the split of one-time from ephemeral was to let a
+    // trusted publishing token outlive a single request, not to make every machine token reusable.
+    @Test
+    void stillConsumesAOneTimeTokenOnFirstUse() {
+        var token = activeUnrestrictedToken();
+        token.setType(PersonalAccessTokenType.OTT);
+        token.setUser(new UserData());
+        when(repositories.findPersonalAccessToken(anyString())).thenReturn(token);
+
+        var tau = accessTokenService.useAccessToken("tok", new AccessTokenAction.PublishVersion("foo", "bar"));
+
+        assertThat(tau).isNotNull();
+        verify(entityManager).remove(token);
+    }
+
+    // Reusable until it expires, but not past it - and the row goes rather than lingering deactivated,
+    // because it carries the OIDC claims of the workflow that obtained it.
+    @Test
+    void deletesAnExpiredTrustedPublishingTokenRatherThanDeactivatingIt() {
+        var token = trustedPublishingToken(new UserData());
+        token.setExpiresTimestamp(LocalDateTime.now(ZoneId.of("UTC")).minusMinutes(1));
+        when(repositories.findPersonalAccessToken(anyString())).thenReturn(token);
+
+        var tau = accessTokenService.useAccessToken("tok", new AccessTokenAction.PublishVersion("foo", "bar"));
+
+        assertThat(tau).isNull();
+        verify(entityManager).remove(token);
+        assertThat(token.isActive()).isTrue();
+    }
+
+    // Nothing ever shows a trusted publishing token to its owner, so there is no page for a revoke link
+    // to sit on. Being reusable does not make it user-managed.
+    @Test
+    void offersNoRevocationLinkForATrustedPublishingToken() {
+        var user = new UserData();
+        var trustedPublisher = trustedPublishingToken(user).getTrustedPublisher();
+        when(config.getPrefix()).thenReturn("ovsx");
+
+        var json = accessTokenService.createTrustedPublishingAccessToken(
+                trustedPublisher,
+                "Trusted publishing (github)",
+                Duration.ofMinutes(5),
+                Map.of());
+
+        assertThat(json.getDeleteTokenUrl()).isNull();
     }
 }


### PR DESCRIPTION
A release commonly publishes one version per target platform, and each is its own publish request. Trusted publishing could not do that: the token was consumed on first use, so only one target could be published per exchange.

## What was happening

The CLI already does the right thing. `publish()` (`cli/src/publish.ts`) fans out over `packagePath[] × targets[]` through `Promise.allSettled`, and `getTrustedPublishingToken` caches one token per `namespace.extension`:

```ts
// publishing fans out over targets and package paths, but one token is enough per extension
const key = `${namespace}.${extension}`;
```

The registry rejected that reuse. `AccessTokenService.useAccessToken` deletes a one-time token on use, in a `REQUIRES_NEW` transaction that commits immediately, so the next target got `401 Invalid access token.`

Because the targets publish **concurrently**, this was never a clean failure: several could read the token before the first delete committed, so an arbitrary subset succeeded. A green CI run did not mean it worked.

Authorization was never the obstacle — the token is `ExtensionScoped`, matching on namespace and extension name only, so it was already entitled to every version and target of its extension.

## Server: splitting one flag into two

`PersonalAccessTokenType.isOneTime()` was doing two unrelated jobs. Only `AccessTokenService:289` (consume on use) and the `published_with_id` guard were about single use; the delete-token URL, the expired-token branch, and the type set feeding `expireAccessTokens` were all about being machine-issued.

| | oneTime | ephemeral | notify |
|---|---|---|---|
| `LLT` | false | false | true |
| `OTT` | true | true | false |
| `TPT` | **false** | true | false |

- `oneTime` — using the token consumes it
- `ephemeral` — deleted rather than left as a deactivated row, and never offered a revocation link, because nothing ever shows it to its owner

So a TPT now publishes every target of a release until it expires, while still leaving no row behind carrying the workflow's OIDC claims. **No migration** — the type is stored as its enum name.

### published_with_id moves to !isEphemeral

Left on `isOneTime`, the reference would start being recorded for TPT again — and that row is deleted the moment it expires, which for a slow publish can fall between authenticating the request and inserting the version. That would have reintroduced the FK violation from #2122 by a different route. What identifies a trusted publish stays `published_provenance`.

## CLI: retrying a refused token

The issued token is short-lived (5 minutes by default) and shared by every target, so a wide fan-out of large packages can outlive it and be refused partway through. Failing a release that was authorised, over an expiry, is the wrong call — so a 401 now triggers one re-exchange and retry.

Targets are refused together, so `refreshTrustedPublishingToken` replaces the cache entry only for the caller still holding the stale token; the rest await that exchange. One expiry costs one exchange however many targets hit it. A token supplied with `--pat` is never retried, since nothing the CLI can do makes it valid, and a second refusal is not an expiry.

## Tests

Server — four in `AccessTokenServiceTest`: multi-use, OTT still consumed, expired TPT deleted rather than deactivated, no revocation link. Fail-first checked: restoring `TPT("tp_", true, ...)` reddens exactly the multi-use test.

CLI — three in `trusted-publishing.spec.ts` (re-exchange, one exchange for concurrent refusals, no re-exchange for an already-replaced token) and three in `publish.spec.ts` (retry on 401, no retry for a user PAT, give up on a second refusal). All fail-first checked; the user-PAT test supplies an ID token as well, so only the token's origin can be what stops the retry.

`buildZip` was duplicated verbatim in two specs and this needed a third copy, so it moved to `test/unit/support/zip.ts` and both existing call sites now use it.

Also corrected `expiryDeletesAOneTimeTokenAndOnlyDeactivatesALongLivedOne` and a comment claiming a TPT "is deleted the moment it is used", which is no longer true.

Server suite 1137 passing; CLI suite 55 passing; `yarn lint` clean.

## Not included

`useAccessToken` returns bare `null` for seven distinct reasons, so the `401 Invalid access token.` gives no hint whether a token was consumed, expired, or simply wrong. Making it say which means changing its signature across all seven call sites in an auth path — worth doing separately, not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)