### PR TITLE
fix: align the Kubernetes ConfigMap with the Spring Boot 4 properties

### DIFF
--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -23,7 +23,7 @@ data:
         name: openvsx-server
       autoconfigure:
         exclude:
-         - org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration
+         - org.springframework.boot.zipkin.autoconfigure.ZipkinAutoConfiguration
       profiles:
         include: ovsx
       cache:
@@ -49,7 +49,7 @@ data:
         jdbc:
           initialize-schema: never
       thymeleaf:
-        enabled: false
+        check-template-location: false
       # Uncomment and configure to enable GitHub OAuth authentication
       # security:
       #   oauth2:
@@ -82,6 +82,9 @@ data:
                 requests: true
 
     springdoc:
+      model-and-view-allowed: true
+      api-docs:
+        version: openapi_3_0
       swagger-ui:
         path: /swagger-ui
         docExpansion: list
@@ -89,19 +92,18 @@ data:
         supportedSubmitMethods:
           - get
 
-    org:
-      jobrunr:
-        job-scheduler:
-          enabled: true
-        background-job-server:
-          enabled: true
-          worker-count: 2
-        dashboard:
-          enabled: false
-        database:
-          type: sql
-        miscellaneous:
-          allow-anonymous-data-usage: false
+    jobrunr:
+      job-scheduler:
+        enabled: true
+      background-job-server:
+        enabled: true
+        worker-count: 2
+      dashboard:
+        enabled: false
+      database:
+        type: sql
+      miscellaneous:
+        allow-anonymous-data-usage: false
 
     bucket4j:
       enabled: false


### PR DESCRIPTION
Fixes #2157

`deploy/kubernetes/` was added in #1792, after the other deployment descriptors, and the two commits that realigned those afterwards left it behind: 46459f4e1 (Spring Boot 4 base configuration) and fbdd4bd3d (springdoc alignment) both updated `deploy/docker`, `deploy/openshift` and `server/src/dev` but skipped `deploy/kubernetes`.

Three keys in the ConfigMap therefore no longer bind to anything:

| Key | Before | After |
|---|---|---|
| jobrunr block | `org.jobrunr.*` | `jobrunr.*` |
| `spring.autoconfigure.exclude` | `org.springframework.boot.actuate.autoconfigure.tracing.zipkin.ZipkinAutoConfiguration` | `org.springframework.boot.zipkin.autoconfigure.ZipkinAutoConfiguration` |
| `spring.thymeleaf` | `enabled: false` | `check-template-location: false` |

- JobRunr dropped the `org.` prefix in version 7 — `jobrunr-spring-boot-4-starter:8.6.1` declares the group name `jobrunr` in its `spring-configuration-metadata.json`. Nothing bound, so both the job scheduler and the background job server silently ran with their defaults, which is what @nh60211as observed in #2157.
- `ZipkinAutoConfiguration` moved packages in Spring Boot 4; `spring-boot-zipkin:4.0.8` only carries `org/springframework/boot/zipkin/autoconfigure/ZipkinAutoConfiguration.class`, so the exclude matched no class.
- `spring.thymeleaf.enabled` is gone; `check-template-location` is what suppresses the missing template location now.

The `springdoc` keys the other two deployments already carry are added as well, so the swagger-ui served from the Kubernetes example behaves the same.

After the change the embedded `application.yml` differs from `deploy/openshift/application.yml` only in the intentional Kubernetes-specific bits: secret-backed DB credentials, commented-out GitHub OAuth, `management.health.redis.enabled: false` (no Redis in this example and bucket4j is off), and no `ovsx.registry.version` placeholder since the image tag carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)