### PR TITLE
build(deps): bump js-yaml from 4.3.1 to 4.3.2

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -22,6 +22,7 @@ This change log covers only the command line interface (CLI) of Open VSX.
 - Bump fast-uri from 3.1.5 to 3.1.7
 - Bump qs from 6.15.2 to 6.16.0
 - Bump @humanfs/node from 0.16.6 to 0.16.8
+- Bump js-yaml from 4.3.1 to 4.3.2
 
 ### [v1.1.1] (09/08/2026)
 

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -3524,13 +3524,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
-  version: 4.3.1
-  resolution: "js-yaml@npm:4.3.1"
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/2ce71b5d632abbd77da80447bf860e8a0264e54bffe94840984887d58b023761495b523727547904517a6107a1ef189854b361e0fc44995ee13a84f222d7bd42
+  checksum: 10/05c44b9c73e4901d92703b155e76518df64bf01ac62e4c036b47de4b391e19b72e32656e8954d51b436307f08cc9d0c0d4ec617d061cf2f65fffee9f3114bee7
   languageName: node
   linkType: hard
 

--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -40,6 +40,7 @@ This change log covers only the frontend library (webui) of Open VSX.
 
 - Remove the `react-dropzone` dependency; the publish page and the navbar's drop target handle their own drag events, and nothing else imports it
 - Bump @humanfs/node from 0.16.6 to 0.16.8
+- Bump js-yaml from 4.3.1 to 4.3.2
 
 ## [v1.1.2] (20/08/2026)
 

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -4866,13 +4866,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.1":
-  version: 4.3.1
-  resolution: "js-yaml@npm:4.3.1"
+  version: 4.3.2
+  resolution: "js-yaml@npm:4.3.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/2ce71b5d632abbd77da80447bf860e8a0264e54bffe94840984887d58b023761495b523727547904517a6107a1ef189854b361e0fc44995ee13a84f222d7bd42
+  checksum: 10/05c44b9c73e4901d92703b155e76518df64bf01ac62e4c036b47de4b391e19b72e32656e8954d51b436307f08cc9d0c0d4ec617d061cf2f65fffee9f3114bee7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Addresses CVE-2026-84375: DoS via unbounded merge key processing in js-yaml < 4.3.2

js-yaml is a transitive dependency pulled in by @eslint/eslintrc, @textlint/linter-formatter, and rc-config-loader. All of them declare ^4.1.0 or ^4.1.1, which already allows 4.3.2 — the lock files just had 4.3.1 pinned from a previous resolution.

Updated by running yarn up -R js-yaml in both cli/ and webui/ workspaces to refresh the lock file resolution within the existing range.