### PR TITLE
feat: show weekly downloads on the extension detail page

### DIFF
--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This change log covers only the frontend library (webui) of Open VSX.
 
+## [next] (unreleased)
+
+### Added
+
+- Add a weekly downloads card to the extension detail page, shown only when the registry reports download analytics as enabled: the last 7 days' downloads, a sparkline of the weekly totals for the year behind it, and the period the headline covers. Hovering moves a marker line and reads out that week instead, and the card shows a skeleton in the same shape while the series loads
+
 ## [v1.2.0] (10/09/2026)
 
 ### Added

--- a/webui/src/extension-registry-service.ts
+++ b/webui/src/extension-registry-service.ts
@@ -28,6 +28,8 @@ import {
     NamespaceMembershipList,
     PublisherInfo,
     RegistryVersion,
+    DownloadSeries,
+    DownloadSeriesInterval,
     SearchEntry,
     LoginProviders,
     ScanResultJson,
@@ -94,6 +96,28 @@ export class ExtensionRegistryService {
         }
 
         return createAbsoluteURL(arr);
+    }
+
+    /**
+     * Fetches the download time series for an extension from the analytics endpoint. The endpoint
+     * only exists when download analytics are enabled server-side (otherwise it responds 404), so
+     * callers should gate on {@link RegistryVersion.analyticsEnabled}. `from`/`to` are UTC dates
+     * (yyyy-MM-dd); `from` is inclusive and `to` is exclusive.
+     */
+    async getExtensionDownloadSeries(
+        abortController: AbortController,
+        params: { namespace: string; name: string; from?: string; to?: string; interval?: DownloadSeriesInterval }
+    ): Promise<Readonly<DownloadSeries>> {
+        const endpoint = createAbsoluteURL(
+            [this.serverUrl, 'api', params.namespace, params.name, 'analytics', 'downloads'],
+            [
+                { key: 'from', value: params.from },
+                { key: 'to', value: params.to },
+                { key: 'interval', value: params.interval }
+            ]
+        );
+        // Non-retriable: retries are owned by the TanStack query that calls this.
+        return sendNonRetriableRequest<DownloadSeries>({ abortController, endpoint });
     }
 
     async getNamespaceDetails(abortController: AbortController, name: string): Promise<Readonly<NamespaceDetails>> {

--- a/webui/src/extension-registry-types.ts
+++ b/webui/src/extension-registry-types.ts
@@ -365,7 +365,20 @@ export interface TargetPlatformVersion {
 export interface RegistryVersion {
     version: string;
     maxExtensionSize?: number;
+    analyticsEnabled?: boolean;
 }
+
+/** One bucket of the download time series: `t` is the UTC bucket start (yyyy-MM-dd). */
+export interface DownloadSeriesPoint {
+    t: string;
+    count: number;
+}
+
+export interface DownloadSeries {
+    points: DownloadSeriesPoint[];
+}
+
+export type DownloadSeriesInterval = 'day' | 'week' | 'month';
 
 export interface LoginProviders {
     loginProviders: Record<string, string>;

--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -24,6 +24,7 @@ import { Extension, ExtensionReference, VERSION_ALIASES } from '../../extension-
 import { ExtensionListRoutes } from '../extension-list/extension-list-routes';
 import { ExtensionDetailRoutes } from './extension-detail-routes';
 import { ExtensionDetailDownloadsMenu } from './extension-detail-downloads-menu';
+import { WeeklyDownloads } from './weekly-downloads';
 
 export const ExtensionDetailOverview: FunctionComponent<ExtensionDetailOverviewProps> = props => {
     const [loading, setLoading] = useState(true);
@@ -350,6 +351,7 @@ export const ExtensionDetailOverview: FunctionComponent<ExtensionDetailOverviewP
                     gap: 2,
                     flexDirection: 'column'
                 }}>
+                <WeeklyDownloads extension={extension} />
                 <Box sx={resourcesGroup}>
                     <Box>{renderVersionSection()}</Box>
                     {otherAliases.length || extension.versionAlias.length ? (

--- a/webui/src/pages/extension-detail/use-extension-download-series.ts
+++ b/webui/src/pages/extension-detail/use-extension-download-series.ts
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import { useContext } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { DateTime } from 'luxon';
+import { MainContext } from '../../context';
+import { controllerFromSignal } from '../../query-client';
+import { DownloadSeriesPoint } from '../../extension-registry-types';
+
+const WEEKS = 52;
+// 6 extra leading days so the first plotted point already has a full trailing-7-day window.
+const LEAD_IN_DAYS = 6;
+
+/**
+ * Loads roughly the last {@link WEEKS} weeks of *daily* downloads for an extension, up to and
+ * including today, as the react-query result (`data` is the ordered {@link DownloadSeriesPoint}
+ * array). Callers turn this into a trailing 7-day ("weekly downloads") view; daily granularity is
+ * what lets that window end on today rather than the last complete calendar week. Gate with
+ * `options.enabled` on `RegistryVersion.analyticsEnabled`, since the endpoint 404s when analytics
+ * is disabled.
+ */
+export const useExtensionDownloadSeries = (namespace: string, name: string, options?: { enabled?: boolean }) => {
+    const { service } = useContext(MainContext);
+    return useQuery({
+        queryKey: ['extension-downloads', namespace, name],
+        queryFn: async ({ signal }): Promise<DownloadSeriesPoint[]> => {
+            const today = DateTime.utc().startOf('day');
+            // `to` is exclusive, so today + 1 day includes today's (still-accruing) bucket.
+            const to = today.plus({ days: 1 });
+            const from = to.minus({ weeks: WEEKS }).minus({ days: LEAD_IN_DAYS });
+            const series = await service.getExtensionDownloadSeries(controllerFromSignal(signal), {
+                namespace,
+                name,
+                from: from.toFormat('yyyy-MM-dd'),
+                to: to.toFormat('yyyy-MM-dd'),
+                interval: 'day'
+            });
+            return series.points;
+        },
+        ...options
+    });
+};

--- a/webui/src/pages/extension-detail/use-extension-download-series.ts
+++ b/webui/src/pages/extension-detail/use-extension-download-series.ts
@@ -19,16 +19,14 @@ import { controllerFromSignal } from '../../query-client';
 import { DownloadSeriesPoint } from '../../extension-registry-types';
 
 const WEEKS = 52;
-// 6 extra leading days so the first plotted point already has a full trailing-7-day window.
-const LEAD_IN_DAYS = 6;
 
 /**
- * Loads roughly the last {@link WEEKS} weeks of *daily* downloads for an extension, up to and
- * including today, as the react-query result (`data` is the ordered {@link DownloadSeriesPoint}
- * array). Callers turn this into a trailing 7-day ("weekly downloads") view; daily granularity is
- * what lets that window end on today rather than the last complete calendar week. Gate with
- * `options.enabled` on `RegistryVersion.analyticsEnabled`, since the endpoint 404s when analytics
- * is disabled.
+ * Loads the last {@link WEEKS} whole weeks of *daily* downloads for an extension, ending today, as
+ * the react-query result (`data` is the ordered {@link DownloadSeriesPoint} array). The range is an
+ * exact multiple of 7 days so callers can fold it into whole weeks with nothing left over; daily
+ * granularity is what lets those weeks end on today rather than on the last complete calendar week.
+ * Gate with `options.enabled` on `RegistryVersion.analyticsEnabled`, since the endpoint 404s when
+ * analytics is disabled.
  */
 export const useExtensionDownloadSeries = (namespace: string, name: string, options?: { enabled?: boolean }) => {
     const { service } = useContext(MainContext);
@@ -38,7 +36,7 @@ export const useExtensionDownloadSeries = (namespace: string, name: string, opti
             const today = DateTime.utc().startOf('day');
             // `to` is exclusive, so today + 1 day includes today's (still-accruing) bucket.
             const to = today.plus({ days: 1 });
-            const from = to.minus({ weeks: WEEKS }).minus({ days: LEAD_IN_DAYS });
+            const from = to.minus({ weeks: WEEKS });
             const series = await service.getExtensionDownloadSeries(controllerFromSignal(signal), {
                 namespace,
                 name,

--- a/webui/src/pages/extension-detail/weekly-downloads.tsx
+++ b/webui/src/pages/extension-detail/weekly-downloads.tsx
@@ -66,7 +66,8 @@ export const WeeklyDownloads: FunctionComponent<{ extension: Extension }> = ({ e
         enabled: analyticsEnabled
     });
 
-    const counts = useMemo(() => trailingWeeklySums(points?.map(point => point.count) ?? []), [points]);
+    const daily = useMemo(() => points ?? [], [points]);
+    const counts = useMemo(() => trailingWeeklySums(daily.map(point => point.count)), [daily]);
     const hasDownloads = counts.some(count => count > 0);
     if (!analyticsEnabled || counts.length === 0 || !hasDownloads) {
         return null;
@@ -90,6 +91,8 @@ export const WeeklyDownloads: FunctionComponent<{ extension: Extension }> = ({ e
                             showHighlight
                             color={theme.palette.secondary.main}
                             valueFormatter={value => (value === null ? '' : `${value.toLocaleString()} downloads`)}
+                            // `.MuiAreaElement-root` is the sparkline's area path; lighten its fill to a wash.
+                            sx={{ '& .MuiAreaElement-root': { fillOpacity: 0.14 } }}
                         />
                     </Box>
                 </Box>

--- a/webui/src/pages/extension-detail/weekly-downloads.tsx
+++ b/webui/src/pages/extension-detail/weekly-downloads.tsx
@@ -1,0 +1,99 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import { FunctionComponent, useContext, useMemo } from 'react';
+import { Box, Typography, styled, useTheme } from '@mui/material';
+import { SparkLineChart } from '@mui/x-charts/SparkLineChart';
+import { MainContext } from '../../context';
+import { Eyebrow, cardSurface } from '../../components/page-primitives';
+import { Extension } from '../../extension-registry-types';
+import { useExtensionDownloadSeries } from './use-extension-download-series';
+
+const DownloadsCard = styled(Box)(({ theme }) => ({
+    ...cardSurface(theme),
+    padding: '0.75rem 1rem'
+}));
+
+const DownloadsCount = styled(Typography)(({ theme }) => ({
+    fontSize: '1.75rem',
+    lineHeight: 1.1,
+    fontWeight: 700,
+    color: theme.palette.text.primary,
+    fontVariantNumeric: 'tabular-nums'
+})) as typeof Typography;
+
+const WINDOW_DAYS = 7;
+
+/** Trailing {@link WINDOW_DAYS}-day rolling sums of a daily series (each point covers that day and
+ *  the previous six), so the last value is the downloads of the last week ending today. */
+function trailingWeeklySums(daily: number[]): number[] {
+    const rolling: number[] = [];
+    let windowSum = 0;
+    for (let i = 0; i < daily.length; i++) {
+        windowSum += daily[i];
+        if (i >= WINDOW_DAYS) {
+            windowSum -= daily[i - WINDOW_DAYS];
+        }
+        if (i >= WINDOW_DAYS - 1) {
+            rolling.push(windowSum);
+        }
+    }
+    return rolling;
+}
+
+/**
+ * "Weekly downloads" sidebar card: the downloads of the last 7 days (ending today) plus a trailing
+ * 7-day trend sparkline over the last year. Renders nothing when download analytics are disabled
+ * server-side (the endpoint 404s) or when the extension has no downloads in the window, so it stays
+ * out of the way on registries without data.
+ */
+export const WeeklyDownloads: FunctionComponent<{ extension: Extension }> = ({ extension }) => {
+    const theme = useTheme();
+    const { version } = useContext(MainContext);
+    const analyticsEnabled = version?.analyticsEnabled ?? false;
+
+    const { data: points } = useExtensionDownloadSeries(extension.namespace, extension.name, {
+        enabled: analyticsEnabled
+    });
+
+    const counts = useMemo(() => trailingWeeklySums(points?.map(point => point.count) ?? []), [points]);
+    const hasDownloads = counts.some(count => count > 0);
+    if (!analyticsEnabled || counts.length === 0 || !hasDownloads) {
+        return null;
+    }
+
+    const latestWeek = counts[counts.length - 1];
+
+    return (
+        <Box sx={{ flex: { md: 1, lg: 1, xl: 'none' }, mb: { xs: 2, sm: 2, md: 0, lg: 0, xl: 2 } }}>
+            <DownloadsCard>
+                <Eyebrow>Weekly downloads</Eyebrow>
+                <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1.5, mt: 0.75 }}>
+                    <DownloadsCount>{latestWeek.toLocaleString()}</DownloadsCount>
+                    <Box sx={{ flex: 1, minWidth: 0, height: '2.75rem' }}>
+                        <SparkLineChart
+                            data={counts}
+                            height={44}
+                            area
+                            curve='linear'
+                            showTooltip
+                            showHighlight
+                            color={theme.palette.secondary.main}
+                            valueFormatter={value => (value === null ? '' : `${value.toLocaleString()} downloads`)}
+                        />
+                    </Box>
+                </Box>
+            </DownloadsCard>
+        </Box>
+    );
+};

--- a/webui/src/pages/extension-detail/weekly-downloads.tsx
+++ b/webui/src/pages/extension-detail/weekly-downloads.tsx
@@ -11,92 +11,179 @@
  * SPDX-License-Identifier: EPL-2.0
  *****************************************************************************/
 
-import { FunctionComponent, useContext, useMemo } from 'react';
-import { Box, Typography, styled, useTheme } from '@mui/material';
+import { FunctionComponent, useContext, useMemo, useState } from 'react';
+import { Box, Skeleton, Typography, alpha, styled, useTheme } from '@mui/material';
 import { SparkLineChart } from '@mui/x-charts/SparkLineChart';
+import { lineClasses } from '@mui/x-charts/LineChart';
+import { chartsAxisHighlightClasses } from '@mui/x-charts/ChartsAxisHighlight';
+import { DateTime } from 'luxon';
 import { MainContext } from '../../context';
-import { Eyebrow, cardSurface } from '../../components/page-primitives';
-import { Extension } from '../../extension-registry-types';
+import { Eyebrow } from '../../components/page-primitives';
+import { DownloadSeriesPoint, Extension } from '../../extension-registry-types';
 import { useExtensionDownloadSeries } from './use-extension-download-series';
 
-const DownloadsCard = styled(Box)(({ theme }) => ({
-    ...cardSurface(theme),
-    padding: '0.75rem 1rem'
-}));
-
+/** Kept modest on purpose: the headline shares its row with the sparkline, which needs the width. */
 const DownloadsCount = styled(Typography)(({ theme }) => ({
-    fontSize: '1.75rem',
-    lineHeight: 1.1,
+    fontSize: '1.25rem',
+    lineHeight: 1.2,
     fontWeight: 700,
     color: theme.palette.text.primary,
     fontVariantNumeric: 'tabular-nums'
 })) as typeof Typography;
 
-const WINDOW_DAYS = 7;
+const Period = styled(Typography)(({ theme }) => ({
+    fontSize: '0.75rem',
+    lineHeight: 1.4,
+    color: theme.palette.text.secondary,
+    fontVariantNumeric: 'tabular-nums'
+})) as typeof Typography;
 
-/** Trailing {@link WINDOW_DAYS}-day rolling sums of a daily series (each point covers that day and
- *  the previous six), so the last value is the downloads of the last week ending today. */
-function trailingWeeklySums(daily: number[]): number[] {
-    const rolling: number[] = [];
-    let windowSum = 0;
-    for (let i = 0; i < daily.length; i++) {
-        windowSum += daily[i];
-        if (i >= WINDOW_DAYS) {
-            windowSum -= daily[i - WINDOW_DAYS];
-        }
-        if (i >= WINDOW_DAYS - 1) {
-            rolling.push(windowSum);
-        }
+const DAY_AND_MONTH = { month: 'short', day: 'numeric' } as const;
+
+const WEEK_DAYS = 7;
+
+/**
+ * Tuned against the headline beside it: the row is bottom-aligned, so its height is the chart's and
+ * anything much taller leaves dead space above the number rather than a bigger curve.
+ */
+const CHART_HEIGHT_PX = 48;
+
+const asDate = (point: DownloadSeriesPoint): DateTime => DateTime.fromISO(point.t, { zone: 'utc' });
+
+/** "Aug 21, 2026" for a single day, or "Aug 15 – Aug 21, 2026" across a week. */
+function formatPeriod(from: DownloadSeriesPoint, to: DownloadSeriesPoint): string | undefined {
+    const start = asDate(from);
+    const end = asDate(to);
+    if (!start.isValid || !end.isValid) {
+        return undefined;
     }
-    return rolling;
+
+    const endLabel = end.toLocaleString({ ...DAY_AND_MONTH, year: 'numeric' });
+    return start.hasSame(end, 'day') ? endLabel : `${start.toLocaleString(DAY_AND_MONTH)} – ${endLabel}`;
 }
 
 /**
- * "Weekly downloads" sidebar card: the downloads of the last 7 days (ending today) plus a trailing
- * 7-day trend sparkline over the last year. Renders nothing when download analytics are disabled
- * server-side (the endpoint 404s) or when the extension has no downloads in the window, so it stays
- * out of the way on registries without data.
+ * Folds a daily series into consecutive {@link WEEK_DAYS}-day totals, aligned so the last week ends
+ * on the most recent day. Any leading remainder shorter than a whole week is dropped, so every
+ * plotted point is a full week sharing no days with its neighbours — a rise or fall on the curve is
+ * a real week-on-week change. Oldest first.
+ */
+function weeklyTotals(daily: number[]): number[] {
+    const weeks: number[] = [];
+    for (let end = daily.length; end >= WEEK_DAYS; end -= WEEK_DAYS) {
+        let total = 0;
+        for (let day = end - WEEK_DAYS; day < end; day++) {
+            total += daily[day];
+        }
+        weeks.unshift(total);
+    }
+    return weeks;
+}
+
+/**
+ * The sidebar slot, shared by the loaded and loading states so neither shifts. Deliberately not a
+ * card: it sits flush with the resources group below it, which is styled the same way.
+ */
+const sectionSx = {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: { xs: 'none', sm: 'none', md: 1, lg: 1, xl: 'none' },
+    mb: { xs: 2, sm: 2, md: 0, lg: 0, xl: 2 }
+} as const;
+
+/** Same shape and heights as the loaded section, so the sidebar does not jump when the series lands. */
+const LoadingCard: FunctionComponent = () => (
+    <Box sx={sectionSx} role='status' aria-label='Loading weekly downloads'>
+        <Eyebrow>Weekly downloads</Eyebrow>
+        <Skeleton variant='text' width='55%' sx={{ fontSize: '0.75rem' }} />
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', gap: 1.5, mt: 0.75 }}>
+            <Skeleton variant='text' width='4.5rem' sx={{ fontSize: '1.25rem' }} />
+            <Skeleton variant='rounded' sx={{ flex: 1, minWidth: 0, height: `${CHART_HEIGHT_PX / 16}rem` }} />
+        </Box>
+    </Box>
+);
+
+/**
+ * "Weekly downloads" sidebar card: the downloads of the last 7 days, with a sparkline of the weekly
+ * totals for the year behind it — one point per week, so the headline is simply its last point.
+ * Hovering reads out that week instead. Renders nothing when download analytics are disabled
+ * server-side (the endpoint 404s) or when the extension has no downloads in the year.
  */
 export const WeeklyDownloads: FunctionComponent<{ extension: Extension }> = ({ extension }) => {
     const theme = useTheme();
     const { version } = useContext(MainContext);
     const analyticsEnabled = version?.analyticsEnabled ?? false;
+    const [hovered, setHovered] = useState<number | undefined>(undefined);
 
-    const { data: points } = useExtensionDownloadSeries(extension.namespace, extension.name, {
+    const { data: points, isLoading } = useExtensionDownloadSeries(extension.namespace, extension.name, {
         enabled: analyticsEnabled
     });
 
     const daily = useMemo(() => points ?? [], [points]);
-    const counts = useMemo(() => trailingWeeklySums(daily.map(point => point.count)), [daily]);
-    const hasDownloads = counts.some(count => count > 0);
-    if (!analyticsEnabled || counts.length === 0 || !hasDownloads) {
+    const counts = useMemo(() => weeklyTotals(daily.map(point => point.count)), [daily]);
+    if (!analyticsEnabled) {
+        return null;
+    }
+    // `isLoading` is the first fetch only, and stays false while the query is disabled
+    if (isLoading) {
+        return <LoadingCard />;
+    }
+    if (counts.length === 0 || !counts.some(count => count > 0)) {
         return null;
     }
 
-    const latestWeek = counts[counts.length - 1];
+    // the last week by default; whole weeks are taken from the end, so a short first week is dropped
+    const selected = hovered !== undefined && hovered < counts.length ? hovered : counts.length - 1;
+    const first = daily.length - counts.length * WEEK_DAYS + selected * WEEK_DAYS;
+    const period = formatPeriod(daily[first], daily[first + WEEK_DAYS - 1]);
+    // Reserve room for the busiest week, so the headline's width does not track its digit count and
+    // resize the sparkline beside it as the pointer moves. Data-derived, so it cannot be a class.
+    const reserved = `${Math.max(...counts).toLocaleString().length}ch`;
 
     return (
-        <Box sx={{ flex: { md: 1, lg: 1, xl: 'none' }, mb: { xs: 2, sm: 2, md: 0, lg: 0, xl: 2 } }}>
-            <DownloadsCard>
-                <Eyebrow>Weekly downloads</Eyebrow>
-                <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1.5, mt: 0.75 }}>
-                    <DownloadsCount>{latestWeek.toLocaleString()}</DownloadsCount>
-                    <Box sx={{ flex: 1, minWidth: 0, height: '2.75rem' }}>
-                        <SparkLineChart
-                            data={counts}
-                            height={44}
-                            area
-                            curve='linear'
-                            showTooltip
-                            showHighlight
-                            color={theme.palette.secondary.main}
-                            valueFormatter={value => (value === null ? '' : `${value.toLocaleString()} downloads`)}
-                            // `.MuiAreaElement-root` is the sparkline's area path; lighten its fill to a wash.
-                            sx={{ '& .MuiAreaElement-root': { fillOpacity: 0.14 } }}
-                        />
-                    </Box>
+        <Box sx={sectionSx}>
+            <Eyebrow>Weekly downloads</Eyebrow>
+            {period && <Period>{period}</Period>}
+            <Box
+                sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'flex-end',
+                    gap: 1.5,
+                    mt: 0.75,
+                    borderBottom: `2px solid ${alpha(theme.palette.secondary.main, 0.2)}`
+                }}>
+                <DownloadsCount style={{ minWidth: reserved }}>{counts[selected].toLocaleString()}</DownloadsCount>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <SparkLineChart
+                        data={counts}
+                        height={CHART_HEIGHT_PX}
+                        area
+                        // Fill from the bottom of the plot with a little underhang, and trim the
+                        // default padding, so the curve uses the box instead of floating in it.
+                        baseline='min'
+                        margin={{ top: 5, right: 0, bottom: 0, left: 4 }}
+                        yAxis={{ domainLimit: (_, maxValue) => ({ min: -maxValue / 6, max: maxValue }) }}
+                        clipAreaOffset={{ top: 2, bottom: 2 }}
+                        showHighlight
+                        // A non-'none' axis highlight is also what enables the axis listener, so
+                        // the readout above tracks the pointer anywhere along the curve.
+                        axisHighlight={{ x: 'line' }}
+                        onHighlightedAxisChange={items => setHovered(items[0]?.dataIndex)}
+                        slotProps={{ lineHighlight: { r: 4 } }}
+                        color={theme.palette.secondary.main}
+                        sx={{
+                            [`& .${lineClasses.area}`]: { opacity: 0.2 },
+                            [`& .${lineClasses.line}`]: { strokeWidth: 3 },
+                            [`& .${chartsAxisHighlightClasses.root}`]: {
+                                stroke: theme.palette.secondary.main,
+                                strokeDasharray: 'none',
+                                strokeWidth: 2
+                            }
+                        }}
+                    />
                 </Box>
-            </DownloadsCard>
+            </Box>
         </Box>
     );
 };

--- a/webui/test/unit/components/weekly-downloads.spec.tsx
+++ b/webui/test/unit/components/weekly-downloads.spec.tsx
@@ -1,0 +1,76 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../support/test-providers';
+import { WeeklyDownloads } from '../../../src/pages/extension-detail/weekly-downloads';
+import { DownloadSeriesPoint, Extension, RegistryVersion } from '../../../src/extension-registry-types';
+import { ExtensionRegistryService } from '../../../src/extension-registry-service';
+
+// The real chart pulls in SVG measurement APIs jsdom lacks; stub it so the test exercises
+// the component's own logic (gating, the headline number, and the series it feeds the chart).
+vi.mock('@mui/x-charts/SparkLineChart', () => ({
+    SparkLineChart: ({ data }: { data: number[] }) => <div data-testid='sparkline' data-length={data.length} />
+}));
+
+const extension = { namespace: 'redhat', name: 'java' } as unknown as Extension;
+const analyticsEnabled: RegistryVersion = { version: '1.0.0', analyticsEnabled: true };
+
+function points(counts: number[]): DownloadSeriesPoint[] {
+    return counts.map((count, i) => ({ t: `2026-01-${String(i + 1).padStart(2, '0')}`, count }));
+}
+
+function serviceReturning(series: DownloadSeriesPoint[]): ExtensionRegistryService {
+    return {
+        getExtensionDownloadSeries: vi.fn().mockResolvedValue({ points: series })
+    } as unknown as ExtensionRegistryService;
+}
+
+describe('WeeklyDownloads', () => {
+    it('shows the last-7-days total and the trailing-week trend when analytics is enabled', async () => {
+        // 14 daily points of 1000 → every trailing-7-day sum is 7000; rolling length = 14 - 6 = 8.
+        const service = serviceReturning(points(Array(14).fill(1000)));
+        renderWithProviders(<WeeklyDownloads extension={extension} />, {
+            mainContext: { service, version: analyticsEnabled }
+        });
+
+        expect(await screen.findByText((7000).toLocaleString())).toBeInTheDocument();
+        expect(screen.getByText(/weekly downloads/i)).toBeInTheDocument();
+        expect(screen.getByTestId('sparkline')).toHaveAttribute('data-length', '8');
+        expect(service.getExtensionDownloadSeries).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ namespace: 'redhat', name: 'java', interval: 'day' })
+        );
+    });
+
+    it('renders nothing (and never calls the endpoint) when analytics is disabled', () => {
+        const service = serviceReturning(points(Array(14).fill(1)));
+        renderWithProviders(<WeeklyDownloads extension={extension} />, {
+            mainContext: { service, version: { version: '1.0.0', analyticsEnabled: false } }
+        });
+
+        expect(screen.queryByText(/weekly downloads/i)).not.toBeInTheDocument();
+        expect(service.getExtensionDownloadSeries).not.toHaveBeenCalled();
+    });
+
+    it('renders nothing when the extension has no downloads in the window', async () => {
+        const service = serviceReturning(points(Array(14).fill(0)));
+        renderWithProviders(<WeeklyDownloads extension={extension} />, {
+            mainContext: { service, version: analyticsEnabled }
+        });
+
+        await waitFor(() => expect(service.getExtensionDownloadSeries).toHaveBeenCalled());
+        expect(screen.queryByText(/weekly downloads/i)).not.toBeInTheDocument();
+    });
+});

--- a/webui/test/unit/components/weekly-downloads.spec.tsx
+++ b/webui/test/unit/components/weekly-downloads.spec.tsx
@@ -13,15 +13,35 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../support/test-providers';
 import { WeeklyDownloads } from '../../../src/pages/extension-detail/weekly-downloads';
 import { DownloadSeriesPoint, Extension, RegistryVersion } from '../../../src/extension-registry-types';
 import { ExtensionRegistryService } from '../../../src/extension-registry-service';
 
-// The real chart pulls in SVG measurement APIs jsdom lacks; stub it so the test exercises
-// the component's own logic (gating, the headline number, and the series it feeds the chart).
+// The real chart pulls in SVG measurement APIs jsdom lacks; stub it so the test exercises the
+// component's own logic (gating, the headline readout, and the series it feeds the chart). The
+// buttons stand in for pointer movement along the axis, which is what the real chart reports
+// through onHighlightedAxisChange.
 vi.mock('@mui/x-charts/SparkLineChart', () => ({
-    SparkLineChart: ({ data }: { data: number[] }) => <div data-testid='sparkline' data-length={data.length} />
+    SparkLineChart: ({
+        data,
+        onHighlightedAxisChange
+    }: {
+        data: number[];
+        onHighlightedAxisChange?: (items: { axisId: string; dataIndex: number }[]) => void;
+    }) => (
+        <div data-testid='sparkline' data-length={data.length}>
+            {data.map((_, index) => (
+                <button
+                    key={index}
+                    aria-label={`hover ${index}`}
+                    onClick={() => onHighlightedAxisChange?.([{ axisId: 'x', dataIndex: index }])}
+                />
+            ))}
+            <button aria-label='hover out' onClick={() => onHighlightedAxisChange?.([])} />
+        </div>
+    )
 }));
 
 const extension = { namespace: 'redhat', name: 'java' } as unknown as Extension;
@@ -37,9 +57,13 @@ function serviceReturning(series: DownloadSeriesPoint[]): ExtensionRegistryServi
     } as unknown as ExtensionRegistryService;
 }
 
+// Two whole weeks, 1..14 downloads per day: week 0 covers Jan 1-7 (28) and week 1, the latest,
+// covers Jan 8-14 (77).
+const ascending = points(Array.from({ length: 14 }, (_, i) => i + 1));
+
 describe('WeeklyDownloads', () => {
     it('shows the last-7-days total and the trailing-week trend when analytics is enabled', async () => {
-        // 14 daily points of 1000 → every trailing-7-day sum is 7000; rolling length = 14 - 6 = 8.
+        // 14 daily points of 1000 → two whole weeks of 7000 each
         const service = serviceReturning(points(Array(14).fill(1000)));
         renderWithProviders(<WeeklyDownloads extension={extension} />, {
             mainContext: { service, version: analyticsEnabled }
@@ -47,11 +71,76 @@ describe('WeeklyDownloads', () => {
 
         expect(await screen.findByText((7000).toLocaleString())).toBeInTheDocument();
         expect(screen.getByText(/weekly downloads/i)).toBeInTheDocument();
-        expect(screen.getByTestId('sparkline')).toHaveAttribute('data-length', '8');
+        expect(screen.getByTestId('sparkline')).toHaveAttribute('data-length', '2');
         expect(service.getExtensionDownloadSeries).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({ namespace: 'redhat', name: 'java', interval: 'day' })
         );
+    });
+
+    it('headlines the last week and labels the period it covers', async () => {
+        renderWithProviders(<WeeklyDownloads extension={extension} />, {
+            mainContext: { service: serviceReturning(ascending), version: analyticsEnabled }
+        });
+
+        expect(await screen.findByText((77).toLocaleString())).toBeInTheDocument();
+        expect(screen.getByText(/Jan 8.*Jan 14, 2026/)).toBeInTheDocument();
+    });
+
+    it('reads out the hovered week, and returns to the last week when the pointer leaves', async () => {
+        renderWithProviders(<WeeklyDownloads extension={extension} />, {
+            mainContext: { service: serviceReturning(ascending), version: analyticsEnabled }
+        });
+        await screen.findByText((77).toLocaleString());
+
+        await userEvent.click(screen.getByRole('button', { name: 'hover 0' }));
+
+        expect(screen.getByText((28).toLocaleString())).toBeInTheDocument();
+        expect(screen.getByText(/Jan 1.*Jan 7, 2026/)).toBeInTheDocument();
+        expect(screen.queryByText((77).toLocaleString())).not.toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', { name: 'hover out' }));
+
+        expect(screen.getByText((77).toLocaleString())).toBeInTheDocument();
+        expect(screen.getByText(/Jan 8.*Jan 14, 2026/)).toBeInTheDocument();
+    });
+
+    it('reserves headline width for the busiest week, so the sparkline does not resize on hover', async () => {
+        // a quiet week of 7 then a busy one of 12,257,000 (ten chars with separators)
+        const uneven = points([...Array(7).fill(1), ...Array(7).fill(1751000)]);
+        renderWithProviders(<WeeklyDownloads extension={extension} />, {
+            mainContext: { service: serviceReturning(uneven), version: analyticsEnabled }
+        });
+
+        // asserted on the style attribute: jsdom drops `ch` from the computed style
+        const reserved = `min-width: ${(12257000).toLocaleString().length}ch`;
+        const headline = await screen.findByText((12257000).toLocaleString());
+        expect(headline.getAttribute('style')).toContain(reserved);
+
+        // the reservation is unchanged while the single-digit week is being read out
+        await userEvent.click(screen.getByRole('button', { name: 'hover 0' }));
+        expect(screen.getByText('7').getAttribute('style')).toContain(reserved);
+    });
+
+    it('shows a skeleton while the first request is in flight, then the figures', async () => {
+        let resolve!: (value: { points: DownloadSeriesPoint[] }) => void;
+        const service = {
+            getExtensionDownloadSeries: vi.fn().mockReturnValue(new Promise(done => (resolve = done)))
+        } as unknown as ExtensionRegistryService;
+        renderWithProviders(<WeeklyDownloads extension={extension} />, {
+            mainContext: { service, version: analyticsEnabled }
+        });
+
+        // the card's shell is already there, so the sidebar does not shift when the data lands
+        expect(screen.getByRole('status', { name: 'Loading weekly downloads' })).toBeInTheDocument();
+        expect(screen.getByText(/weekly downloads/i)).toBeInTheDocument();
+        expect(screen.queryByTestId('sparkline')).not.toBeInTheDocument();
+
+        resolve({ points: ascending });
+
+        expect(await screen.findByText((77).toLocaleString())).toBeInTheDocument();
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+        expect(screen.getByTestId('sparkline')).toBeInTheDocument();
     });
 
     it('renders nothing (and never calls the endpoint) when analytics is disabled', () => {
@@ -70,7 +159,8 @@ describe('WeeklyDownloads', () => {
             mainContext: { service, version: analyticsEnabled }
         });
 
-        await waitFor(() => expect(service.getExtensionDownloadSeries).toHaveBeenCalled());
-        expect(screen.queryByText(/weekly downloads/i)).not.toBeInTheDocument();
+        // the skeleton shows first, so wait for the card to settle on rendering nothing
+        await waitFor(() => expect(screen.queryByText(/weekly downloads/i)).not.toBeInTheDocument());
+        expect(service.getExtensionDownloadSeries).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
**Stack: 6 of 6.** Split out of #2027. Base: #2134 (`split/download-analytics`).

All three commits are @gnugomez's, cherry-picked with `-x`, and they applied cleanly.

The visible end of the feature: a weekly-downloads card on the extension detail page, fed by the series endpoint from #2134.

- `weekly-downloads.tsx` and `use-extension-download-series.ts`
- the series call and its types in `extension-registry-service.ts` / `extension-registry-types.ts`
- placed by `extension-detail-overview.tsx`

It reads `analyticsEnabled` from `/api/version`, so on a registry with analytics off nothing is requested and nothing is rendered — which is every deployment by default.

## Why it is last

It is the only part of #2027 with a dependency in both directions: it needs the page primitives and `Pill` from #2130, and the series endpoint from #2134. Landing it earlier would have meant either stubbing the endpoint or shipping a card with nothing behind it.

## Verification

`yarn test` 281 passing across 55 files (274 from #2130 plus 7 here), `yarn lint` clean, `tsc --noEmit` clean.

## Stack summary

| PR | Unit | Base |
|---|---|---|
| #2130 | webui library surface | `main` |
| #2131 | ingestion move (pure relocation) | #2130 |
| #2132 | ingestion rework | #2131 |
| #2133 | time-series database | #2132 |
| #2134 | analytics core and API | #2133 |
| #2135 | this | #2134 |

Two of those carry things worth deciding rather than just reviewing: #2132 is a rewrite of **live download counting** that #2027's "disabled by default" framing hides, and #2134 is where a synchronous time-series write lands on the download request path.

Refs #2027, #2025