### PR TITLE
fix: keep generated token bodies free of - and _

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
@@ -68,10 +68,13 @@ public class AccessTokenService {
     private static final int TOKEN_BYTES = 32;
 
     /**
-     * Base62 rather than base64url, so that the only underscore in a token is the one ending the marker.
-     * Base64url would put a further {@code -} or {@code _} in roughly three of every four token bodies,
-     * which reads as though the marker were longer than it is and makes a token awkward to select as a
-     * single word. It costs nothing in length: 62^43 still exceeds 2^256, so the body stays 43 characters.
+     * Base62 rather than base64url, so that the body carries no {@code _} or {@code -} and the underscore
+     * ending the marker stays the last separator in the value. The deployment prefix in front of the
+     * marker may well contain one of its own - the development configuration uses {@code dev_ovsx} - but
+     * that part is fixed and recognisable, where base64url put a further {@code -} or {@code _} at a
+     * random place in roughly three of every four bodies, making the marker look longer than it is and a
+     * token awkward to select as a single word. Base62 costs nothing in length: 62^43 still exceeds
+     * 2^256, so the body stays 43 characters.
      */
     private static final char[] TOKEN_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
             .toCharArray();

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
@@ -12,6 +12,7 @@
  *****************************************************************************/
 package org.eclipse.openvsx.accesstoken;
 
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -19,7 +20,6 @@ import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -67,7 +67,19 @@ public class AccessTokenService {
     /** 256 bits; far beyond guessing, and the encoded form is still shorter than a UUID. */
     private static final int TOKEN_BYTES = 32;
 
-    private static final Base64.Encoder TOKEN_ENCODER = Base64.getUrlEncoder().withoutPadding();
+    /**
+     * Base62 rather than base64url, so that the only underscore in a token is the one ending the marker.
+     * Base64url would put a further {@code -} or {@code _} in roughly three of every four token bodies,
+     * which reads as though the marker were longer than it is and makes a token awkward to select as a
+     * single word. It costs nothing in length: 62^43 still exceeds 2^256, so the body stays 43 characters.
+     */
+    private static final char[] TOKEN_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+            .toCharArray();
+
+    /** Characters needed for 256 bits in base62: ceil(256 / log2(62)). */
+    private static final int TOKEN_LENGTH = 43;
+
+    private static final BigInteger TOKEN_RADIX = BigInteger.valueOf(TOKEN_ALPHABET.length);
 
     /** The token types that are retired by deleting the row rather than deactivating it. */
     private static final List<PersonalAccessTokenType> EPHEMERAL_TOKEN_TYPES = Arrays
@@ -211,7 +223,26 @@ public class AccessTokenService {
     public String generateTokenValue(PersonalAccessTokenType type) {
         var bytes = new byte[TOKEN_BYTES];
         random.nextBytes(bytes);
-        return config.getPrefix() + type.getTokenMarker() + TOKEN_ENCODER.encodeToString(bytes);
+        return config.getPrefix() + type.getTokenMarker() + encodeTokenBody(bytes);
+    }
+
+    /**
+     * Renders the random bytes as a fixed-width base62 string, most significant digit first.
+     * <p>
+     * The bytes are read as one unsigned number, so no entropy is lost and none is added: 62^43 is larger
+     * than 2^256, which makes every distinct byte sequence a distinct string and leaves no room for the
+     * modulo bias that mapping each character separately onto a 62-letter alphabet would introduce. Values
+     * that need fewer digits keep the same width by carrying leading zero characters.
+     */
+    private static String encodeTokenBody(byte[] bytes) {
+        var remaining = new BigInteger(1, bytes);
+        var body = new char[TOKEN_LENGTH];
+        for (var i = TOKEN_LENGTH - 1; i >= 0; i--) {
+            var divideAndRemainder = remaining.divideAndRemainder(TOKEN_RADIX);
+            remaining = divideAndRemainder[0];
+            body[i] = TOKEN_ALPHABET[divideAndRemainder[1].intValue()];
+        }
+        return new String(body);
     }
 
     @Transactional

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
@@ -152,13 +152,15 @@ class AccessTokenServiceTest {
 
         // prefix, then the marker saying what kind of token this is, then 256 bits base62 encoded
         assertThat(value).startsWith("ovsxat_");
-        assertThat(value.substring("ovsxat_".length())).hasSize(43).containsPattern("^[0-9A-Za-z]+$");
+        assertThat(value.substring("ovsxat_".length())).matches("[0-9A-Za-z]{43}");
         verifyNoInteractions(repositories);
     }
 
-    // The marker ends in the only underscore a token has, so that what follows it reads as one word.
-    // Base64url put a further - or _ in about three of every four bodies, which made the marker look
-    // longer than it is.
+    // Nothing in the body may look like the marker's own delimiter, so that what follows the marker
+    // reads as one word. Base64url put a further - or _ at a random place in about three of every four
+    // bodies, which made the marker look longer than it is. The configured prefix ahead of the marker
+    // may contain an underscore of its own; that one is fixed and recognisable, so it does not blur
+    // where the marker ends.
     @Test
     void keepsTheBodyFreeOfTheCharactersThatMarkTheTokenType() {
         when(config.getPrefix()).thenReturn("ovsx");

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
@@ -150,10 +150,25 @@ class AccessTokenServiceTest {
 
         var value = accessTokenService.generateTokenValue(PersonalAccessTokenType.LLT);
 
-        // prefix, then the marker saying what kind of token this is, then 256 bits base64url encoded
+        // prefix, then the marker saying what kind of token this is, then 256 bits base62 encoded
         assertThat(value).startsWith("ovsxat_");
-        assertThat(value.substring("ovsxat_".length())).hasSize(43).doesNotContain("=", "+", "/");
+        assertThat(value.substring("ovsxat_".length())).hasSize(43).containsPattern("^[0-9A-Za-z]+$");
         verifyNoInteractions(repositories);
+    }
+
+    // The marker ends in the only underscore a token has, so that what follows it reads as one word.
+    // Base64url put a further - or _ in about three of every four bodies, which made the marker look
+    // longer than it is.
+    @Test
+    void keepsTheBodyFreeOfTheCharactersThatMarkTheTokenType() {
+        when(config.getPrefix()).thenReturn("ovsx");
+
+        var values = java.util.stream.Stream.generate(
+                () -> accessTokenService.generateTokenValue(PersonalAccessTokenType.LLT)).limit(500).toList();
+
+        assertThat(values).allSatisfy(
+                value -> assertThat(value.substring("ovsxat_".length()))
+                        .doesNotContain("_", "-", "=", "+", "/"));
     }
 
     @Test


### PR DESCRIPTION
A generated token is the deployment prefix, a marker ending in an underscore saying which kind of token it is, and the encoded random bytes — `ovsx` + `at_` + body. Because the body is base64url encoded, it frequently contains a further `_` or `-`, which reads as though the marker were longer than it is.

## Is that expected?

Yes — `Base64.getUrlEncoder()` draws from a 64-character alphabet of `A–Z a–z 0–9 - _`, so those two are ordinary body characters. It is common enough to be worth fixing. Over 200k sampled bodies:

| | share of bodies |
| --- | --- |
| contains `_` | 48.3% |
| contains `-` | 48.4% |
| contains either | 73.6% |

So about half of all issued tokens appear to have a second separator in them.

## The change

Encode the 32 random bytes in base62 (`0-9A-Za-z`) instead, so the body carries no `_` or `-` and the underscore ending the marker stays the last separator in the value, with the body selectable as a single word. (The deployment prefix ahead of the marker may contain an underscore of its own - the dev configuration uses `dev_ovsx` - but that part is fixed and recognisable, unlike a random one in the body.) This is the same reasoning behind GitHub's `ghp_` tokens.

It costs nothing in length: 62^43 is still larger than 2^256 (by about 2%), so the body stays **43 characters**, exactly as before.

Two details in the implementation:

- **No modulo bias.** The bytes are read as one unsigned `BigInteger` and divided down by 62, rather than mapping each random byte onto a 62-letter alphabet — 256 is not a multiple of 62, so the per-character approach would skew the distribution. All 256 bits are preserved and distinct byte sequences stay distinct.
- **Fixed width.** Values that need fewer digits are left-padded with `0`, so the body is never shorter than 43 characters. One consequence: 2^256 covers 97.9% of the 62^43 space, so the leading character spans indices 0–60 of 62 and `z` never appears first. That is a property of the encoding, not a loss of entropy.

## Compatibility

Only newly issued tokens are affected:

- Existing tokens keep working — validation hashes whatever value the client presents and matches it against the stored salted hash, so the encoding of the body never enters into it.
- Nothing parses the body. I checked the server, `webui`, `cli`, the docs, and the gitleaks rules — those come from upstream's `gitleaks.toml` and carry no openvsx-specific pattern.
- The prefix and per-type markers (`at_`, `tp_`, `ot_`) are unchanged, so secret scanning keyed on those is unaffected.

## Testing

- The existing format assertion now requires the body to be alphanumeric.
- Added a test that generates 500 tokens and asserts no `_`, `-`, `=`, `+` or `/` in any body.
- `server/gradlew --no-daemon -p server check` — BUILD SUCCESSFUL, 1139 tests.

## Unrelated observation

`spotlessApply` also reformats four files this PR does not touch — `ExtensionQueryParam`, `ExtensionQueryResult`, `TargetPlatformActiveJson`, `TargetPlatformVersionJson`. They are already spotless-dirty on `main` (confirmed by stashing this branch's changes and re-running), so they are excluded here. `check` does not appear to run `spotlessCheck`, which is why CI stays green on them — might be worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
