### PR TITLE
feat: limit TPT tokens to publishing only

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenScope.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenScope.java
@@ -18,6 +18,8 @@ import java.util.Objects;
 import org.eclipse.openvsx.entities.Extension;
 import org.eclipse.openvsx.entities.Namespace;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Access token scope.
  */
@@ -31,6 +33,7 @@ public sealed interface AccessTokenScope {
      * Concatenates scopes into new scope, that is enforcing both this and provided scope applies.
      */
     default AccessTokenScope and(AccessTokenScope scope) {
+        requireNonNull(scope);
         return new AndScoped(this, scope);
     }
 
@@ -40,6 +43,7 @@ public sealed interface AccessTokenScope {
     record Unrestricted() implements AccessTokenScope {
         @Override
         public boolean allowsAction(AccessTokenAction accessTokenAction) {
+            requireNonNull(accessTokenAction);
             return true;
         }
     }
@@ -51,6 +55,7 @@ public sealed interface AccessTokenScope {
     record NamespaceScoped(Namespace namespace) implements AccessTokenScope {
         @Override
         public boolean allowsAction(AccessTokenAction accessTokenAction) {
+            requireNonNull(accessTokenAction);
             return accessTokenAction.namespace().isPresent()
                     && Objects.equals(namespace.getName(), accessTokenAction.namespace().get());
         }
@@ -63,6 +68,7 @@ public sealed interface AccessTokenScope {
     record ExtensionScoped(Extension extension) implements AccessTokenScope {
         @Override
         public boolean allowsAction(AccessTokenAction accessTokenAction) {
+            requireNonNull(accessTokenAction);
             return accessTokenAction.namespace().isPresent() && accessTokenAction.extension().isPresent() &&
                     Objects.equals(extension.getNamespace().getName(), accessTokenAction.namespace().get()) &&
                     Objects.equals(extension.getName(), accessTokenAction.extension().get());
@@ -75,7 +81,8 @@ public sealed interface AccessTokenScope {
     record ActionScoped(Class<?>... allowedActions) implements AccessTokenScope {
         @Override
         public boolean allowsAction(AccessTokenAction accessTokenAction) {
-            return Arrays.stream(allowedActions).anyMatch(c -> c == accessTokenAction.getClass());
+            requireNonNull(accessTokenAction);
+            return Arrays.stream(allowedActions).anyMatch(c -> c.isAssignableFrom(accessTokenAction.getClass()));
         }
     }
 
@@ -85,6 +92,7 @@ public sealed interface AccessTokenScope {
     record AndScoped(AccessTokenScope one, AccessTokenScope second) implements AccessTokenScope {
         @Override
         public boolean allowsAction(AccessTokenAction accessTokenAction) {
+            requireNonNull(accessTokenAction);
             return one.allowsAction(accessTokenAction) && second.allowsAction(accessTokenAction);
         }
     }

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenScope.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenScope.java
@@ -12,6 +12,7 @@
  *****************************************************************************/
 package org.eclipse.openvsx.accesstoken;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import org.eclipse.openvsx.entities.Extension;
@@ -25,6 +26,13 @@ public sealed interface AccessTokenScope {
      * Checks for scope applicability, and returns {@code true} if action is applicable to this scope.
      */
     boolean allowsAction(AccessTokenAction accessTokenAction);
+
+    /**
+     * Concatenates scopes into new scope, that is enforcing both this and provided scope applies.
+     */
+    default AccessTokenScope and(AccessTokenScope scope) {
+        return new AndScope(this, scope);
+    }
 
     /**
      * Unrestricted token scope; every action is applicable.
@@ -58,6 +66,26 @@ public sealed interface AccessTokenScope {
             return accessTokenAction.namespace().isPresent() && accessTokenAction.extension().isPresent() &&
                     Objects.equals(extension.getNamespace().getName(), accessTokenAction.namespace().get()) &&
                     Objects.equals(extension.getName(), accessTokenAction.extension().get());
+        }
+    }
+
+    /**
+     * Action type scope; allows only listed action types.
+     */
+    record ActionScoped(Class<?>... allowedActions) implements AccessTokenScope {
+        @Override
+        public boolean allowsAction(AccessTokenAction accessTokenAction) {
+            return Arrays.binarySearch(allowedActions, accessTokenAction.getClass()) >= 0;
+        }
+    }
+
+    /**
+     * Concatenates scopes with logical {@code AND}. Enforces both scopes are allowing action.
+     */
+    record AndScope(AccessTokenScope one, AccessTokenScope second) implements AccessTokenScope {
+        @Override
+        public boolean allowsAction(AccessTokenAction accessTokenAction) {
+            return one.allowsAction(accessTokenAction) && second.allowsAction(accessTokenAction);
         }
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenScope.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenScope.java
@@ -31,7 +31,7 @@ public sealed interface AccessTokenScope {
      * Concatenates scopes into new scope, that is enforcing both this and provided scope applies.
      */
     default AccessTokenScope and(AccessTokenScope scope) {
-        return new AndScope(this, scope);
+        return new AndScoped(this, scope);
     }
 
     /**
@@ -75,14 +75,14 @@ public sealed interface AccessTokenScope {
     record ActionScoped(Class<?>... allowedActions) implements AccessTokenScope {
         @Override
         public boolean allowsAction(AccessTokenAction accessTokenAction) {
-            return Arrays.binarySearch(allowedActions, accessTokenAction.getClass()) >= 0;
+            return Arrays.stream(allowedActions).anyMatch(c -> c == accessTokenAction.getClass());
         }
     }
 
     /**
      * Concatenates scopes with logical {@code AND}. Enforces both scopes are allowing action.
      */
-    record AndScope(AccessTokenScope one, AccessTokenScope second) implements AccessTokenScope {
+    record AndScoped(AccessTokenScope one, AccessTokenScope second) implements AccessTokenScope {
         @Override
         public boolean allowsAction(AccessTokenAction accessTokenAction) {
             return one.allowsAction(accessTokenAction) && second.allowsAction(accessTokenAction);

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
@@ -298,13 +298,18 @@ public class AccessTokenService {
     }
 
     private AccessTokenScope getScope(PersonalAccessToken token) {
+        AccessTokenScope scope;
         if (token.getScopeExtension() != null) {
-            return new AccessTokenScope.ExtensionScoped(token.getScopeExtension());
+            scope = new AccessTokenScope.ExtensionScoped(token.getScopeExtension());
         } else if (token.getScopeNamespace() != null) {
-            return new AccessTokenScope.NamespaceScoped(token.getScopeNamespace());
+            scope = new AccessTokenScope.NamespaceScoped(token.getScopeNamespace());
         } else {
-            return new AccessTokenScope.Unrestricted();
+            scope = new AccessTokenScope.Unrestricted();
         }
+        if (token.getType() == PersonalAccessTokenType.TPT) {
+            scope = scope.and(new AccessTokenScope.ActionScoped(AccessTokenAction.PublishVersion.class));
+        }
+        return scope;
     }
 
     /**

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
@@ -241,7 +241,10 @@ class AccessTokenServiceTest {
         var tau = accessTokenService
                 .useAccessToken("tok", new AccessTokenAction.DeleteVersion("foo", "bar"));
 
+        // is null; while token is valid, is not allowed for delete action
         assertThat(tau).isNull();
+        // was not "used"; TPT token was not deleted
+        verify(entityManager, never()).remove(any());
     }
 
     // A release commonly publishes one version per target platform, and each is its own publish request.

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
@@ -232,6 +232,18 @@ class AccessTokenServiceTest {
         return token;
     }
 
+    @Test
+    void refusesTrustedPublishingTokenForNonPublishing() {
+        var user = new UserData();
+        var token = trustedPublishingToken(user);
+        when(repositories.findPersonalAccessToken(anyString())).thenReturn(token);
+
+        var tau = accessTokenService
+                .useAccessToken("tok", new AccessTokenAction.DeleteVersion("foo", "bar"));
+
+        assertThat(tau).isNull();
+    }
+
     // A release commonly publishes one version per target platform, and each is its own publish request.
     // The CLI exchanges the CI identity once and shares the token across them (cli/src/trusted-publishing.ts
     // caches it per extension), so consuming it on first use failed every target but one - and since the


### PR DESCRIPTION
Changes:
* add new scopes: "actionType" scope that allows for given types of actions only, and "and" scope that basically does `a1 && a2` new scope instance
* access token service adds narrow (only publish) `actionType` scope to existing scope