### PR TITLE
refactor: call the access token hash secret a pepper, not a salt

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenConfig.java
@@ -104,17 +104,24 @@ public class AccessTokenConfig {
     private String tokenHashAlgorithm;
 
     /**
-     * The (instance wide) hash salt string used for personal access tokens.
-     * Note: if this instance wide salt changes, all existing/active
-     * personal access tokens will become invalid. Salt exists only in configuration,
-     * should never get into database. Default is empty string, and is not recommended
-     * for production!
+     * The (instance wide) secret mixed into the hash of every personal access token.
      * <p>
-     * Property: {@code ovsx.access-token.token-hash-salt}
+     * A pepper rather than a salt: one value for the whole instance, not one per token, and it lives
+     * only in the configuration so that it is never stored next to the hashes it protects. That is what
+     * it is for - the token values are 256 random bits each, so there is nothing to precompute against
+     * and no chance of two of them colliding, and the only thing this secret can buy is making a leaked
+     * {@code personal_access_token.value} column useless to whoever holds it. Keep it out of anywhere a
+     * non-secret would go.
+     * <p>
+     * Note: because the same pepper covers every token, changing it invalidates all existing/active
+     * personal access tokens at once. Default is the empty string, which mixes in nothing and is not
+     * recommended for production!
+     * <p>
+     * Property: {@code ovsx.access-token.token-hash-pepper}
      * Default: {@code ''}
      */
-    @Value("${ovsx.access-token.token-hash-salt:}")
-    private String tokenHashSalt;
+    @Value("${ovsx.access-token.token-hash-pepper:}")
+    private String tokenHashPepper;
 
     @Value("${ovsx.data.mirror.enabled:false}")
     private boolean mirrorEnabled;
@@ -167,8 +174,8 @@ public class AccessTokenConfig {
         return tokenHashAlgorithm;
     }
 
-    public @NonNull String getTokenHashSalt() {
-        return tokenHashSalt;
+    public @NonNull String getTokenHashPepper() {
+        return tokenHashPepper;
     }
 
     @PostConstruct
@@ -201,8 +208,8 @@ public class AccessTokenConfig {
                             + tokenHashAlgorithm,
                     e);
         }
-        if (tokenHashSalt == null) {
-            throw new IllegalArgumentException("ovsx.access-token.token-hash-salt must not be null");
+        if (tokenHashPepper == null) {
+            throw new IllegalArgumentException("ovsx.access-token.token-hash-pepper must not be null");
         }
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
@@ -445,8 +445,8 @@ public class AccessTokenService {
 
     private String hashTokenValue(String tokenValue) {
         try {
-            // token hash salt must not be present in DB (is in config)
-            String payload = tokenValue + config.getTokenHashSalt();
+            // the pepper is instance wide and lives in the configuration only; it must never reach the DB
+            String payload = tokenValue + config.getTokenHashPepper();
             return Hex.encodeHexString(
                     DigestUtils.digest(
                             MessageDigest.getInstance(config.getTokenHashAlgorithm()),

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
@@ -72,7 +72,7 @@ class AccessTokenServiceTest {
     void setUp() {
         // lenient: generateTokenValue does not hash anything, so it needs neither of these
         lenient().when(config.getTokenHashAlgorithm()).thenReturn("SHA-256");
-        lenient().when(config.getTokenHashSalt()).thenReturn("salt");
+        lenient().when(config.getTokenHashPepper()).thenReturn("pepper");
     }
 
     private PersonalAccessToken activeUnrestrictedToken() {
@@ -141,9 +141,9 @@ class AccessTokenServiceTest {
     }
 
     // The old implementation regenerated until repositories.hasPersonalAccessToken(value) came back
-    // false, comparing a raw value against a column that stores salted hashes - it could never match for
-    // a current token, so it only cost a query per token created. Uniqueness is UNIQUE (value)'s job, and
-    // only it can work across pods anyway.
+    // false, comparing a raw value against a column that stores peppered hashes - it could never match
+    // for a current token, so it only cost a query per token created. Uniqueness is UNIQUE (value)'s job,
+    // and only it can work across pods anyway.
     @Test
     void generatesATokenValueWithoutAskingTheDatabase() {
         when(config.getPrefix()).thenReturn("ovsx");


### PR DESCRIPTION
`ovsx.access-token.token-hash-salt` has every property of a pepper and none of a salt:

| | Salt | Pepper | This value |
|---|---|---|---|
| Scope | unique per record | one per instance | one per instance |
| Storage | stored next to the hash | kept out of the datastore | config only |
| Secret? | no | yes | yes |

The name misleads in a way that matters. A reader looking for the per-token salt column will not find one, and — worse — may take the value for the non-secret a salt is and put it somewhere a salt could legitimately go, such as a plain ConfigMap or a committed `application.yml`.

A salt would also have nothing to do here. Token values are 256 bits from a CSPRNG (`AccessTokenService.java:67-83`), so there is no dictionary to precompute against and no realistic chance of two hashing alike. The one thing this value buys is the pepper property: that a leaked `personal_access_token.value` column is useless without the configuration. The old javadoc gave it away too — a changed value invalidating every existing token is pepper rotation, since a per-record salt stays with its row.

### Changes

- `ovsx.access-token.token-hash-salt` → `ovsx.access-token.token-hash-pepper`
- `tokenHashSalt` → `tokenHashPepper`, `getTokenHashSalt()` → `getTokenHashPepper()`, and the `validate()` failure message
- Javadoc now says *why* it is a pepper, and keeps the rotation warning reframed as the pepper property it is
- Call site and comment in `AccessTokenService.hashTokenValue`, plus the mock stub and one comment in `AccessTokenServiceTest`

No behaviour change: the hash construction is untouched.

### No back-compat alias needed

The property has never shipped. It arrived in d5a01c83f (Trusted Publishing, #2000) on 2026-08-21, one day after the v1.1.2 release — `git show v1.1.2:.../AccessTokenConfig.java` has no trace of it. So unlike `ovsx.access-token.prefix`, which carries a fallback to its old `ovsx.token-prefix` key, this one needs none. Renaming after the next release would mean carrying that alias forever.

### Verification

- `compileJava compileTestJava` clean
- `./gradlew test --tests '*AccessToken*'` — 30 tests pass (`AccessTokenServiceTest`, plus the `AdminAPITest` and `TrustedPublishingAPITest` cases that exercise token creation and hashing end to end)
- `spotlessCheck` reports no violations in the three touched files (it fails overall on pre-existing formatting under `json/`, untouched here)

### Follow-ups, not in this PR

- Rotating the pepper still invalidates every token, because the raw value is never stored and so no row can be rehashed. A pepper keyring with lazy rehash on use would fix that; PR to follow.
- The pepper is applied as `H(token || pepper)` rather than `HMAC(pepper, token)`. Not practically exploitable — the attacker controls no part of the input and length extension neither recovers the pepper nor forges a chosen token's hash — and changing it would break every stored hash, so it is deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)