### PR TITLE
feat(cli): add a show command

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ This change log covers only the command line interface (CLI) of Open VSX.
 
 #### Added
 
+- Add `show` command to print an extension's metadata, mirroring `vsce show`: identity, publisher, rating, notices and a version history listing each version's target platforms ([#2149](https://github.com/eclipse-openvsx/openvsx/issues/2149)). `namespace.extension@version` reports a single version, `--target` scopes the report to one target platform, `--all-versions` lists every published version instead of the most recent few, and `--json` prints the registry's raw metadata
 - Add `unpublish` command to delete an extension or some of its versions, mirroring `vsce unpublish` ([#1958](https://github.com/eclipse-openvsx/openvsx/issues/1958)); requires a registry running version 1.2.0 or later, which `unpublish` checks for before deleting
 - `publish` checks the packaged extension's size against the limit reported by the registry's `/api/version` endpoint before uploading, instead of failing only after the upload completes ([#1953](https://github.com/eclipse-openvsx/openvsx/issues/1953))
 - Add `verify` command to check a downloaded `.vsix` package's signature against the registry's public key, mirroring `vsce verify-signature` ([#993](https://github.com/eclipse-openvsx/openvsx/issues/993))

--- a/cli/src/get.ts
+++ b/cli/src/get.ts
@@ -23,7 +23,7 @@ export async function getExtension(options: GetOptions): Promise<void> {
     const registry = new Registry(options);
     const match = matchExtensionId(options.extensionId);
     if (!match) {
-        throw new Error('The extension identifier must have the form `namespace.extension`.');
+        throw new Error('The extension identifier must have the form `namespace.extension` or `namespace/extension`.');
     }
 
     const extension = await registry.getMetadata(match[1], match[2], options.target);

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -16,6 +16,7 @@ import { publish } from './publish';
 import { unpublish } from './unpublish';
 import { handleError } from './util';
 import { getExtension } from './get';
+import { show } from './show';
 import { verify } from './verify';
 import { verifySignature } from './verify-signature';
 import login from './login';
@@ -114,6 +115,16 @@ module.exports = function (argv: string[]): void {
                 registryUrl,
                 pat
             }).catch(handleError(program.debug));
+        });
+
+    const showCmd = program.command('show <namespace.extension[@version]>');
+    showCmd.description('Show an extension\'s metadata.')
+        .option('-t, --target <target>', 'Only report on the given target architecture.')
+        .option('--all-versions', 'List every published version instead of the most recent few.')
+        .option('--json', 'Print the raw metadata as JSON.')
+        .action((extensionId: string, { target, allVersions, json }) => {
+            const { registryUrl } = program.opts();
+            show({ extensionId, target, allVersions, json, registryUrl }).catch(handleError(program.debug));
         });
 
     const getCmd = program.command('get <namespace.extension>');

--- a/cli/src/registry.ts
+++ b/cli/src/registry.ts
@@ -139,16 +139,15 @@ export class Registry {
     }
 
     /**
-     * Returns every published version of an extension, one entry per version and target platform.
-     * `allVersions` on the metadata response only carries version numbers and links, so this is
-     * what makes timestamps and pre-release flags available without a request per version.
+     * Returns a page of an extension's published versions, newest first, one entry per version and
+     * target platform. `allVersions` on the metadata response carries version numbers and links
+     * only, so this is what makes the target platforms of each version available.
      */
-    queryAllVersions(namespace: string, extension: string): Promise<QueryResult> {
+    getVersionReferences(namespace: string, extension: string, size: number, offset: number): Promise<VersionReferences> {
         try {
-            return this.getJson(this.getUrl(['api', 'v2', '-', 'query'], {
-                namespaceName: namespace,
-                extensionName: extension,
-                includeAllVersions: 'true'
+            return this.getJson(this.getUrl(['api', namespace, extension, 'version-references'], {
+                size: String(size),
+                offset: String(offset)
             }));
         } catch (err) {
             return rejectError(err);
@@ -381,10 +380,18 @@ export interface ExtensionReplacement {
     displayName?: string;
 }
 
-export interface QueryResult extends Response {
+export interface VersionReference {
+    url: string;
+    files: { [type: string]: string };
+    version: string;
+    targetPlatform?: string;
+    engines?: { [engine: string]: string };
+}
+
+export interface VersionReferences extends Response {
     offset: number;
     totalSize: number;
-    extensions?: Extension[];
+    versions?: VersionReference[];
 }
 
 export interface ExtensionReference {

--- a/cli/src/registry.ts
+++ b/cli/src/registry.ts
@@ -123,13 +123,33 @@ export class Registry {
         }
     }
 
-    getMetadata(namespace: string, extension: string, target?: string): Promise<Extension> {
+    getMetadata(namespace: string, extension: string, target?: string, version?: string): Promise<Extension> {
         try {
             const segments = ['api', namespace, extension];
             if (target) {
                 segments.push(target);
             }
+            if (version) {
+                segments.push(version);
+            }
             return this.getJson(this.getUrl(segments));
+        } catch (err) {
+            return rejectError(err);
+        }
+    }
+
+    /**
+     * Returns every published version of an extension, one entry per version and target platform.
+     * `allVersions` on the metadata response only carries version numbers and links, so this is
+     * what makes timestamps and pre-release flags available without a request per version.
+     */
+    queryAllVersions(namespace: string, extension: string): Promise<QueryResult> {
+        try {
+            return this.getJson(this.getUrl(['api', 'v2', '-', 'query'], {
+                namespaceName: namespace,
+                extensionName: extension,
+                includeAllVersions: 'true'
+            }));
         } catch (err) {
             return rejectError(err);
         }
@@ -293,8 +313,18 @@ export interface Extension extends Response {
     versionAlias: string[];
     timestamp: string;
     preview?: boolean;
+    preRelease?: boolean;
     displayName?: string;
+    namespaceDisplayName?: string;
     description?: string;
+    deprecated?: boolean;
+    replacement?: ExtensionReplacement;
+    downloadable?: boolean;
+    publishedWithTrustedPublishing?: boolean;
+    namespaceOwnershipConflict?: boolean;
+    extensionKind?: string[];
+    localizedLanguages?: string[];
+    sponsorLink?: string;
 
     // key: engine, value: version constraint
     engines?: { [engine: string]: string };
@@ -344,6 +374,17 @@ export interface Badge {
     url: string;
     href: string;
     description: string;
+}
+
+export interface ExtensionReplacement {
+    url: string;
+    displayName?: string;
+}
+
+export interface QueryResult extends Response {
+    offset: number;
+    totalSize: number;
+    extensions?: Extension[];
 }
 
 export interface ExtensionReference {

--- a/cli/src/registry.ts
+++ b/cli/src/registry.ts
@@ -143,9 +143,20 @@ export class Registry {
      * target platform. `allVersions` on the metadata response carries version numbers and links
      * only, so this is what makes the target platforms of each version available.
      */
-    getVersionReferences(namespace: string, extension: string, size: number, offset: number): Promise<VersionReferences> {
+    getVersionReferences(
+        namespace: string,
+        extension: string,
+        target: string | undefined,
+        size: number,
+        offset: number
+    ): Promise<VersionReferences> {
         try {
-            return this.getJson(this.getUrl(['api', namespace, extension, 'version-references'], {
+            const segments = ['api', namespace, extension];
+            if (target) {
+                segments.push(target);
+            }
+            segments.push('version-references');
+            return this.getJson(this.getUrl(segments, {
                 size: String(size),
                 offset: String(offset)
             }));

--- a/cli/src/show-options.ts
+++ b/cli/src/show-options.ts
@@ -1,0 +1,34 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import { RegistryOptions } from './registry-options';
+
+export interface ShowOptions extends RegistryOptions {
+    /**
+     * Identifier in the form `namespace.extension` or `namespace/extension`, optionally suffixed
+     * with `@<version>` - an exact version, or one of the `latest` / `pre-release` aliases.
+     */
+    extensionId: string;
+    /**
+     * Target platform to report on. Defaults to whichever the registry considers current.
+     */
+    target?: string;
+    /**
+     * Print the raw metadata as JSON instead of a readable summary.
+     */
+    json?: boolean;
+    /**
+     * List every published version rather than the most recent few.
+     */
+    allVersions?: boolean;
+}

--- a/cli/src/show.ts
+++ b/cli/src/show.ts
@@ -12,7 +12,7 @@
  *****************************************************************************/
 
 import * as semver from 'semver';
-import { Extension, Registry } from './registry';
+import { Extension, Registry, VersionReference } from './registry';
 import { ShowOptions } from './show-options';
 import { addEnvOptions, matchExtensionId } from './util';
 
@@ -31,10 +31,15 @@ const INTERNAL_TAG_PREFIX = '__';
 /** One row of the version history table. */
 interface VersionSummary {
     version: string;
-    timestamp?: string;
-    preRelease: boolean;
     targetPlatforms: string[];
 }
+
+/**
+ * Page size for the version-reference listing. Versions come back newest first, and each version
+ * contributes one entry per target platform, so a page has to be comfortably larger than the
+ * number of versions shown for the default table to be filled from a single request.
+ */
+const VERSION_PAGE_SIZE = 100;
 
 /**
  * Prints an extension's metadata.
@@ -59,7 +64,8 @@ export async function show(options: ShowOptions): Promise<void> {
         return;
     }
 
-    printSummary(extension, await getVersions(registry, namespace, name), options.allVersions === true);
+    const allVersions = options.allVersions === true;
+    printSummary(extension, await getVersions(registry, namespace, name, allVersions), allVersions);
 }
 
 /**
@@ -75,36 +81,49 @@ function splitVersion(extensionId: string): { id: string; version?: string } {
 }
 
 /**
- * Collects the version history, collapsing the one-entry-per-target-platform rows the query
- * returns into a single row per version. Best-effort: a registry that doesn't serve the v2 query
- * endpoint still gets everything else, just without the history table.
+ * Collects the version history, collapsing the one-entry-per-target-platform rows the registry
+ * returns into a single row per version. Fetches one page unless every version is wanted, in which
+ * case it pages to the end - `totalSize` counts version/target-platform pairs, not versions, so
+ * paging has to run on what has actually been returned rather than on a version count.
+ *
+ * Best-effort: a registry that doesn't serve this endpoint still gets everything else, just
+ * without the history table.
  */
-async function getVersions(registry: Registry, namespace: string, name: string): Promise<VersionSummary[]> {
-    let extensions: Extension[] | undefined;
+async function getVersions(
+    registry: Registry,
+    namespace: string,
+    name: string,
+    allVersions: boolean
+): Promise<VersionSummary[]> {
+    const references: VersionReference[] = [];
+    let offset = 0;
     try {
-        extensions = (await registry.queryAllVersions(namespace, name)).extensions;
+        for (;;) {
+            const page = await registry.getVersionReferences(namespace, name, VERSION_PAGE_SIZE, offset);
+            if (page.error) {
+                return [];
+            }
+            const versions = page.versions ?? [];
+            references.push(...versions);
+            offset += versions.length;
+            if (!allVersions || versions.length === 0 || offset >= page.totalSize) {
+                break;
+            }
+        }
     } catch {
-        return [];
-    }
-    if (!extensions) {
         return [];
     }
 
     const byVersion = new Map<string, VersionSummary>();
-    for (const extension of extensions) {
-        const summary = byVersion.get(extension.version);
-        if (summary) {
-            if (extension.targetPlatform && !summary.targetPlatforms.includes(extension.targetPlatform)) {
-                summary.targetPlatforms.push(extension.targetPlatform);
-            }
-            continue;
+    for (const reference of references) {
+        let summary = byVersion.get(reference.version);
+        if (!summary) {
+            summary = { version: reference.version, targetPlatforms: [] };
+            byVersion.set(reference.version, summary);
         }
-        byVersion.set(extension.version, {
-            version: extension.version,
-            timestamp: extension.timestamp,
-            preRelease: extension.preRelease === true,
-            targetPlatforms: extension.targetPlatform ? [extension.targetPlatform] : []
-        });
+        if (reference.targetPlatform && !summary.targetPlatforms.includes(reference.targetPlatform)) {
+            summary.targetPlatforms.push(reference.targetPlatform);
+        }
     }
 
     return [...byVersion.values()].sort(byNewestFirst);
@@ -186,16 +205,11 @@ function printVersionHistory(versions: VersionSummary[], allVersions: boolean): 
     }
 
     const shown = allVersions ? versions : versions.slice(0, VERSION_HISTORY_SIZE);
-    const rows = shown.map(v => [
-        v.version,
-        v.timestamp ?? '',
-        v.preRelease ? 'pre-release' : '',
-        v.targetPlatforms.join(', ')
-    ]);
+    const rows = shown.map(v => [v.version, v.targetPlatforms.join(', ')]);
 
     console.log();
     console.log('Version History:');
-    printRows([['Version', 'Last Updated', '', 'Target Platforms'], ...rows]);
+    printRows([['Version', 'Target Platforms'], ...rows]);
     const remaining = versions.length - shown.length;
     if (remaining > 0) {
         console.log(`  ... and ${remaining} more (pass --all-versions to list them)`);

--- a/cli/src/show.ts
+++ b/cli/src/show.ts
@@ -1,0 +1,319 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import * as semver from 'semver';
+import { Extension, Registry } from './registry';
+import { ShowOptions } from './show-options';
+import { addEnvOptions, matchExtensionId } from './util';
+
+/**
+ * How many versions the history table prints unless `--all-versions` is given. Matches what
+ * `vsce show` lists; the remainder is reported as a count rather than dropped silently.
+ */
+const VERSION_HISTORY_SIZE = 6;
+
+/**
+ * Tags starting with `__` are internal bookkeeping (e.g. `__web_extension`) rather than anything
+ * the publisher wrote, and the web UI hides them too.
+ */
+const INTERNAL_TAG_PREFIX = '__';
+
+/** One row of the version history table. */
+interface VersionSummary {
+    version: string;
+    timestamp?: string;
+    preRelease: boolean;
+    targetPlatforms: string[];
+}
+
+/**
+ * Prints an extension's metadata.
+ */
+export async function show(options: ShowOptions): Promise<void> {
+    addEnvOptions(options);
+    const { id, version } = splitVersion(options.extensionId);
+    const match = matchExtensionId(id);
+    if (!match) {
+        throw new Error('The extension identifier must have the form `namespace.extension`.');
+    }
+
+    const [, namespace, name] = match;
+    const registry = new Registry(options);
+    const extension = await registry.getMetadata(namespace, name, options.target, version);
+    if (extension.error) {
+        throw new Error(extension.error);
+    }
+
+    if (options.json) {
+        console.log(JSON.stringify(extension, null, 4));
+        return;
+    }
+
+    printSummary(extension, await getVersions(registry, namespace, name), options.allVersions === true);
+}
+
+/**
+ * Splits a trailing `@<version>` off the identifier, the way `vsce show` accepts it. Only the last
+ * `@` is considered, so it stays out of the way of the identifier itself.
+ */
+function splitVersion(extensionId: string): { id: string; version?: string } {
+    const at = extensionId.lastIndexOf('@');
+    if (at <= 0) {
+        return { id: extensionId };
+    }
+    return { id: extensionId.substring(0, at), version: extensionId.substring(at + 1) };
+}
+
+/**
+ * Collects the version history, collapsing the one-entry-per-target-platform rows the query
+ * returns into a single row per version. Best-effort: a registry that doesn't serve the v2 query
+ * endpoint still gets everything else, just without the history table.
+ */
+async function getVersions(registry: Registry, namespace: string, name: string): Promise<VersionSummary[]> {
+    let extensions: Extension[] | undefined;
+    try {
+        extensions = (await registry.queryAllVersions(namespace, name)).extensions;
+    } catch {
+        return [];
+    }
+    if (!extensions) {
+        return [];
+    }
+
+    const byVersion = new Map<string, VersionSummary>();
+    for (const extension of extensions) {
+        const summary = byVersion.get(extension.version);
+        if (summary) {
+            if (extension.targetPlatform && !summary.targetPlatforms.includes(extension.targetPlatform)) {
+                summary.targetPlatforms.push(extension.targetPlatform);
+            }
+            continue;
+        }
+        byVersion.set(extension.version, {
+            version: extension.version,
+            timestamp: extension.timestamp,
+            preRelease: extension.preRelease === true,
+            targetPlatforms: extension.targetPlatform ? [extension.targetPlatform] : []
+        });
+    }
+
+    return [...byVersion.values()].sort(byNewestFirst);
+}
+
+/**
+ * Newest version first. Anything that isn't valid semver (the registry accepts such versions from
+ * a mirror) sorts after everything that is, rather than being compared incomparably.
+ */
+function byNewestFirst(a: VersionSummary, b: VersionSummary): number {
+    const left = semver.coerce(a.version);
+    const right = semver.coerce(b.version);
+    if (left && right) {
+        return semver.rcompare(left, right);
+    }
+    if (left) {
+        return -1;
+    }
+    if (right) {
+        return 1;
+    }
+    return b.version.localeCompare(a.version);
+}
+
+function printSummary(extension: Extension, versions: VersionSummary[], allVersions: boolean): void {
+    const publisher = extension.namespaceDisplayName || extension.namespace;
+    console.log(extension.displayName || extension.name);
+    console.log(`  ${publisher}${extension.verified ? ' (verified publisher)' : ''}`);
+    console.log(`  ${formatCount(extension.downloadCount, 'download')}  ${formatRating(extension)}`);
+    if (extension.description) {
+        console.log();
+        console.log(`  ${extension.description}`);
+    }
+
+    printNotices(extension);
+    printVersionHistory(versions, allVersions);
+    printList('Categories', extension.categories);
+    printList('Tags', extension.tags?.filter(tag => !tag.startsWith(INTERNAL_TAG_PREFIX)));
+    printTable('More Info', moreInfo(extension));
+    printTable('Registry', registryInfo(extension));
+    printTable('Statistics', statistics(extension));
+}
+
+/**
+ * Anything a consumer of this extension should see before its metadata: deprecation first, since
+ * it changes whether they should install it at all.
+ */
+function printNotices(extension: Extension): void {
+    const notices: string[] = [];
+    if (extension.deprecated) {
+        const replacement = extension.replacement;
+        notices.push(
+            replacement
+                ? `Deprecated - superseded by ${replacement.displayName ?? replacement.url}`
+                : 'Deprecated'
+        );
+    }
+    if (extension.downloadable === false) {
+        notices.push('Not downloadable from this registry');
+    }
+    if (extension.preview) {
+        notices.push('Preview');
+    }
+    if (extension.namespaceOwnershipConflict) {
+        notices.push('The namespace ownership of this extension is disputed');
+    }
+
+    if (notices.length > 0) {
+        console.log();
+        for (const notice of notices) {
+            console.log(`  ! ${notice}`);
+        }
+    }
+}
+
+function printVersionHistory(versions: VersionSummary[], allVersions: boolean): void {
+    if (versions.length === 0) {
+        return;
+    }
+
+    const shown = allVersions ? versions : versions.slice(0, VERSION_HISTORY_SIZE);
+    const rows = shown.map(v => [
+        v.version,
+        v.timestamp ?? '',
+        v.preRelease ? 'pre-release' : '',
+        v.targetPlatforms.join(', ')
+    ]);
+
+    console.log();
+    console.log('Version History:');
+    printRows([['Version', 'Last Updated', '', 'Target Platforms'], ...rows]);
+    const remaining = versions.length - shown.length;
+    if (remaining > 0) {
+        console.log(`  ... and ${remaining} more (pass --all-versions to list them)`);
+    }
+}
+
+function moreInfo(extension: Extension): string[][] {
+    const rows: string[][] = [
+        ['Unique Identifier', `${extension.namespace}.${extension.name}`],
+        ['Version', extension.version]
+    ];
+    if (extension.versionAlias?.length > 0) {
+        rows.push(['Version Aliases', extension.versionAlias.join(', ')]);
+    }
+    if (extension.targetPlatform) {
+        rows.push(['Target Platform', extension.targetPlatform]);
+    }
+    rows.push(['Last Updated', extension.timestamp]);
+    rows.push(['Published By', extension.publishedBy?.loginName ?? '']);
+    addIfPresent(rows, 'License', extension.license);
+    addIfPresent(rows, 'Homepage', extension.homepage);
+    addIfPresent(rows, 'Repository', extension.repository);
+    addIfPresent(rows, 'Bugs', extension.bugs);
+    addIfPresent(rows, 'Q&A', extension.qna);
+    addIfPresent(rows, 'Sponsor', extension.sponsorLink);
+    if (extension.engines) {
+        rows.push(['Engines', Object.entries(extension.engines).map(([e, v]) => `${e} ${v}`).join(', ')]);
+    }
+    return rows;
+}
+
+/**
+ * The parts an Open VSX compatible registry reports that the Marketplace has no equivalent for.
+ * Kept in its own block rather than mixed into "More Info" so it's obvious what is registry
+ * specific, and omitted entirely when none of it applies.
+ */
+function registryInfo(extension: Extension): string[][] {
+    const rows: string[][] = [];
+    if (extension.verified !== undefined) {
+        rows.push(['Verified Publisher', yesNo(extension.verified)]);
+    }
+    if (extension.publishedWithTrustedPublishing) {
+        rows.push(['Trusted Publishing', 'yes']);
+    }
+    if (extension.preRelease !== undefined) {
+        rows.push(['Pre-Release', yesNo(extension.preRelease)]);
+    }
+    addIfPresent(rows, 'Extension Kind', extension.extensionKind?.join(', '));
+    addIfPresent(rows, 'Localized', extension.localizedLanguages?.join(', '));
+    addIfPresent(rows, 'Dependencies', extension.dependencies?.map(referenceId).join(', '));
+    addIfPresent(rows, 'Bundled Extensions', extension.bundledExtensions?.map(referenceId).join(', '));
+    return rows;
+}
+
+function statistics(extension: Extension): string[][] {
+    const rows: string[][] = [['Downloads', (extension.downloadCount ?? 0).toLocaleString('en-US')]];
+    if (extension.averageRating !== undefined) {
+        rows.push(['Average Rating', `${extension.averageRating.toFixed(1)}/5`]);
+    }
+    rows.push(['Reviews', Number(extension.reviewCount ?? 0).toLocaleString('en-US')]);
+    return rows;
+}
+
+function referenceId(reference: { namespace: string; extension: string }): string {
+    return `${reference.namespace}.${reference.extension}`;
+}
+
+function addIfPresent(rows: string[][], label: string, value?: string): void {
+    if (value) {
+        rows.push([label, value]);
+    }
+}
+
+function printList(title: string, values?: string[]): void {
+    if (!values || values.length === 0) {
+        return;
+    }
+    console.log();
+    console.log(`${title}:`);
+    console.log(`  ${values.join(', ')}`);
+}
+
+function printTable(title: string, rows: string[][]): void {
+    if (rows.length === 0) {
+        return;
+    }
+    console.log();
+    console.log(`${title}:`);
+    printRows(rows);
+}
+
+/** Pads every column but the last, so trailing empty cells don't leave ragged whitespace. */
+function printRows(rows: string[][]): void {
+    const widths: number[] = [];
+    for (const row of rows) {
+        row.forEach((cell, i) => widths[i] = Math.max(widths[i] ?? 0, cell.length));
+    }
+    for (const row of rows) {
+        const line = row
+            .map((cell, i) => (i === row.length - 1 ? cell : cell.padEnd(widths[i])))
+            .join('  ')
+            .trimEnd();
+        console.log(`  ${line}`);
+    }
+}
+
+function formatCount(count: number | undefined, noun: string): string {
+    const value = count ?? 0;
+    return `${value.toLocaleString('en-US')} ${value === 1 ? noun : noun + 's'}`;
+}
+
+function formatRating(extension: Extension): string {
+    if (extension.averageRating === undefined) {
+        return 'no ratings';
+    }
+    return `${extension.averageRating.toFixed(1)}/5 from ${formatCount(Number(extension.reviewCount), 'review')}`;
+}
+
+function yesNo(value: boolean): string {
+    return value ? 'yes' : 'no';
+}

--- a/cli/src/show.ts
+++ b/cli/src/show.ts
@@ -72,13 +72,21 @@ export async function show(options: ShowOptions): Promise<void> {
 /**
  * Splits a trailing `@<version>` off the identifier, the way `vsce show` accepts it. Only the last
  * `@` is considered, so it stays out of the way of the identifier itself.
+ *
+ * An `@` with nothing after it is rejected rather than read as "no version given". It usually means a
+ * shell variable that did not expand - `ovsx show redhat.java@$VERSION` with `VERSION` unset - and
+ * reporting the latest version for that would answer a question the caller did not ask.
  */
 function splitVersion(extensionId: string): { id: string; version?: string } {
     const at = extensionId.lastIndexOf('@');
     if (at <= 0) {
         return { id: extensionId };
     }
-    return { id: extensionId.substring(0, at), version: extensionId.substring(at + 1) };
+    const version = extensionId.substring(at + 1);
+    if (version.length === 0) {
+        throw new Error('A version must follow `@`, as in `namespace.extension@1.2.3`.');
+    }
+    return { id: extensionId.substring(0, at), version };
 }
 
 /**

--- a/cli/src/show.ts
+++ b/cli/src/show.ts
@@ -49,7 +49,7 @@ export async function show(options: ShowOptions): Promise<void> {
     const { id, version } = splitVersion(options.extensionId);
     const match = matchExtensionId(id);
     if (!match) {
-        throw new Error('The extension identifier must have the form `namespace.extension`.');
+        throw new Error('The extension identifier must have the form `namespace.extension` or `namespace/extension`.');
     }
 
     const [, namespace, name] = match;
@@ -65,7 +65,8 @@ export async function show(options: ShowOptions): Promise<void> {
     }
 
     const allVersions = options.allVersions === true;
-    printSummary(extension, await getVersions(registry, namespace, name, allVersions), allVersions);
+    const versions = await getVersions(registry, namespace, name, options.target, allVersions);
+    printSummary(extension, versions, allVersions);
 }
 
 /**
@@ -93,13 +94,14 @@ async function getVersions(
     registry: Registry,
     namespace: string,
     name: string,
+    target: string | undefined,
     allVersions: boolean
 ): Promise<VersionSummary[]> {
     const references: VersionReference[] = [];
     let offset = 0;
     try {
         for (;;) {
-            const page = await registry.getVersionReferences(namespace, name, VERSION_PAGE_SIZE, offset);
+            const page = await registry.getVersionReferences(namespace, name, target, VERSION_PAGE_SIZE, offset);
             if (page.error) {
                 return [];
             }
@@ -132,10 +134,14 @@ async function getVersions(
 /**
  * Newest version first. Anything that isn't valid semver (the registry accepts such versions from
  * a mirror) sorts after everything that is, rather than being compared incomparably.
+ *
+ * Deliberately `valid` and not `coerce`: coerce drops prerelease identifiers, so `1.2.0-alpha.1`
+ * and `1.2.0` would compare equal and order unstably, and it accepts inputs semver itself rejects
+ * (`v1.2` becomes `1.2.0`), which would defeat the fallback below.
  */
 function byNewestFirst(a: VersionSummary, b: VersionSummary): number {
-    const left = semver.coerce(a.version);
-    const right = semver.coerce(b.version);
+    const left = semver.valid(a.version);
+    const right = semver.valid(b.version);
     if (left && right) {
         return semver.rcompare(left, right);
     }
@@ -325,7 +331,7 @@ function formatRating(extension: Extension): string {
     if (extension.averageRating === undefined) {
         return 'no ratings';
     }
-    return `${extension.averageRating.toFixed(1)}/5 from ${formatCount(Number(extension.reviewCount), 'review')}`;
+    return `${extension.averageRating.toFixed(1)}/5 from ${formatCount(extension.reviewCount, 'review')}`;
 }
 
 function yesNo(value: boolean): string {

--- a/cli/src/unpublish.ts
+++ b/cli/src/unpublish.ts
@@ -41,7 +41,7 @@ export async function unpublish(options: UnpublishOptions = {}): Promise<void> {
     const extensionId = options.extensionId ?? await readExtensionId();
     const match = matchExtensionId(extensionId);
     if (!match) {
-        throw new Error('The extension identifier must have the form `namespace.extension`.');
+        throw new Error('The extension identifier must have the form `namespace.extension` or `namespace/extension`.');
     }
 
     const [, namespace, extension] = match;

--- a/cli/test/unit/show.spec.ts
+++ b/cli/test/unit/show.spec.ts
@@ -1,0 +1,273 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { show } from '../../src/show';
+
+interface ShowRequest {
+    pathname: string;
+    query: URLSearchParams;
+}
+
+interface RegistryStub {
+    url: string;
+    metadataRequests: ShowRequest[];
+    queryRequests: ShowRequest[];
+    close: () => Promise<void>;
+}
+
+const extension = {
+    namespace: 'redhat',
+    name: 'java',
+    version: '1.2.0',
+    targetPlatform: 'universal',
+    displayName: 'Language Support for Java',
+    description: 'Java language support',
+    timestamp: '2026-08-01T10:00:00Z',
+    versionAlias: ['latest'],
+    downloadCount: 1234567,
+    averageRating: 4.25,
+    reviewCount: 12,
+    verified: true,
+    publishedBy: { loginName: 'redhat-bot' },
+    categories: ['Programming Languages', 'Linters'],
+    tags: ['java', '__web_extension'],
+    license: 'EPL-2.0',
+    repository: 'https://github.com/redhat-developer/vscode-java',
+    engines: { vscode: '^1.90.0' },
+    extensionKind: ['workspace'],
+    publishedWithTrustedPublishing: true,
+    preRelease: false
+};
+
+/** Stands in for `/api/{namespace}/{extension}` plus the v2 query used for version history. */
+async function startRegistryStub(
+    metadata: { status?: number; body?: unknown } = {},
+    query: { status?: number; body?: unknown } = {}
+): Promise<RegistryStub> {
+    const metadataRequests: ShowRequest[] = [];
+    const queryRequests: ShowRequest[] = [];
+    const server = http.createServer((req, res) => {
+        const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+        const request = { pathname: url.pathname, query: url.searchParams };
+        const isQuery = url.pathname === '/api/v2/-/query';
+        (isQuery ? queryRequests : metadataRequests).push(request);
+        const stub = isQuery ? query : metadata;
+        res.writeHead(stub.status ?? 200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(stub.body ?? (isQuery ? { offset: 0, totalSize: 1, extensions: [extension] } : extension)));
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as AddressInfo).port;
+    return {
+        url: `http://127.0.0.1:${port}`,
+        metadataRequests,
+        queryRequests,
+        close: () => new Promise<void>(resolve => server.close(() => resolve()))
+    };
+}
+
+describe('show', () => {
+
+    const stubs: RegistryStub[] = [];
+    let log: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    });
+
+    afterEach(async () => {
+        log.mockRestore();
+        await Promise.all(stubs.splice(0).map(stub => stub.close()));
+    });
+
+    async function givenRegistry(
+        metadata?: { status?: number; body?: unknown },
+        query?: { status?: number; body?: unknown }
+    ): Promise<RegistryStub> {
+        const stub = await startRegistryStub(metadata, query);
+        stubs.push(stub);
+        return stub;
+    }
+
+    /** The printed output as one string, so assertions can be about content rather than layout. */
+    function output(): string {
+        return log.mock.calls.map(call => String(call[0] ?? '')).join('\n');
+    }
+
+    it('rejects a malformed extension identifier', async () => {
+        const registry = await givenRegistry();
+        await expect(show({ extensionId: 'not-an-id', registryUrl: registry.url }))
+            .rejects.toThrow('The extension identifier must have the form `namespace.extension`.');
+        expect(registry.metadataRequests).toHaveLength(0);
+    });
+
+    it('reports the error the registry returns', async () => {
+        const registry = await givenRegistry({ body: { error: 'Extension not found: redhat.java' } });
+        await expect(show({ extensionId: 'redhat.java', registryUrl: registry.url }))
+            .rejects.toThrow('Extension not found: redhat.java');
+    });
+
+    it('prints the identity, publisher and statistics', async () => {
+        const registry = await givenRegistry();
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url });
+
+        expect(registry.metadataRequests[0].pathname).toBe('/api/redhat/java');
+        const printed = output();
+        expect(printed).toContain('Language Support for Java');
+        expect(printed).toContain('redhat (verified publisher)');
+        expect(printed).toContain('1,234,567 downloads');
+        expect(printed).toContain('4.3/5 from 12 reviews');
+        expect(printed).toContain('redhat.java');
+        expect(printed).toContain('EPL-2.0');
+    });
+
+    it('hides internal tags', async () => {
+        const registry = await givenRegistry();
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url });
+
+        const printed = output();
+        expect(printed).toContain('java');
+        expect(printed).not.toContain('__web_extension');
+    });
+
+    it('reports the registry-specific metadata the Marketplace has no equivalent for', async () => {
+        const registry = await givenRegistry();
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url });
+
+        const printed = output();
+        expect(printed).toContain('Verified Publisher');
+        expect(printed).toContain('Trusted Publishing');
+        expect(printed).toContain('Extension Kind');
+    });
+
+    it('leads with a deprecation notice and names the replacement', async () => {
+        const registry = await givenRegistry({
+            body: {
+                ...extension,
+                deprecated: true,
+                replacement: { url: 'https://open-vsx.org/extension/redhat/java-next', displayName: 'Java Next' }
+            }
+        });
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url });
+
+        expect(output()).toContain('Deprecated - superseded by Java Next');
+    });
+
+    it('collapses the per-target-platform rows into one row per version', async () => {
+        const registry = await givenRegistry({}, {
+            body: {
+                offset: 0,
+                totalSize: 3,
+                extensions: [
+                    { ...extension, version: '1.2.0', targetPlatform: 'linux-x64' },
+                    { ...extension, version: '1.2.0', targetPlatform: 'win32-x64' },
+                    { ...extension, version: '1.1.0', targetPlatform: 'universal', preRelease: true }
+                ]
+            }
+        });
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url });
+
+        expect(registry.queryRequests[0].query.get('includeAllVersions')).toBe('true');
+        const printed = output();
+        expect(printed).toContain('Version History:');
+        expect(printed).toContain('linux-x64, win32-x64');
+        expect(printed).toContain('pre-release');
+    });
+
+    // The query makes no ordering promise, so the sort has to happen here - and it has to, because
+    // the history cap would otherwise drop an arbitrary version rather than the oldest.
+    it('orders the version history newest first', async () => {
+        const registry = await givenRegistry({}, {
+            body: {
+                offset: 0,
+                totalSize: 3,
+                extensions: [
+                    { ...extension, version: '1.9.0' },
+                    { ...extension, version: '1.10.0' },
+                    { ...extension, version: '1.2.0' }
+                ]
+            }
+        });
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url });
+
+        const printed = output();
+        // 1.10.0 outranks 1.9.0 numerically, which a string sort would get wrong.
+        expect(printed.indexOf('1.10.0')).toBeLessThan(printed.indexOf('1.9.0'));
+        expect(printed.indexOf('1.9.0')).toBeLessThan(printed.indexOf('1.2.0'));
+    });
+
+    it('caps the version history and says how many were left out', async () => {
+        const versions = Array.from({ length: 9 }, (_, i) => ({ ...extension, version: `1.0.${i}` }));
+        const registry = await givenRegistry({}, { body: { offset: 0, totalSize: 9, extensions: versions } });
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url });
+
+        expect(output()).toContain('... and 3 more');
+    });
+
+    it('lists every version with --all-versions', async () => {
+        const versions = Array.from({ length: 9 }, (_, i) => ({ ...extension, version: `1.0.${i}` }));
+        const registry = await givenRegistry({}, { body: { offset: 0, totalSize: 9, extensions: versions } });
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url, allVersions: true });
+
+        const printed = output();
+        expect(printed).not.toContain('more (pass --all-versions');
+        expect(printed).toContain('1.0.8');
+    });
+
+    it('requests the version named after @ and the given target platform', async () => {
+        const registry = await givenRegistry();
+
+        await show({ extensionId: 'redhat.java@1.1.0', target: 'linux-x64', registryUrl: registry.url });
+
+        expect(registry.metadataRequests[0].pathname).toBe('/api/redhat/java/linux-x64/1.1.0');
+    });
+
+    it('passes a version alias through as given', async () => {
+        const registry = await givenRegistry();
+
+        await show({ extensionId: 'redhat.java@pre-release', registryUrl: registry.url });
+
+        expect(registry.metadataRequests[0].pathname).toBe('/api/redhat/java/pre-release');
+    });
+
+    it('prints raw JSON with --json, without querying the version history', async () => {
+        const registry = await givenRegistry();
+
+        await show({ extensionId: 'redhat.java', json: true, registryUrl: registry.url });
+
+        expect(JSON.parse(output())).toMatchObject({ namespace: 'redhat', name: 'java', version: '1.2.0' });
+        expect(registry.queryRequests).toHaveLength(0);
+    });
+
+    // The v2 query is only there for the history table, so a registry too old to serve it - or one
+    // that errors on it - must still produce the rest of the output rather than failing outright.
+    it('still prints the summary when the version query fails', async () => {
+        const registry = await givenRegistry({}, { status: 404, body: { error: 'Not found' } });
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url });
+
+        const printed = output();
+        expect(printed).toContain('Language Support for Java');
+        expect(printed).not.toContain('Version History:');
+    });
+});

--- a/cli/test/unit/show.spec.ts
+++ b/cli/test/unit/show.spec.ts
@@ -110,7 +110,7 @@ describe('show', () => {
     it('rejects a malformed extension identifier', async () => {
         const registry = await givenRegistry();
         await expect(show({ extensionId: 'not-an-id', registryUrl: registry.url }))
-            .rejects.toThrow('The extension identifier must have the form `namespace.extension`.');
+            .rejects.toThrow('The extension identifier must have the form `namespace.extension` or `namespace/extension`.');
         expect(registry.metadataRequests).toHaveLength(0);
     });
 
@@ -213,6 +213,55 @@ describe('show', () => {
         // 1.10.0 outranks 1.9.0 numerically, which a string sort would get wrong.
         expect(printed.indexOf('1.10.0')).toBeLessThan(printed.indexOf('1.9.0'));
         expect(printed.indexOf('1.9.0')).toBeLessThan(printed.indexOf('1.2.0'));
+    });
+
+    // semver.coerce would drop the prerelease identifier, making 1.2.0-alpha.1 compare equal to
+    // 1.2.0 and the order unstable. semver.valid keeps it, so the release sorts ahead of its
+    // prereleases - and inputs semver rejects still fall through to the string comparison.
+    it('orders prereleases below their release', async () => {
+        const registry = await givenRegistry({}, {
+            body: {
+                offset: 0,
+                totalSize: 4,
+                versions: [
+                    { version: '1.2.0-alpha.1' },
+                    { version: '1.2.0' },
+                    { version: '1.2.0-beta.1' },
+                    { version: 'nightly' }
+                ]
+            }
+        });
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url });
+
+        const printed = output();
+        expect(printed.indexOf('1.2.0 ')).toBeLessThan(printed.indexOf('1.2.0-beta.1'));
+        expect(printed.indexOf('1.2.0-beta.1')).toBeLessThan(printed.indexOf('1.2.0-alpha.1'));
+        // Not valid semver, so it sorts after everything that is.
+        expect(printed.indexOf('1.2.0-alpha.1')).toBeLessThan(printed.indexOf('nightly'));
+    });
+
+    // --target says it scopes the report, so it has to scope the listing too, not just the
+    // metadata lookup. The registry serves /api/{ns}/{ext}/{target}/version-references for this.
+    it('scopes the version history to --target', async () => {
+        const registry = await givenRegistry();
+
+        await show({ extensionId: 'redhat.java', target: 'linux-x64', registryUrl: registry.url });
+
+        expect(registry.versionRequests[0].pathname).toBe('/api/redhat/java/linux-x64/version-references');
+    });
+
+    // Number(undefined) is NaN, which printed "NaN reviews".
+    it('reports a rating with no review count without printing NaN', async () => {
+        const registry = await givenRegistry({
+            body: { ...extension, averageRating: 4.25, reviewCount: undefined }
+        });
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url });
+
+        const printed = output();
+        expect(printed).not.toContain('NaN');
+        expect(printed).toContain('0 reviews');
     });
 
     it('caps the version history and says how many were left out', async () => {

--- a/cli/test/unit/show.spec.ts
+++ b/cli/test/unit/show.spec.ts
@@ -309,6 +309,16 @@ describe('show', () => {
         expect(registry.metadataRequests[0].pathname).toBe('/api/redhat/java/linux-x64/1.1.0');
     });
 
+    // A trailing `@` with nothing after it used to be read as "no version", so this silently reported
+    // the latest version - the wrong answer for `ovsx show ext@$VERSION` with the variable unset.
+    it('rejects an empty version after @', async () => {
+        const registry = await givenRegistry();
+
+        await expect(show({ extensionId: 'redhat.java@', registryUrl: registry.url }))
+            .rejects.toThrow('A version must follow `@`, as in `namespace.extension@1.2.3`.');
+        expect(registry.metadataRequests).toHaveLength(0);
+    });
+
     it('passes a version alias through as given', async () => {
         const registry = await givenRegistry();
 

--- a/cli/test/unit/show.spec.ts
+++ b/cli/test/unit/show.spec.ts
@@ -24,7 +24,7 @@ interface ShowRequest {
 interface RegistryStub {
     url: string;
     metadataRequests: ShowRequest[];
-    queryRequests: ShowRequest[];
+    versionRequests: ShowRequest[];
     close: () => Promise<void>;
 }
 
@@ -52,28 +52,29 @@ const extension = {
     preRelease: false
 };
 
-/** Stands in for `/api/{namespace}/{extension}` plus the v2 query used for version history. */
+/** Stands in for `/api/{namespace}/{extension}` plus the version-reference listing. */
 async function startRegistryStub(
     metadata: { status?: number; body?: unknown } = {},
-    query: { status?: number; body?: unknown } = {}
+    versions: { status?: number; body?: unknown } = {}
 ): Promise<RegistryStub> {
     const metadataRequests: ShowRequest[] = [];
-    const queryRequests: ShowRequest[] = [];
+    const versionRequests: ShowRequest[] = [];
+    const defaultVersions = { offset: 0, totalSize: 1, versions: [{ version: '1.2.0', targetPlatform: 'universal' }] };
     const server = http.createServer((req, res) => {
         const url = new URL(req.url ?? '/', 'http://127.0.0.1');
         const request = { pathname: url.pathname, query: url.searchParams };
-        const isQuery = url.pathname === '/api/v2/-/query';
-        (isQuery ? queryRequests : metadataRequests).push(request);
-        const stub = isQuery ? query : metadata;
+        const isVersions = url.pathname.endsWith('/version-references');
+        (isVersions ? versionRequests : metadataRequests).push(request);
+        const stub = isVersions ? versions : metadata;
         res.writeHead(stub.status ?? 200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(stub.body ?? (isQuery ? { offset: 0, totalSize: 1, extensions: [extension] } : extension)));
+        res.end(JSON.stringify(stub.body ?? (isVersions ? defaultVersions : extension)));
     });
     await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
     const port = (server.address() as AddressInfo).port;
     return {
         url: `http://127.0.0.1:${port}`,
         metadataRequests,
-        queryRequests,
+        versionRequests,
         close: () => new Promise<void>(resolve => server.close(() => resolve()))
     };
 }
@@ -94,9 +95,9 @@ describe('show', () => {
 
     async function givenRegistry(
         metadata?: { status?: number; body?: unknown },
-        query?: { status?: number; body?: unknown }
+        versions?: { status?: number; body?: unknown }
     ): Promise<RegistryStub> {
-        const stub = await startRegistryStub(metadata, query);
+        const stub = await startRegistryStub(metadata, versions);
         stubs.push(stub);
         return stub;
     }
@@ -174,21 +175,21 @@ describe('show', () => {
             body: {
                 offset: 0,
                 totalSize: 3,
-                extensions: [
-                    { ...extension, version: '1.2.0', targetPlatform: 'linux-x64' },
-                    { ...extension, version: '1.2.0', targetPlatform: 'win32-x64' },
-                    { ...extension, version: '1.1.0', targetPlatform: 'universal', preRelease: true }
+                versions: [
+                    { version: '1.2.0', targetPlatform: 'linux-x64' },
+                    { version: '1.2.0', targetPlatform: 'win32-x64' },
+                    { version: '1.1.0', targetPlatform: 'universal' }
                 ]
             }
         });
 
         await show({ extensionId: 'redhat.java', registryUrl: registry.url });
 
-        expect(registry.queryRequests[0].query.get('includeAllVersions')).toBe('true');
+        expect(registry.versionRequests[0].pathname).toBe('/api/redhat/java/version-references');
         const printed = output();
         expect(printed).toContain('Version History:');
         expect(printed).toContain('linux-x64, win32-x64');
-        expect(printed).toContain('pre-release');
+        expect(printed).toContain('1.1.0');
     });
 
     // The query makes no ordering promise, so the sort has to happen here - and it has to, because
@@ -198,10 +199,10 @@ describe('show', () => {
             body: {
                 offset: 0,
                 totalSize: 3,
-                extensions: [
-                    { ...extension, version: '1.9.0' },
-                    { ...extension, version: '1.10.0' },
-                    { ...extension, version: '1.2.0' }
+                versions: [
+                    { version: '1.9.0' },
+                    { version: '1.10.0' },
+                    { version: '1.2.0' }
                 ]
             }
         });
@@ -215,8 +216,8 @@ describe('show', () => {
     });
 
     it('caps the version history and says how many were left out', async () => {
-        const versions = Array.from({ length: 9 }, (_, i) => ({ ...extension, version: `1.0.${i}` }));
-        const registry = await givenRegistry({}, { body: { offset: 0, totalSize: 9, extensions: versions } });
+        const refs = Array.from({ length: 9 }, (_, i) => ({ version: `1.0.${i}` }));
+        const registry = await givenRegistry({}, { body: { offset: 0, totalSize: 9, versions: refs } });
 
         await show({ extensionId: 'redhat.java', registryUrl: registry.url });
 
@@ -224,14 +225,31 @@ describe('show', () => {
     });
 
     it('lists every version with --all-versions', async () => {
-        const versions = Array.from({ length: 9 }, (_, i) => ({ ...extension, version: `1.0.${i}` }));
-        const registry = await givenRegistry({}, { body: { offset: 0, totalSize: 9, extensions: versions } });
+        const refs = Array.from({ length: 9 }, (_, i) => ({ version: `1.0.${i}` }));
+        const registry = await givenRegistry({}, { body: { offset: 0, totalSize: 9, versions: refs } });
 
         await show({ extensionId: 'redhat.java', registryUrl: registry.url, allVersions: true });
 
         const printed = output();
         expect(printed).not.toContain('more (pass --all-versions');
         expect(printed).toContain('1.0.8');
+    });
+
+    // totalSize counts version/target-platform pairs rather than versions, so paging has to run off
+    // what actually came back. Without this the listing stopped after the first page and quietly
+    // under-reported - the reason this doesn't use the query endpoint, which caps at 100 rows.
+    it('pages to the end with --all-versions', async () => {
+        const firstPage = Array.from({ length: 100 }, (_, i) => ({ version: `1.0.${i}` }));
+        const registry = await givenRegistry({}, {
+            body: { offset: 0, totalSize: 150, versions: firstPage }
+        });
+
+        await show({ extensionId: 'redhat.java', registryUrl: registry.url, allVersions: true });
+
+        // The first page returned 100 of 150, so a second request must follow at the next offset.
+        expect(registry.versionRequests).toHaveLength(2);
+        expect(registry.versionRequests[0].query.get('offset')).toBe('0');
+        expect(registry.versionRequests[1].query.get('offset')).toBe('100');
     });
 
     it('requests the version named after @ and the given target platform', async () => {
@@ -256,12 +274,12 @@ describe('show', () => {
         await show({ extensionId: 'redhat.java', json: true, registryUrl: registry.url });
 
         expect(JSON.parse(output())).toMatchObject({ namespace: 'redhat', name: 'java', version: '1.2.0' });
-        expect(registry.queryRequests).toHaveLength(0);
+        expect(registry.versionRequests).toHaveLength(0);
     });
 
-    // The v2 query is only there for the history table, so a registry too old to serve it - or one
+    // The listing is only there for the history table, so a registry that doesn't serve it - or one
     // that errors on it - must still produce the rest of the output rather than failing outright.
-    it('still prints the summary when the version query fails', async () => {
+    it('still prints the summary when the version listing fails', async () => {
         const registry = await givenRegistry({}, { status: 404, body: { error: 'Not found' } });
 
         await show({ extensionId: 'redhat.java', registryUrl: registry.url });

--- a/cli/test/unit/unpublish.spec.ts
+++ b/cli/test/unit/unpublish.spec.ts
@@ -105,7 +105,7 @@ describe('unpublish', () => {
     it('rejects a malformed extension identifier', async () => {
         const registry = await givenRegistry();
         await expect(unpublish({ extensionId: 'not-an-id', pat: 'the.pat', force: true, registryUrl: registry.url }))
-            .rejects.toThrow('The extension identifier must have the form `namespace.extension`.');
+            .rejects.toThrow('The extension identifier must have the form `namespace.extension` or `namespace/extension`.');
         expect(registry.requests).toHaveLength(0);
     });
 


### PR DESCRIPTION
Closes #2149. Follows `vsce show` closely enough that the habit transfers, then leans into what an Open VSX compatible registry knows and the Marketplace has no equivalent for.

```
$ ovsx show redhat.java
Language Support for Java(TM) by Red Hat
  Red Hat (verified publisher)
  8,421,337 downloads  4.3/5 from 142 reviews

  Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...

Version History:
  Version          Target Platforms
  1.56.2026090208  universal, darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, win32-x64
  1.56.2026082811  universal, darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, win32-x64
  1.56.2026082608  universal, darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, win32-x64
  ... and 9 more (pass --all-versions to list them)

Categories:
  Programming Languages, Linters, Formatters

Tags:
  java, maven, gradle

More Info:
  Unique Identifier  redhat.java
  Version            1.42.0
  Version Aliases    latest
  Target Platform    universal
  Last Updated       2026-08-01T10:00:00Z
  Published By       redhat-bot
  License            EPL-2.0
  Homepage           https://projects.eclipse.org/projects/eclipse.jdt.ls
  Repository         https://github.com/redhat-developer/vscode-java
  Sponsor            https://github.com/sponsors/redhat
  Engines            vscode ^1.90.0

Registry:
  Verified Publisher  yes
  Trusted Publishing  yes
  Pre-Release         no
  Extension Kind      workspace
  Localized           en, de, ja
  Dependencies        vscjava.vscode-java-debug

Statistics:
  Downloads       8,421,337
  Average Rating  4.3/5
  Reviews         142
```

## Parity

The sections and their order follow `vsce show`, including filtering the internal `__`-prefixed tags (the web UI hides those too). `--json` prints the raw metadata.

Identifiers accept `namespace.extension@version` the way vsce does — an exact version or the registry's own `latest` / `pre-release` aliases — plus `-t/--target`, since Open VSX is target-platform aware in a way vsce's `show` isn't. No token required: both endpoints it uses are public, so this also works on a private registry with no login provider configured.

## Beyond parity

The `Registry:` block is kept separate rather than mixed into `More Info`, so it's obvious which fields are registry specific, and it's omitted entirely when none apply: verified publisher, trusted publishing, pre-release status, extension kind, localized languages, dependencies and bundled extensions.

Deprecation is promoted above the metadata instead of being a table row, naming the replacement where the registry supplies one, since it changes whether you should install the extension at all:

```
  ! Deprecated - superseded by Java Next
```

A disputed namespace and an extension the registry won't serve for download are surfaced the same way.

## Why there is a second request

The version history needs one extra request. `allVersions` on the metadata response carries version numbers and links only, and `allTargetPlatformVersions` is populated on the user and admin endpoints rather than the public one, so the table comes from `/api/{namespace}/{extension}/version-references` - one page for the default table, paging to the end for `--all-versions`. Its one-row-per-target-platform results are collapsed into a row per version, which is also what fills the Targets column. `--target` scopes that listing too, via `/api/{namespace}/{extension}/{target}/version-references`.

That listing is best-effort. A registry that doesn't serve it, or errors on it, still gets the whole summary minus the history table; there's a test for that.

**The table is Version and Target Platforms only.** It initially also carried "Last Updated" and a pre-release marker, sourced from `/api/v2/-/query?includeAllVersions=true`, but that was the wrong source: 267KB against 11KB for the same extension, and capped at 100 of 3817 rows, so `--all-versions` was quietly incomplete - measurements are in the comment below. Neither `version-references` nor `/versions` reports a timestamp or the pre-release flag, so those two columns are gone for now. Adding `timestamp` and `preRelease` to `VersionReferenceJson` would bring them back at no bandwidth cost, which seems better than making every client pull the query endpoint - happy to put that up separately.

Versions are sorted newest first here rather than trusting the listing's order, which also means the cap drops the oldest rather than arbitrary ones. Sorting uses `semver.valid` and not `coerce`: coerce drops prerelease identifiers, so `1.2.0-alpha.1` would compare equal to `1.2.0`. Versions that aren't valid semver (reachable via mirroring) sort after those that are. `--all-versions` lists everything, and the number left out is reported rather than truncated silently.

## Testing

13 new cases in `cli/test/unit/show.spec.ts` against a local HTTP stub, following `unpublish.spec.ts`. Full CLI suite green (70 tests), `tsc` and `eslint` clean.

Worth noting that two bugs in this PR were found by *running* the command rather than by the tests — the unsorted version history above, and `Downloads` printing unformatted while the header line used thousands separators. Both are now covered, the sort by a case using 1.9.0/1.10.0/1.2.0 that a string sort would get wrong.

## One thing to decide

`--json` overlaps with the existing `get --metadata`, which already prints the same JSON. I kept it for vsce parity and made the content identical rather than subtly different, but if you would rather there were only one way to get it, it is easy to drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

