### PR TITLE
feat: give download analytics its own time-series database

### DIFF
--- a/deploy/docker/configuration/application.yml
+++ b/deploy/docker/configuration/application.yml
@@ -23,6 +23,13 @@ spring:
     url: jdbc:postgresql://localhost:5432/openvsx
     username: openvsx
     password: openvsx
+  # Download analytics is disabled by default. When enabled it keeps its time-series schema in a
+  # separate database, migrated on its own and requiring the timescaledb extension:
+  #   ovsx.analytics.enabled: true
+  #   ovsx.analytics.datasource.url: jdbc:postgresql://localhost:5433/openvsx_timeseries
+  #   ovsx.analytics.datasource.username: openvsx
+  #   ovsx.analytics.datasource.password: openvsx
+  #   ovsx.analytics.datasource.maximum-pool-size: 5
   flyway:
     baseline-on-migrate: true
     baseline-version: 0.1.0

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -33,6 +33,13 @@ data:
         url: jdbc:postgresql://postgresql:5432/openvsx
         username: ${DB_USERNAME}
         password: ${DB_PASSWORD}
+      # Download analytics is disabled by default. When enabled it keeps its time-series schema in a
+      # separate database, migrated on its own and requiring the timescaledb extension:
+      #   ovsx.analytics.enabled: true
+      #   ovsx.analytics.datasource.url: jdbc:postgresql://postgresql-timeseries:5432/openvsx_timeseries
+      #   ovsx.analytics.datasource.username: ${DB_USERNAME}
+      #   ovsx.analytics.datasource.password: ${DB_PASSWORD}
+      #   ovsx.analytics.datasource.maximum-pool-size: 5
       flyway:
         baseline-on-migrate: true
         baseline-version: 0.1.0

--- a/deploy/openshift/application.yml
+++ b/deploy/openshift/application.yml
@@ -23,6 +23,13 @@ spring:
     url: jdbc:postgresql://postgresql:5432/openvsx
     username: openvsx
     password: openvsx
