### PR TITLE
chore: add a Makefile for common development tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ server: ## Run the registry server on http://localhost:8080
 	cd server && ./scripts/generate-properties.sh && ./gradlew runServer
 
 webui: ## Run the web UI on http://localhost:3000
-	cd webui && yarn install && yarn dev
+	cd webui && yarn install --immutable && yarn dev

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# Common development tasks. Run `make` for the list.
+#
+# The three run targets are meant to be started in separate terminals: `make dev-env` holds the
+# containers the other two talk to, and both `make server` and `make webui` stay in the foreground
+# so that they pick up code changes.
+
+# Postgres, the Valkey cluster with its admin UI, and MinIO. Elasticsearch is deliberately absent:
+# the dev profile searches the database instead (ovsx.databasesearch.enabled).
+DEV_PROFILES := db valkey valkey-admin minio
+
+.DEFAULT_GOAL := help
+.PHONY: help dev-env dev-env-down server webui
+
+help: ## Show the available targets
+	@grep -hE '^[a-z][a-z-]*:.*## ' $(MAKEFILE_LIST) \
+		| sort \
+		| awk -F ':.*## ' '{ printf "  %-14s %s\n", $$1, $$2 }'
+
+dev-env: ## Start the containers the server and web UI need (Ctrl-C stops them)
+	docker compose $(addprefix --profile ,$(DEV_PROFILES)) up
+
+dev-env-down: ## Stop those containers and remove them
+	docker compose $(addprefix --profile ,$(DEV_PROFILES)) down
+
+server: ## Run the registry server on http://localhost:8080
+	cd server && ./scripts/generate-properties.sh && ./gradlew runServer
+
+webui: ## Run the web UI on http://localhost:3000
+	cd webui && yarn install && yarn dev


### PR DESCRIPTION
Adds a root `Makefile` with the three things a local setup needs running. They are meant for three terminals: `dev-env` holds the containers, `server` and `webui` run the two applications against them and stay in the foreground so they pick up code changes.

```
$ make
  dev-env        Start the containers the server and web UI need (Ctrl-C stops them)
  dev-env-down   Stop those containers and remove them
  help           Show the available targets
  server         Run the registry server on http://localhost:8080
  webui          Run the web UI on http://localhost:3000
```

## Targets

| Target | Runs |
| --- | --- |
| `dev-env` | `docker compose --profile db --profile valkey --profile valkey-admin --profile minio up` |
| `dev-env-down` | the same profiles, `down` |
| `server` | `cd server && ./scripts/generate-properties.sh && ./gradlew runServer` |
| `webui` | `cd webui && yarn install && yarn dev` |

Notes on the two that are not a single command:

- **`server`** runs `generate-properties.sh` first because `runServer` needs `application-ovsx.properties` to exist. The script exits early when it is already there, so it costs nothing on repeat runs.
- **`webui`** runs `yarn install` first, mirroring what the compose `webui` service already does (`yarn install --immutable && yarn dev`).

The profile list lives in one `DEV_PROFILES` variable rather than being repeated across the two compose targets, and `make` with no argument prints the target list, parsed from the `##` comments so it cannot drift from the targets themselves.

**Elasticsearch is deliberately not in the profile set** — the dev profile searches the database (`ovsx.databasesearch.enabled: true`, `ovsx.elasticsearch.enabled: false`), so the server runs fine without it. There is a comment in the file saying so, since its absence otherwise looks like an oversight.

Worth knowing when using this: `ovsx.redis.enabled` is `false` and storage defaults to `local` in the dev profile, so valkey and minio start but the server does not talk to them until the corresponding blocks in `server/src/dev/resources/application.yml` are uncommented.

## Testing

Each target was run for real, not just written:

- `make dev-env` — all 9 containers up and healthy (postgres, 6 valkey nodes, valkey-admin, minio).
- `make server` — reached `Started RegistryApplication`, Jetty on 8080, `GET /api/-/search` returned 200.
- `make webui` — vite serving on 3000, `GET /` returned 200.
- `make dev-env-down` — removed every container and the network, leaving a clean `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)