### PR TITLE
refactor: replace the remaining EntityManager.merge updates with find

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
@@ -377,12 +377,17 @@ public class AccessTokenService {
 
     @Transactional
     public void scheduleTokenExpirationNotification(PersonalAccessToken token) {
-        token = entityManager.merge(token);
-        if (token.getType().isNotify() && !token.isNotified()) {
+        // find, not merge: only `notified` is this method's to change, and merging the whole
+        // detached token reverted any column that moved since it was loaded - see #989.
+        var managedToken = entityManager.find(PersonalAccessToken.class, token.getId());
+        if (managedToken == null) {
+            return;
+        }
+        if (managedToken.getType().isNotify() && !managedToken.isNotified()) {
             try {
-                mail.scheduleAccessTokenExpiryNotification(token);
+                mail.scheduleAccessTokenExpiryNotification(managedToken);
             } finally {
-                token.setNotified(true);
+                managedToken.setNotified(true);
             }
         }
     }

--- a/server/src/main/java/org/eclipse/openvsx/admin/ChangeNamespaceService.java
+++ b/server/src/main/java/org/eclipse/openvsx/admin/ChangeNamespaceService.java
@@ -61,21 +61,43 @@ public class ChangeNamespaceService {
         if (createNewNamespace) {
             entityManager.persist(newNamespace);
         } else {
+            // Deliberately a merge, unlike the rest of #989's call sites: the caller mutates this
+            // detached namespace before handing it over (ChangeNamespaceJobRequestHandler sets
+            // logoName on it), so the update belongs to the caller and only merge can carry it.
+            // find-then-set would silently drop that rename.
             newNamespace = entityManager.merge(newNamespace);
         }
 
         changeExtensionNamespace(extensions, newNamespace);
         changeMembershipNamespace(oldNamespace, newNamespace, removeOldNamespace);
-        updatedResources.forEach(entityManager::merge);
+        renameResources(updatedResources);
 
         if (removeOldNamespace) {
-            oldNamespace = entityManager.merge(oldNamespace);
-            entityManager.remove(oldNamespace);
+            // find, not merge: this row is about to go, so merging every column of a detached copy
+            // first was a wasted UPDATE - and would have resurrected a row already deleted.
+            var managedOldNamespace = entityManager.find(Namespace.class, oldNamespace.getId());
+            if (managedOldNamespace != null) {
+                entityManager.remove(managedOldNamespace);
+            }
         }
 
         cache.evictSitemap();
         cache.evictNamespaceDetails(oldNamespace);
         search.updateSearchEntries(extensions.filter(Extension::isActive).toList());
+    }
+
+    /**
+     * Applies the names the caller computed for the copied resources. Only the name changes there
+     * (see {@code ChangeNamespaceJobRequestHandler}), so this writes that field rather than merging
+     * every column of each detached resource back - see #989.
+     */
+    private void renameResources(List<FileResource> updatedResources) {
+        for (var resource : updatedResources) {
+            var managedResource = entityManager.find(FileResource.class, resource.getId());
+            if (managedResource != null) {
+                managedResource.setName(resource.getName());
+            }
+        }
     }
 
     private void changeExtensionNamespace(Streamable<Extension> extensions, Namespace newNamespace) {

--- a/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
+++ b/server/src/main/java/org/eclipse/openvsx/eclipse/EclipseService.java
@@ -195,8 +195,14 @@ public class EclipseService {
      */
     @Transactional
     public void updateUserData(UserData user, EclipseProfile profile) {
-        user = entityManager.merge(user);
-        user.setEclipsePersonId(profile.getName());
+        // find-then-set rather than merge: merge writes every column of the detached copy, so
+        // anything that changed on the row since it was loaded gets reverted. Only the field
+        // below is this method's to change - see #989.
+        var managedUser = entityManager.find(UserData.class, user.getId());
+        if (managedUser == null) {
+            return;
+        }
+        managedUser.setEclipsePersonId(profile.getName());
     }
 
     public void enrichUserJsonWithPublisherAgreement(UserJson json, UserData user) {

--- a/server/src/main/java/org/eclipse/openvsx/migration/CheckPotentiallyMaliciousExtensionVersionsService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/CheckPotentiallyMaliciousExtensionVersionsService.java
@@ -33,9 +33,9 @@ public class CheckPotentiallyMaliciousExtensionVersionsService {
 
     @Transactional
     public void checkPotentiallyMaliciousExtensionVersion(ExtensionVersion extVersion, TempFile extensionFile) {
+        boolean isMalicious;
         try (var extProcessor = new ExtensionProcessor(extensionFile)) {
-            boolean isMalicious = extProcessor.isPotentiallyMalicious();
-            extVersion.setPotentiallyMalicious(isMalicious);
+            isMalicious = extProcessor.isPotentiallyMalicious();
             if (isMalicious) {
                 logger.atWarn()
                         .setMessage("Extension version is potentially malicious: {}")
@@ -43,6 +43,14 @@ public class CheckPotentiallyMaliciousExtensionVersionsService {
                         .log();
             }
         }
-        entityManager.merge(extVersion);
+
+        // find-then-set rather than merge: merge writes every column of the detached copy, so
+        // anything that changed on the row since it was loaded gets reverted. Only the field
+        // below is this method's to change - see #989.
+        var managedVersion = entityManager.find(ExtensionVersion.class, extVersion.getId());
+        if (managedVersion == null) {
+            return;
+        }
+        managedVersion.setPotentiallyMalicious(isMalicious);
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandler.java
@@ -73,7 +73,7 @@ public class FileResourceSizeJobRequestHandler implements JobRequestHandler<Migr
 
             try {
                 resource.setSize(migrations.getFileSize(resource));
-                migrations.updateResource(resource);
+                migrations.updateResourceSize(resource);
             } catch (FileNotFoundInStorageException e) {
                 // The object backing this resource is confirmed gone, not just temporarily
                 // unreachable -- there's nothing further this job can do about that

--- a/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/MigrationService.java
@@ -126,9 +126,18 @@ public class MigrationService {
         return entityManager.find(FileResource.class, jobRequest.getEntityId());
     }
 
+    /**
+     * Persists the size its caller determined for {@code resource}, and nothing else. Named for the
+     * one field it writes: a generic "update this resource" could only be implemented by merging the
+     * whole detached copy, which reverts any column that changed since it was loaded (#989).
+     */
     @Transactional
-    public void updateResource(FileResource resource) {
-        entityManager.merge(resource);
+    public void updateResourceSize(FileResource resource) {
+        var managedResource = entityManager.find(FileResource.class, resource.getId());
+        if (managedResource == null) {
+            return;
+        }
+        managedResource.setSize(resource.getSize());
     }
 
     @Retryable
@@ -161,8 +170,10 @@ public class MigrationService {
 
     @Transactional
     public void deleteFileResource(FileResource resource) {
-        resource = entityManager.merge(resource);
-        entityManager.remove(resource);
+        var managedResource = entityManager.find(FileResource.class, resource.getId());
+        if (managedResource != null) {
+            entityManager.remove(managedResource);
+        }
     }
 
     public FileResource getFileResource(ExtensionVersion extVersion, String type) {

--- a/server/src/main/java/org/eclipse/openvsx/migration/RenameDownloadsJobRequestHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/RenameDownloadsJobRequestHandler.java
@@ -54,7 +54,7 @@ public class RenameDownloadsJobRequestHandler implements JobRequestHandler<Migra
             migrations.removeFile(download);
 
             download.setName(name);
-            service.updateResource(download);
+            service.updateResourceName(download);
         }
 
         logger.info("Updated download name to: {}", name);

--- a/server/src/main/java/org/eclipse/openvsx/migration/RenameDownloadsService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/RenameDownloadsService.java
@@ -43,8 +43,16 @@ public class RenameDownloadsService {
         return clone;
     }
 
+    /**
+     * Persists the new name its caller set on {@code resource}, and nothing else - see
+     * {@code MigrationService#updateResourceSize} for why this is named for its field.
+     */
     @Transactional
-    public void updateResource(FileResource resource) {
-        entityManager.merge(resource);
+    public void updateResourceName(FileResource resource) {
+        var managedResource = entityManager.find(FileResource.class, resource.getId());
+        if (managedResource == null) {
+            return;
+        }
+        managedResource.setName(resource.getName());
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/migration/SetPreReleaseJobService.java
+++ b/server/src/main/java/org/eclipse/openvsx/migration/SetPreReleaseJobService.java
@@ -44,11 +44,21 @@ public class SetPreReleaseJobService {
 
     @Transactional
     public void updatePreviewAndPreRelease(ExtensionVersion extVersion, TempFile extensionFile) {
+        boolean preRelease;
+        boolean preview;
         try (var extProcessor = new ExtensionProcessor(extensionFile)) {
-            extVersion.setPreRelease(extProcessor.isPreRelease());
-            extVersion.setPreview(extProcessor.isPreview());
+            preRelease = extProcessor.isPreRelease();
+            preview = extProcessor.isPreview();
         }
 
-        entityManager.merge(extVersion);
+        // find-then-set rather than merge: merge writes every column of the detached copy, so
+        // anything that changed on the row since it was loaded gets reverted. Only the field
+        // below is this method's to change - see #989.
+        var managedVersion = entityManager.find(ExtensionVersion.class, extVersion.getId());
+        if (managedVersion == null) {
+            return;
+        }
+        managedVersion.setPreRelease(preRelease);
+        managedVersion.setPreview(preview);
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/publish/ExtensionVersionIntegrityService.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/ExtensionVersionIntegrityService.java
@@ -97,8 +97,14 @@ public class ExtensionVersionIntegrityService {
 
     @Transactional
     public void setSignatureKeyPair(ExtensionVersion extVersion, SignatureKeyPair keyPair) {
-        extVersion = entityManager.merge(extVersion);
-        extVersion.setSignatureKeyPair(keyPair);
+        // find-then-set rather than merge: merge writes every column of the detached copy, so
+        // anything that changed on the row since it was loaded gets reverted. Only the field
+        // below is this method's to change - see #989.
+        var managedVersion = entityManager.find(ExtensionVersion.class, extVersion.getId());
+        if (managedVersion == null) {
+            return;
+        }
+        managedVersion.setSignatureKeyPair(keyPair);
     }
 
     public TempFile generateSignature(TempFile extensionFile, SignatureKeyPair keyPair) throws IOException {

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionService.java
@@ -91,8 +91,14 @@ public class PublishExtensionVersionService {
 
     @Transactional
     public void markExtensionAsPotentiallyMalicious(ExtensionVersion extVersion) {
-        extVersion = entityManager.merge(extVersion);
-        extVersion.setPotentiallyMalicious(true);
+        // find-then-set rather than merge: merge writes every column of the detached copy, so
+        // anything that changed on the row since it was loaded gets reverted. Only the field
+        // below is this method's to change - see #989.
+        var managedVersion = entityManager.find(ExtensionVersion.class, extVersion.getId());
+        if (managedVersion == null) {
+            return;
+        }
+        managedVersion.setPotentiallyMalicious(true);
     }
 
     @Transactional

--- a/server/src/main/java/org/eclipse/openvsx/ratelimit/CustomerService.java
+++ b/server/src/main/java/org/eclipse/openvsx/ratelimit/CustomerService.java
@@ -193,8 +193,17 @@ public class CustomerService {
 
     @Transactional
     public ResultJson deactivateRateLimitToken(RateLimitToken token) {
-        token = entityManager.merge(token);
-        token.setActive(false);
-        return ResultJson.success("Deactivated rate limit token for customer " + token.getCustomer().getName() + ".");
+        // find-then-set rather than merge: merge writes every column of the detached copy, so
+        // anything that changed on the row since it was loaded gets reverted. Only the field
+        // below is this method's to change - see #989.
+        var managedToken = entityManager.find(RateLimitToken.class, token.getId());
+        if (managedToken == null) {
+            // RateLimitAPI already established the token exists before calling, so this only
+            // happens if the row went away in between; matches how this class reports a missing row.
+            throw new ErrorResultException("Rate limit token not found: " + token.getId());
+        }
+        managedToken.setActive(false);
+        return ResultJson
+                .success("Deactivated rate limit token for customer " + managedToken.getCustomer().getName() + ".");
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandlerTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/migration/FileResourceSizeJobRequestHandlerTest.java
@@ -58,8 +58,8 @@ class FileResourceSizeJobRequestHandlerTest {
 
         new FileResourceSizeJobRequestHandler(migrations).run(jobRequest);
 
-        verify(migrations).updateResource(unsized);
-        verify(migrations, never()).updateResource(alreadySized);
+        verify(migrations).updateResourceSize(unsized);
+        verify(migrations, never()).updateResourceSize(alreadySized);
         verify(migrations, never()).getFileSize(alreadySized);
     }
 
@@ -78,8 +78,8 @@ class FileResourceSizeJobRequestHandlerTest {
 
         assertThatCode(() -> handler.run(jobRequest)).doesNotThrowAnyException();
 
-        verify(migrations, never()).updateResource(missing);
-        verify(migrations).updateResource(present);
+        verify(migrations, never()).updateResourceSize(missing);
+        verify(migrations).updateResourceSize(present);
     }
 
     private ExtensionVersion extVersion() {

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionServiceTest.java
@@ -179,6 +179,51 @@ class PublishExtensionVersionServiceTest {
         verify(entityManager).persist(resource);
     }
 
+    // #989: markExtensionAsPotentiallyMalicious used to merge the whole detached extVersion to set
+    // one boolean, so any column that had moved since the caller loaded it was reverted - the same
+    // failure mode that once left published extensions inactive. It now writes the flag on the
+    // managed row, matching what activateExtension above already did.
+    @Test
+    void markExtensionAsPotentiallyMalicious_flagsTheManagedRow() {
+        var stale = version(1L, false);
+        var managed = version(1L, false);
+        when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(managed);
+
+        svc.markExtensionAsPotentiallyMalicious(stale);
+
+        assertThat(managed.isPotentiallyMalicious()).isTrue();
+        verify(entityManager, never()).merge(any());
+    }
+
+    @Test
+    void markExtensionAsPotentiallyMalicious_leavesConcurrentChangesAlone() {
+        // The caller's copy was loaded while the version was still inactive; it has since been
+        // activated. Merging that stale copy back would have deactivated it again.
+        var stale = version(1L, false);
+        stale.setActive(false);
+        var managed = version(1L, false);
+        managed.setActive(true);
+        when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(managed);
+
+        svc.markExtensionAsPotentiallyMalicious(stale);
+
+        assertThat(managed.isPotentiallyMalicious()).isTrue();
+        assertThat(managed.isActive()).as("a concurrent activation must survive the flag write").isTrue();
+    }
+
+    // The row can be purged between the caller loading it and this running; merge would have tried
+    // to resurrect it rather than doing nothing.
+    @Test
+    void markExtensionAsPotentiallyMalicious_ignoresAVersionThatIsGone() {
+        var stale = version(1L, false);
+        when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(null);
+
+        svc.markExtensionAsPotentiallyMalicious(stale);
+
+        verify(entityManager, never()).merge(any());
+        verify(entityManager, never()).persist(any());
+    }
+
     private ExtensionVersion version(long id, boolean removed) {
         var namespace = new Namespace();
         namespace.setName("redhat");


### PR DESCRIPTION
Second and final batch of the #989 audit — the 13 sites left after #2150. Between the two, every `EntityManager.merge` call site has been dealt with.

> **Stacked on #2150.** The base is `fix/entitymanager-merge-audit`, so the diff here shows only this batch; GitHub will retarget it to `main` automatically once #2150 merges. Please review that one first.

## Why these were subtler than the first batch

Every site here *did* intend an update, so none of them is dead code. The hazard is that `merge` writes **every column** of the detached copy, so any field that moved on the row since the caller loaded it is silently reverted — which is exactly how the original outage happened. These sites have long windows between load and write: a VSIX download and scan, a storage round-trip.

The clearest example is a pair that could revert *each other*. `SetPreReleaseJobService` writes `preRelease`/`preview` and `CheckPotentiallyMaliciousExtensionVersionsService` writes `potentiallyMalicious`; both loaded an `ExtensionVersion`, did slow VSIX work, then merged the whole row. Overlapping on the same version, whichever finished second undid the other's field — and either could revert `active`.

## Service owns the mutation → `find` then set its own field

`EclipseService#updateUserData`, `CustomerService#deactivateRateLimitToken`, `ExtensionVersionIntegrityService#setSignatureKeyPair`, `PublishExtensionVersionService#markExtensionAsPotentiallyMalicious`, `AccessTokenService#scheduleTokenExpirationNotification`, `SetPreReleaseJobService`, `CheckPotentiallyMaliciousExtensionVersionsService`.

Worth noting that `PublishExtensionVersionService#activateExtension` **already** did exactly this, so the correct pattern was sitting next to the incorrect one in the same class; this makes the neighbours consistent with it.

## Two methods renamed for the field they persist

`MigrationService#updateResource` → `updateResourceSize`, `RenameDownloadsService#updateResource` → `updateResourceName`.

Their old signatures couldn't express *which* field the caller had changed, which is precisely why they had to merge the whole row. Naming them for the field they write removes the hazard and stops a future caller setting something else and quietly having it dropped. Each had exactly one caller.

## Merge before remove

`MigrationService#deleteFileResource` and the old namespace in `ChangeNamespaceService` now `find` and `remove`, skipping a row that has already gone rather than having `merge` try to resurrect it.

## One merge deliberately kept

`ChangeNamespaceService` keeps a single merge, now documented:

```java
} else {
    // Deliberately a merge, unlike the rest of #989's call sites: the caller mutates this
    // detached namespace before handing it over (ChangeNamespaceJobRequestHandler sets
    // logoName on it), so the update belongs to the caller and only merge can carry it.
    // find-then-set would silently drop that rename.
    newNamespace = entityManager.merge(newNamespace);
}
```

I nearly converted this one before reading the caller. So the conclusion of the audit isn't "merge is wrong" — it's that merge is wrong when the *service* owns the mutation, and right when the *caller* does. That distinction is what the comment is there to preserve. The same method's `updatedResources` loop only ever changes the name, so that one writes just the name.

`CustomerService` needed something to throw for the vanished-row case; it uses `ErrorResultException`, which the class already imports and uses for a missing row, rather than introducing a different exception type.

## Testing

Full server suite green (1145 tests). Three new cases on `markExtensionAsPotentiallyMalicious`: the flag landing on the managed row, a concurrent activation **surviving** the write (the reverted-column case, which is the point of the change), and a version purged in the meantime being ignored rather than resurrected.

Fixes #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)