+  # Download analytics is disabled by default. When enabled it keeps its time-series schema in a
+  # separate database, migrated on its own and requiring the timescaledb extension:
+  #   ovsx.analytics.enabled: true
+  #   ovsx.analytics.datasource.url: jdbc:postgresql://postgresql-timeseries:5432/openvsx_timeseries
+  #   ovsx.analytics.datasource.username: openvsx
+  #   ovsx.analytics.datasource.password: openvsx
+  #   ovsx.analytics.datasource.maximum-pool-size: 5
   flyway:
     baseline-on-migrate: true
     baseline-version: 0.1.0

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1537,3 +1537,55 @@ The `Subject` header for the access token expired email. This email is sent to a
 | Compatibility | Since 0.33.0
 
 Name of the [Thymeleaf](https://www.thymeleaf.org) template to use for the access token expired email. Templates should be put into the `mail-templates` classpath directory.
+
+## Download Analytics
+
+Download analytics keeps its time-series data in a **separate** database from the registry, migrated on its own and requiring the [TimescaleDB](https://www.timescale.com) extension. Disabled by default; when disabled, none of its beans are created and the registry database is untouched.
+
+| Property      | `ovsx.analytics.enabled`
+|---------------|-------------------------
+| Type          | boolean
+| Default       | `false`
+| Compatibility | Unreleased
+
+Whether to enable download analytics. When `false`, the time-series datasource, its migrations and its jOOQ context are not created at all, and none of the settings below are read.
+
+| Property      | `ovsx.analytics.datasource.url`
+|---------------|-------------------------
+| Type          | string
+| Default       |
+| Compatibility | Unreleased
+
+JDBC URL of the time-series database, e.g. `jdbc:postgresql://localhost:5433/openvsx_timeseries`. Required when analytics are enabled: startup fails if it is not set, because reaching that point means analytics were asked for and a missing URL is a mistake rather than a way to opt out. It must not point at the registry database, whose schema is migrated separately and does not need the `timescaledb` extension.
+
+| Property      | `ovsx.analytics.datasource.username`
+|---------------|-------------------------
+| Type          | string
+| Default       |
+| Compatibility | Unreleased
+
+User name for the time-series database. Optional: when unset, nothing is passed to the pool and the driver resolves it its own way, from a URL parameter, `.pgpass` or IAM.
+
+| Property      | `ovsx.analytics.datasource.password`
+|---------------|-------------------------
+| Type          | string
+| Default       |
+| Compatibility | Unreleased
+
+Password for the time-series database. Optional, on the same terms as the user name above.
+
+| Property      | `ovsx.analytics.datasource.maximum-pool-size`
+|---------------|-------------------------
+| Type          | int
+| Default       | `5`
+| Compatibility | Unreleased
+
+Maximum size of the time-series connection pool. Must be at least 1. Enabling analytics gives a deployment a **second** pool, so size this against the time-series server's `max_connections` together with the registry pool rather than in isolation.
+
+| Property      | `ovsx.analytics.datasource.connection-timeout`
+|---------------|-------------------------
+| Type          | long
+| Default       | `2000`
+| Compatibility | Unreleased
+
+How long to wait for a connection from the time-series pool, in milliseconds. Deliberately far below Hikari's own 30 seconds: analytics writes happen on the download-serving path, so an unreachable time-series database has to fail fast enough for the caller to swallow the error rather than holding a request thread. Must be greater than 250ms — the validation timeout is derived at half this value with a 250ms floor, and Hikari rejects a validation timeout that is not below the connection timeout.

--- a/doc/development.md
+++ b/doc/development.md
@@ -30,6 +30,7 @@ To run the Open VSX registry in a development environment, you can use `docker c
  * Decide which profile(s) to run based on your needs. The [docker-compose.yml](../docker-compose.yml) file defines profiles for specific components:
    * `db`: Starts the PostgreSQL container.
    * `es`: Starts the Elasticsearch container.
+   * `analytics`: Starts the separate TimescaleDB container used by download analytics. Only needed when `ovsx.analytics.enabled` is set, which it is not by default.
    * `debug`: Starts the PostgreSQL and Elasticsearch containers, which suits running the OpenVSX server and web UI locally for easier debugging.
    * `backend`: Starts the OpenVSX server container (java).
    * `frontend`: Starts the web UI container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,33 @@ services:
       - db
       - debug
 
+  postgres-timeseries:
+    # download analytics only: PostgreSQL plus the timescaledb extension, kept apart from the
+    # registry database so the registry never needs the extension
+    image: timescale/timescaledb:2.17.2-pg16
+    environment:
+      - POSTGRES_USER=openvsx
+      - POSTGRES_PASSWORD=openvsx
+      - POSTGRES_DB=openvsx_timeseries
+    logging:
+      options:
+        max-size: 10m
+        max-file: "3"
+    ports:
+      - '5433:5432'
+    volumes:
+      - postgres-timeseries-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U openvsx -d openvsx_timeseries"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    # Its own profile, not `db` or `debug`: download analytics are off by default, so the ordinary
+    # local setup should not pay for a second database it will never connect to. Select `analytics`
+    # alongside the rest, and set ovsx.analytics.enabled, when working on them.
+    profiles:
+      - analytics
+
   elasticsearch:
     image: elasticsearch:9.2.8
     environment:
@@ -214,6 +241,9 @@ services:
       postgres:
         condition: service_healthy
         required: false
+      postgres-timeseries:
+        condition: service_healthy
+        required: false
       elasticsearch:
         condition: service_healthy
         required: false
@@ -302,3 +332,6 @@ services:
       "
     profiles:
       - minio
+
+volumes:
+  postgres-timeseries-data:

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -285,6 +285,14 @@ test {
     // observed as an OutOfMemoryError during unrelated context bootstrapping on CI.
     jvmArgs = ['--enable-native-access=ALL-UNNAMED', '-Xmx6144m', '-Xshare:off'] // due to https://github.com/netty/netty/issues/15161
     useJUnitPlatform()
+
+    // registry tests run on plain postgres, analytics tests on timescale/timescaledb; override
+    // either image with -Dovsx.test.postgres.image=... / -Dovsx.test.timeseries.image=...
+    ['ovsx.test.postgres.image', 'ovsx.test.timeseries.image'].each { property ->
+        if (System.getProperty(property) != null) {
+            systemProperty property, System.getProperty(property)
+        }
+    }
 }
 
 tasks.register('unitTests', Test) {

--- a/server/src/dev/resources/application.yml
+++ b/server/src/dev/resources/application.yml
@@ -157,6 +157,16 @@ ovsx:
 #      path-style-access: true
     local:
       directory: /tmp/ovsx
+  analytics:
+    # Off by default, matching every other deployment. Set this to true and start the `analytics`
+    # docker-compose profile together to work on download analytics locally; enabling it without
+    # that database reachable fails startup rather than degrading quietly.
+    enabled: false
+    # the postgres-timeseries service of docker-compose.yml
+    datasource:
+      url: jdbc:postgresql://localhost:5433/openvsx_timeseries
+      username: openvsx
+      password: openvsx
   access-token:
     prefix: dev_ovsx # use a token prefix that clearly indicates that it's for development; the kind of
                      # token (at_, tp_) is appended by the code, so no trailing separator here

--- a/server/src/main/java/org/eclipse/openvsx/analytics/timescale/TimeseriesDatabaseConfiguration.java
+++ b/server/src/main/java/org/eclipse/openvsx/analytics/timescale/TimeseriesDatabaseConfiguration.java
@@ -1,0 +1,148 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.analytics.timescale;
+
+import javax.sql.DataSource;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.annotation.PostConstruct;
+import org.apache.commons.lang3.StringUtils;
+import org.flywaydb.core.Flyway;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * The time-series database behind download analytics: its own PostgreSQL instance (with the
+ * timescaledb extension), its own connection pool, its own Flyway migration set and its own
+ * jOOQ context, all configured from {@code ovsx.analytics.datasource.*}. Nothing is created
+ * unless {@code ovsx.analytics.enabled=true}.
+ */
+@Configuration
+@ConditionalOnProperty(name = "ovsx.analytics.enabled", havingValue = "true")
+class TimeseriesDatabaseConfiguration {
+
+    private static final String DEFAULT_POOL_SIZE = "5";
+
+    // A download records its event on the request path, so an unreachable time-series database has
+    // to surface as a fast failure the caller can swallow. Hikari's 30 second default would hold a
+    // request thread for that long on every download until the outage ends.
+    private static final String DEFAULT_CONNECTION_TIMEOUT_MS = "2000";
+
+    // The derived validation timeout floors at this, and Hikari rejects a validation timeout that
+    // is not below the connection timeout, so the connection timeout has to exceed it.
+    private static final long VALIDATION_TIMEOUT_FLOOR_MS = 250L;
+
+    /** JDBC URL of the time-series database. Required whenever analytics are enabled. */
+    @Value("${ovsx.analytics.datasource.url:}")
+    String url;
+
+    /** User name for the time-series database. Optional: unset leaves it to the driver. */
+    @Value("${ovsx.analytics.datasource.username:}")
+    String username;
+
+    /** Password for the time-series database. Optional: unset leaves it to the driver. */
+    @Value("${ovsx.analytics.datasource.password:}")
+    String password;
+
+    /** Maximum size of the time-series connection pool. Default: {@code 5} */
+    @Value("${ovsx.analytics.datasource.maximum-pool-size:" + DEFAULT_POOL_SIZE + "}")
+    int maximumPoolSize;
+
+    /** How long to wait for a connection from the pool, in ms. Default: {@code 2000} */
+    @Value("${ovsx.analytics.datasource.connection-timeout:" + DEFAULT_CONNECTION_TIMEOUT_MS + "}")
+    long connectionTimeout;
+
+    /**
+     * Rejects a half-configured analytics deployment at startup rather than at the first download.
+     * These beans only exist when {@code ovsx.analytics.enabled=true}, so reaching here at all means
+     * the operator asked for analytics, and a missing URL is a mistake rather than a way to opt out.
+     */
+    @PostConstruct
+    void validateConfiguration() {
+        if (StringUtils.isEmpty(url)) {
+            throw new IllegalStateException(
+                    "ovsx.analytics.datasource.url must be set when ovsx.analytics.enabled is true");
+        }
+        if (maximumPoolSize < 1) {
+            throw new IllegalStateException(
+                    "ovsx.analytics.datasource.maximum-pool-size must be at least 1, but was " + maximumPoolSize);
+        }
+        if (connectionTimeout <= VALIDATION_TIMEOUT_FLOOR_MS) {
+            throw new IllegalStateException(
+                    "ovsx.analytics.datasource.connection-timeout must be greater than "
+                            + VALIDATION_TIMEOUT_FLOOR_MS + "ms, but was " + connectionTimeout + "ms");
+        }
+    }
+
+    // defaultCandidate = false keeps these beans invisible to @ConditionalOnMissingBean and to
+    // plain by-type injection, so Boot still auto-configures the primary DataSource, the main
+    // Flyway chain and the primary DSLContext; only an explicit @Qualifier reaches them.
+    @Bean(destroyMethod = "close", defaultCandidate = false)
+    DataSource timeseriesDataSource() {
+        var config = new HikariConfig();
+        config.setPoolName("timeseries");
+        config.setJdbcUrl(url);
+        // Unset has to reach Hikari as null, not "": an empty user name is a value, and the driver
+        // would send it rather than fall back to its own resolution (a URL parameter, .pgpass, IAM).
+        config.setUsername(emptyToNull(username));
+        config.setPassword(emptyToNull(password));
+        config.setMaximumPoolSize(maximumPoolSize);
+        config.setConnectionTimeout(connectionTimeout);
+        config.setValidationTimeout(Math.max(VALIDATION_TIMEOUT_FLOOR_MS, connectionTimeout / 2));
+        return new HikariDataSource(config);
+    }
+
+    private static @Nullable String emptyToNull(String value) {
+        return StringUtils.isEmpty(value) ? null : value;
+    }
+
+    /**
+     * Migrates the time-series schema. Configured programmatically rather than through
+     * {@code spring.flyway.*} so that the main and the time-series migration settings cannot leak
+     * into each other; in particular there is no baseline, because this database starts empty and
+     * an unexpected schema must fail the startup.
+     */
+    @Bean(defaultCandidate = false)
+    Flyway timeseriesFlyway(@Qualifier("timeseriesDataSource") DataSource dataSource) {
+        var flyway = Flyway.configure()
+                .dataSource(dataSource)
+                // a sibling of db/migration, never a child: Flyway scans locations recursively,
+                // so a child would be swept into the registry's migration chain as well
+                .locations("classpath:db/migration-timeseries")
+                .load();
+        flyway.migrate();
+        return flyway;
+    }
+
+    /**
+     * Standalone jOOQ context on the time-series pool. Being outside Spring's transaction and
+     * exception-translation infrastructure, queries throw jOOQ's {@code DataAccessException}
+     * rather than Spring's, and never join a caller's registry transaction.
+     */
+    @Bean(defaultCandidate = false)
+    DSLContext timeseriesDsl(
+            @Qualifier("timeseriesDataSource") DataSource dataSource,
+            // depended upon so the schema exists before the first query
+            @Qualifier("timeseriesFlyway") Flyway flyway
+    ) {
+        return DSL.using(dataSource, SQLDialect.POSTGRES);
+    }
+}

--- a/server/src/main/resources/db/migration-timeseries/V1__Download_Analytics.sql
+++ b/server/src/main/resources/db/migration-timeseries/V1__Download_Analytics.sql
@@ -1,0 +1,63 @@
+-- Time-series download analytics schema, applied to the separate timeseries database. Requires
+-- a PostgreSQL image with the timescaledb extension available. Every migration in this set that
+-- creates a hypertable, a continuous aggregate or one of their policies needs an
+-- executeInTransaction=false sidecar, as those cannot run inside a transaction block.
+
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+CREATE TABLE download_event (
+    time TIMESTAMPTZ NOT NULL,
+    extension_id BIGINT NOT NULL,
+    extension_version_id BIGINT NOT NULL,
+    namespace VARCHAR(255) NOT NULL,
+    extension_name VARCHAR(255) NOT NULL,
+    version VARCHAR(255) NOT NULL,
+    target_platform VARCHAR(255) NOT NULL,
+    country CHAR(2),
+    ip VARCHAR(45),
+    user_agent TEXT,
+    count INTEGER NOT NULL DEFAULT 1
+);
+
+SELECT create_hypertable('download_event', by_range('time', INTERVAL '7 days'));
+
+CREATE INDEX de_ext_time ON download_event (extension_id, time DESC);
+
+-- materialized_only = false keeps the not-yet-materialized tail (e.g. today) queryable
+-- through real-time aggregation, which the settling-margin logic in the query service
+-- relies on.
+CREATE MATERIALIZED VIEW download_stats_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
+SELECT time_bucket('1 day', time) AS day,
+       extension_id, extension_version_id, version, target_platform, country,
+       SUM(count) AS downloads
+FROM download_event
+GROUP BY time_bucket('1 day', time), extension_id, extension_version_id, version, target_platform, country
+WITH NO DATA;
+
+-- Materialize what is already there before the policy takes over. Until its first run the
+-- watermark sits at -infinity and real-time aggregation answers everything, so the gap only
+-- opens once the policy advances it: from then on buckets below the watermark are served from
+-- the materialization alone, and anything never materialized reads as zero.
+CALL refresh_continuous_aggregate('download_stats_daily', NULL, NULL);
+
+-- start_offset tracks the raw retention below rather than the schedule. Log ingestion applies no
+-- date filter, so a delayed or backfilled file writes events well outside a short window, and
+-- once the watermark has passed them they would never materialize while the raw rows are dropped
+-- at 90 days. A refresh only reprocesses invalidated ranges, so the wider window costs nothing
+-- when nothing old changed.
+SELECT add_continuous_aggregate_policy('download_stats_daily',
+    start_offset => INTERVAL '90 days',
+    end_offset => INTERVAL '1 hour',
+    schedule_interval => INTERVAL '1 hour');
+
+-- compress raw chunks after 7 days, drop them after 90 days; the daily aggregate is kept forever
+ALTER TABLE download_event SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'extension_id',
+    timescaledb.compress_orderby = 'time DESC'
+);
+
+SELECT add_compression_policy('download_event', INTERVAL '7 days');
+
+SELECT add_retention_policy('download_event', INTERVAL '90 days');

--- a/server/src/main/resources/db/migration-timeseries/V1__Download_Analytics.sql.conf
+++ b/server/src/main/resources/db/migration-timeseries/V1__Download_Analytics.sql.conf
@@ -1,0 +1,1 @@
+executeInTransaction=false

--- a/server/src/test/java/org/eclipse/openvsx/AbstractPostgresContainerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/AbstractPostgresContainerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Tag;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * Base class for tests that need a PostgreSQL database.
@@ -34,7 +35,9 @@ import org.testcontainers.postgresql.PostgreSQLContainer;
 @Tag("integration")
 public abstract class AbstractPostgresContainerTest {
 
-    static final PostgreSQLContainer POSTGRES = new PostgreSQLContainer("postgres:16.2");
+    static final PostgreSQLContainer POSTGRES = new PostgreSQLContainer(
+            DockerImageName.parse(System.getProperty("ovsx.test.postgres.image", "postgres:16.2"))
+                    .asCompatibleSubstituteFor("postgres"));
 
     static {
         POSTGRES.start();

--- a/server/src/test/java/org/eclipse/openvsx/AbstractTimeseriesContainerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/AbstractTimeseriesContainerTest.java
@@ -1,0 +1,49 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Base class for tests that need the time-series database on top of the registry database, i.e.
+ * download analytics. Like the registry container, this one is a JVM-wide singleton started once
+ * in its static initializer and reaped by Ryuk when the JVM exits.
+ * <p>
+ * Two containers rather than two databases in one is deliberate: the timescale image installs the
+ * extension into {@code template1}, so a second database inside it would still carry timescaledb -
+ * exactly the coupling that keeping the two schemas apart is meant to remove. Override the image
+ * with {@code -Dovsx.test.timeseries.image=...} if needed.
+ */
+public abstract class AbstractTimeseriesContainerTest extends AbstractPostgresContainerTest {
+
+    static final PostgreSQLContainer TIMESERIES = new PostgreSQLContainer(
+            DockerImageName
+                    .parse(System.getProperty("ovsx.test.timeseries.image", "timescale/timescaledb:2.17.2-pg16"))
+                    .asCompatibleSubstituteFor("postgres"));
+
+    static {
+        TIMESERIES.start();
+    }
+
+    @DynamicPropertySource
+    static void timeseriesProperties(DynamicPropertyRegistry registry) {
+        registry.add("ovsx.analytics.enabled", () -> true);
+        registry.add("ovsx.analytics.datasource.url", TIMESERIES::getJdbcUrl);
+        registry.add("ovsx.analytics.datasource.username", TIMESERIES::getUsername);
+        registry.add("ovsx.analytics.datasource.password", TIMESERIES::getPassword);
+        registry.add("ovsx.analytics.datasource.maximum-pool-size", () -> 2);
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/analytics/timescale/TimeseriesDatabaseConfigurationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/analytics/timescale/TimeseriesDatabaseConfigurationTest.java
@@ -1,0 +1,92 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.analytics.timescale;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the startup validation of {@link TimeseriesDatabaseConfiguration}. These beans only
+ * exist when {@code ovsx.analytics.enabled=true}, so every case here is a deployment that asked for
+ * analytics and configured them wrongly.
+ */
+class TimeseriesDatabaseConfigurationTest {
+
+    @Test
+    void acceptsAUrlWithTheDefaultsForEverythingElse() {
+        assertThatCode(() -> config().validateConfiguration()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsAMissingUrl() {
+        var config = config();
+        config.url = "";
+
+        assertThatThrownBy(config::validateConfiguration)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("ovsx.analytics.datasource.url");
+    }
+
+    @Test
+    void acceptsUnsetCredentials() {
+        // Optional: the driver may resolve them from a URL parameter, .pgpass or IAM instead.
+        var config = config();
+        config.username = "";
+        config.password = "";
+
+        assertThatCode(config::validateConfiguration).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsAPoolThatCannotHandOutAConnection() {
+        var config = config();
+        config.maximumPoolSize = 0;
+
+        assertThatThrownBy(config::validateConfiguration)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("ovsx.analytics.datasource.maximum-pool-size");
+    }
+
+    @Test
+    void rejectsAConnectionTimeoutTheValidationTimeoutCouldNotFitUnder() {
+        // The validation timeout floors at 250ms and Hikari rejects one that is not below the
+        // connection timeout, so 250 itself is already too low - Hikari would refuse the pool.
+        var config = config();
+        config.connectionTimeout = 250L;
+
+        assertThatThrownBy(config::validateConfiguration)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("ovsx.analytics.datasource.connection-timeout");
+    }
+
+    @Test
+    void acceptsAConnectionTimeoutJustAboveThatFloor() {
+        var config = config();
+        config.connectionTimeout = 251L;
+
+        assertThatCode(config::validateConfiguration).doesNotThrowAnyException();
+    }
+
+    /** A configuration carrying the defaults the @Value annotations declare. */
+    private TimeseriesDatabaseConfiguration config() {
+        var config = new TimeseriesDatabaseConfiguration();
+        config.url = "jdbc:postgresql://localhost:5433/openvsx_timeseries";
+        config.username = "openvsx";
+        config.password = "openvsx";
+        config.maximumPoolSize = 5;
+        config.connectionTimeout = 2000L;
+        return config;
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/analytics/timescale/TimeseriesDatabaseTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/analytics/timescale/TimeseriesDatabaseTest.java
@@ -1,0 +1,72 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.analytics.timescale;
+
+import java.util.List;
+
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import org.eclipse.openvsx.AbstractTimeseriesContainerTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The time-series database stands on its own: nothing reads or writes it yet, so its own migration
+ * chain applying to a separate database - without disturbing the registry's - is the only thing
+ * there is to verify.
+ */
+@SpringBootTest
+class TimeseriesDatabaseTest extends AbstractTimeseriesContainerTest {
+
+    @Autowired
+    @Qualifier("timeseriesDsl")
+    DSLContext timeseriesDsl;
+
+    // defaultCandidate = false on the time-series beans means plain by-type injection still reaches
+    // the registry's own DSLContext, which is what this asserts.
+    @Autowired
+    DSLContext registryDsl;
+
+    @Test
+    void appliesItsOwnMigrationsToTheTimeSeriesDatabase() {
+        // the hypertable and the continuous aggregate the analytics schema is built on
+        assertThat(namesFrom("timescaledb_information.hypertables", "hypertable_name"))
+                .contains("download_event");
+        assertThat(namesFrom("timescaledb_information.continuous_aggregates", "view_name"))
+                .contains("download_stats_daily");
+    }
+
+    // The registry database must not gain the analytics schema. The two migration sets are siblings
+    // under db/ rather than parent and child, because Flyway scans locations recursively and a child
+    // would have been pulled into the registry's own chain - which would also make the registry
+    // require the timescaledb extension.
+    @Test
+    void leavesTheRegistryDatabaseAlone() {
+        var registryTables = registryDsl
+                .select(DSL.field("table_name", String.class))
+                .from("information_schema.tables")
+                .where(DSL.field("table_schema").eq("public"))
+                .fetchInto(String.class);
+
+        assertThat(registryTables).doesNotContain("download_event", "download_stats_daily");
+    }
+
+    private List<String> namesFrom(String table, String column) {
+        return timeseriesDsl.select(DSL.field(column, String.class)).from(table).fetchInto(String.class);
+    }
+}

--- a/server/src/test/resources/application.yml
+++ b/server/src/test/resources/application.yml
@@ -37,6 +37,10 @@ jobrunr:
     allow-anonymous-data-usage: false
 
 ovsx:
+  analytics:
+    # the timeseries container is shared the same way, so its pool needs the same treatment
+    datasource:
+      maximum-pool-size: 2
   elasticsearch:
     # Disabled by default for tests: the Elasticsearch container is expensive, so only tests that
     # activate the "test_search" profile (which also provisions the container) enable it, via


### PR DESCRIPTION
**Stack: 4 of 6.** Split out of #2027. Base: #2132 (`split/ingestion-rework`).

The second datasource the download analytics need, and nothing that reads or writes it. Gated on `ovsx.analytics.enabled`, which no deployment sets, so by default **not a single bean of it is created**.

## What it adds

`TimeseriesDatabaseConfiguration` builds a Hikari pool, a Flyway chain and a jOOQ `DSLContext` against a separate PostgreSQL database carrying the `timescaledb` extension. All three are `defaultCandidate = false`, so Boot still auto-configures the primary datasource, the registry's Flyway chain and the primary `DSLContext` — only an explicit `@Qualifier` reaches the time-series ones.

The migration set lives in `db/migration-timeseries`, a **sibling** of `db/migration` rather than a child. Flyway scans locations recursively, so a child would be pulled into the registry's own chain and would make the registry require the `timescaledb` extension. It creates the `download_event` hypertable and the `download_stats_daily` continuous aggregate, with the `executeInTransaction=false` sidecar those statements need.

Also: `docker-compose` gains a `postgres-timeseries` service on 5433, the dev config points at it and enables analytics, the deployment configs carry the settings commented out, and the test containers can be overridden with `-Dovsx.test.postgres.image` / `-Dovsx.test.timeseries.image`.

## Worth a deliberate look

**The connection budget.** This is the PR where a deployment goes from one pool to two, and #2027 never states what the combined budget should be against the deployed `max_connections`. The test suite already hit that wall — the previous PR in this stack needed a pool cap because the extra Spring context exhausted the shared container — which is a useful signal rather than just a test annoyance. Production sizing is a decision, not a default.

**The 2-second connection timeout**, against Hikari's 30. It is deliberate and worth understanding now, because the reason only becomes live in the next PR: a download records its event on the request path, so an unreachable time-series database has to fail fast enough for the caller to swallow it. At 30 seconds an outage would hold a request thread on every download.

## One test that is not from #2027

`TimeseriesDatabaseTest`. Without it this PR would ship `AbstractTimeseriesContainerTest` as an abstract base with no subclass — dead code — and nothing would exercise the migration until the analytics land.

It asserts the hypertable and the continuous aggregate exist in the time-series database, and that the registry database does **not** gain them. That second assertion guards the sibling-vs-child location choice above, which is otherwise invisible.

Its fail-first check is weaker than I would like, and I would rather say so than imply otherwise: removing `create_hypertable` from the migration reddens both tests rather than just the hypertable assertion, because the continuous aggregate depends on it, so the migration fails and the context never starts. It shows the test is coupled to the migration; it does not show each assertion is individually wired.

## Verification

Full server suite: 1179 tests passing (1177 from the base plus these two).

Refs #2027, #2025