### PR TITLE
feat: Optimize extensionQuery

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -213,8 +213,18 @@ public class LocalVSCodeService implements IVSCodeService {
         // see https://github.com/eclipse/openvsx/issues/1394
         var extensionsMap = extensionsList.stream()
                 .collect(Collectors.toMap(Extension::getId, Function.identity(), (a, b) -> a));
-        List<ExtensionVersion> allActiveExtensionVersions = repositories
-                .findActiveExtensionVersions(extensionsMap.keySet(), targetPlatform, maxPreReleaseVersions);
+
+        // The full active version list (all pre-releases included, unless capped) is only needed to populate
+        // the response's per-extension version list, which itself is only included for these flags. Skipping
+        // the fetch otherwise avoids pulling an extension's entire (potentially unbounded) version history
+        // just to compute "latest", which repositories.findLatestVersions below does directly in the database.
+        var needsVersionList = test(flags, FLAG_INCLUDE_LATEST_VERSION_ONLY)
+                || test(flags, FLAG_INCLUDE_VERSIONS)
+                || test(flags, FLAG_INCLUDE_VERSION_PROPERTIES);
+        List<ExtensionVersion> allActiveExtensionVersions = needsVersionList
+                ? repositories
+                        .findActiveExtensionVersions(extensionsMap.keySet(), targetPlatform, maxPreReleaseVersions)
+                : Collections.emptyList();
 
         List<ExtensionVersion> extensionVersions;
         if (test(flags, FLAG_INCLUDE_LATEST_VERSION_ONLY)) {
@@ -262,11 +272,7 @@ public class LocalVSCodeService implements IVSCodeService {
             fileResources = Collections.emptyMap();
         }
 
-        var latestVersions = allActiveExtensionVersions.stream()
-                .collect(Collectors.groupingBy(ev -> ev.getExtension().getId()))
-                .values()
-                .stream()
-                .map(list -> versions.getLatest(list, false))
+        var latestVersions = repositories.findLatestVersions(extensionsMap.keySet(), targetPlatform).stream()
                 .collect(Collectors.toMap(ev -> ev.getExtension().getId(), ev -> ev));
 
         var extensionQueryResults = new ArrayList<ExtensionQueryResult.Extension>();

--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -214,10 +214,8 @@ public class LocalVSCodeService implements IVSCodeService {
         var extensionsMap = extensionsList.stream()
                 .collect(Collectors.toMap(Extension::getId, Function.identity(), (a, b) -> a));
 
-        // The full active version list (all pre-releases included, unless capped) is only needed to populate
-        // the response's per-extension version list, which itself is only included for these flags. Skipping
-        // the fetch otherwise avoids pulling an extension's entire (potentially unbounded) version history
-        // just to compute "latest", which repositories.findLatestVersions below does directly in the database.
+        // Version details (and thus the potentially unbounded active-version history) are only needed
+        // for these flags; "latest" is computed separately below without fetching this list.
         var needsVersionList = test(flags, FLAG_INCLUDE_LATEST_VERSION_ONLY)
                 || test(flags, FLAG_INCLUDE_VERSIONS)
                 || test(flags, FLAG_INCLUDE_VERSION_PROPERTIES);
@@ -234,7 +232,7 @@ public class LocalVSCodeService implements IVSCodeService {
                     .stream()
                     .map(list -> versions.getLatest(list, true))
                     .collect(Collectors.toList());
-        } else if (test(flags, FLAG_INCLUDE_VERSIONS) || test(flags, FLAG_INCLUDE_VERSION_PROPERTIES)) {
+        } else if (needsVersionList) {
             extensionVersions = allActiveExtensionVersions;
         } else {
             extensionVersions = Collections.emptyList();
@@ -272,8 +270,21 @@ public class LocalVSCodeService implements IVSCodeService {
             fileResources = Collections.emptyMap();
         }
 
-        var latestVersions = repositories.findLatestVersions(extensionsMap.keySet(), targetPlatform).stream()
-                .collect(Collectors.toMap(ev -> ev.getExtension().getId(), ev -> ev));
+        // ponytail: reuse the already-fetched list for "latest" only when it's uncapped (complete) -
+        // a pre-release cap ranks across all target platforms combined, so a capped list can miss the
+        // true latest for this platform; that case still queries the database directly.
+        Map<Long, ExtensionVersion> latestVersions;
+        if (needsVersionList && maxPreReleaseVersions < 0) {
+            latestVersions = allActiveExtensionVersions.stream()
+                    .collect(Collectors.groupingBy(ev -> ev.getExtension().getId()))
+                    .values()
+                    .stream()
+                    .map(list -> versions.getLatest(list, false))
+                    .collect(Collectors.toMap(ev -> ev.getExtension().getId(), ev -> ev));
+        } else {
+            latestVersions = repositories.findLatestVersions(extensionsMap.keySet(), targetPlatform).stream()
+                    .collect(Collectors.toMap(ev -> ev.getExtension().getId(), ev -> ev));
+        }
 
         var extensionQueryResults = new ArrayList<ExtensionQueryResult.Extension>();
         for (var extension : extensionsList) {

--- a/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/ExtensionVersionJooqRepository.java
@@ -1014,7 +1014,11 @@ public class ExtensionVersionJooqRepository {
     }
 
     public List<ExtensionVersion> findLatest(Collection<Long> extensionIds) {
-        var latestQuery = findLatestQuery(null, false, true);
+        return findLatest(extensionIds, null);
+    }
+
+    public List<ExtensionVersion> findLatest(Collection<Long> extensionIds, String targetPlatform) {
+        var latestQuery = findLatestQuery(targetPlatform, false, true);
         latestQuery.addSelect(
                 EXTENSION_VERSION.ID,
                 EXTENSION_VERSION.VERSION,

--- a/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/RepositoryService.java
@@ -970,6 +970,10 @@ public class RepositoryService {
         return extensionVersionJooqRepo.findLatest(extensionIds);
     }
 
+    public List<ExtensionVersion> findLatestVersions(Collection<Long> extensionIds, String targetPlatform) {
+        return extensionVersionJooqRepo.findLatest(extensionIds, targetPlatform);
+    }
+
     public Map<Long, Boolean> findLatestVersionsIsPreview(Collection<Long> extensionIds) {
         return extensionVersionJooqRepo.findLatestIsPreview(extensionIds);
     }

--- a/server/src/test/java/org/eclipse/openvsx/adapter/LocalVSCodeServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/LocalVSCodeServiceTest.java
@@ -74,6 +74,7 @@ public class LocalVSCodeServiceTest {
                 .thenReturn(List.of(extension, extension));
         Mockito.when(repositories.findActiveExtensionVersions(any(), any(), anyInt()))
                 .thenReturn(List.of(extensionVersion));
+        Mockito.when(repositories.findLatestVersions(any(), any())).thenReturn(List.of(extensionVersion));
         Mockito.when(versions.getLatest(anyList(), anyBoolean())).thenReturn(extensionVersion);
 
         var result = vsCodeService.extensionQuery(param, 10);

--- a/server/src/test/java/org/eclipse/openvsx/adapter/LocalVSCodeServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/LocalVSCodeServiceTest.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -79,6 +80,76 @@ public class LocalVSCodeServiceTest {
 
         var result = vsCodeService.extensionQuery(param, 10);
         assertThat(result.results()).hasSize(1);
+    }
+
+    @AfterEach
+    void resetMaxPreReleaseVersions() {
+        vsCodeService.maxPreReleaseVersions = -1;
+    }
+
+    @Test
+    void testExtensionQuery_noVersionFlags_skipsActiveVersionsFetch() {
+        var extension = mockExtension();
+        var extensionVersion = mockExtensionVersion(extension, 1, "0.1.0", "linux");
+
+        var criterion = new ExtensionQueryParam.Criterion(Criterion.FILTER_EXTENSION_ID, "test-1");
+        var filter = new ExtensionQueryParam.Filter(List.of(criterion), 0, 0, 0, 0);
+        var param = new ExtensionQueryParam(List.of(filter), 0);
+
+        Mockito.when(repositories.findActiveExtensionsByPublicId(any(), any()))
+                .thenReturn(List.of(extension));
+        Mockito.when(repositories.findLatestVersions(any(), any())).thenReturn(List.of(extensionVersion));
+
+        vsCodeService.extensionQuery(param, 10);
+
+        Mockito.verify(repositories, Mockito.never()).findActiveExtensionVersions(any(), any(), anyInt());
+        Mockito.verify(repositories, Mockito.times(1)).findLatestVersions(any(), any());
+    }
+
+    @Test
+    void testExtensionQuery_versionsFlagUncapped_reusesFetchedListForLatest() {
+        assertThat(vsCodeService.maxPreReleaseVersions).isNegative();
+
+        var extension = mockExtension();
+        var extensionVersion = mockExtensionVersion(extension, 1, "0.1.0", "linux");
+
+        var criterion = new ExtensionQueryParam.Criterion(Criterion.FILTER_EXTENSION_ID, "test-1");
+        var filter = new ExtensionQueryParam.Filter(List.of(criterion), 0, 0, 0, 0);
+        var param = new ExtensionQueryParam(List.of(filter), FLAG_INCLUDE_VERSIONS);
+
+        Mockito.when(repositories.findActiveExtensionsByPublicId(any(), any()))
+                .thenReturn(List.of(extension));
+        Mockito.when(repositories.findActiveExtensionVersions(any(), any(), anyInt()))
+                .thenReturn(List.of(extensionVersion));
+        Mockito.when(versions.getLatest(anyList(), eq(false))).thenReturn(extensionVersion);
+
+        vsCodeService.extensionQuery(param, 10);
+
+        Mockito.verify(repositories, Mockito.times(1)).findActiveExtensionVersions(any(), any(), anyInt());
+        Mockito.verify(repositories, Mockito.never()).findLatestVersions(any(), any());
+    }
+
+    @Test
+    void testExtensionQuery_versionsFlagCapped_queriesLatestDirectly() {
+        vsCodeService.maxPreReleaseVersions = 5;
+
+        var extension = mockExtension();
+        var extensionVersion = mockExtensionVersion(extension, 1, "0.1.0", "linux");
+
+        var criterion = new ExtensionQueryParam.Criterion(Criterion.FILTER_EXTENSION_ID, "test-1");
+        var filter = new ExtensionQueryParam.Filter(List.of(criterion), 0, 0, 0, 0);
+        var param = new ExtensionQueryParam(List.of(filter), FLAG_INCLUDE_VERSIONS);
+
+        Mockito.when(repositories.findActiveExtensionsByPublicId(any(), any()))
+                .thenReturn(List.of(extension));
+        Mockito.when(repositories.findActiveExtensionVersions(any(), any(), anyInt()))
+                .thenReturn(List.of(extensionVersion));
+        Mockito.when(repositories.findLatestVersions(any(), any())).thenReturn(List.of(extensionVersion));
+
+        vsCodeService.extensionQuery(param, 10);
+
+        Mockito.verify(repositories, Mockito.times(1)).findActiveExtensionVersions(any(), any(), anyInt());
+        Mockito.verify(repositories, Mockito.times(1)).findLatestVersions(any(), any());
     }
 
     // ---------- UTILITY ----------//

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -1120,6 +1120,11 @@ class VSCodeAPITest {
                                 anyInt()))
                 .thenReturn(extVersions);
 
+        var latest = extVersions.stream().min(ExtensionVersion.SORT_COMPARATOR).orElse(null);
+        Mockito
+                .when(repositories.findLatestVersions(eq(Set.of(extension.getId())), eq(queryTargetPlatform)))
+                .thenReturn(latest != null ? List.of(latest) : Collections.emptyList());
+
         mockFileResources(extVersions);
     }
 

--- a/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/repositories/RepositoryServiceSmokeTest.java
@@ -339,6 +339,7 @@ class RepositoryServiceSmokeTest extends AbstractPostgresContainerTest {
                 () -> repositories.findActivePersonalAccessTokensAndType(userData, PersonalAccessTokenType.LLT),
                 () -> repositories.findAllPersonalAccessTokensByVersion(0),
                 () -> repositories.findLatestVersions(List.of(1L)),
+                () -> repositories.findLatestVersions(List.of(1L), "targetPlatform"),
                 () -> repositories.hasSameVersion(extVersion),
                 () -> repositories.hasActiveReview(extension, userData),
                 () -> repositories.findLatestVersionsIsPreview(List.of(1L)),


### PR DESCRIPTION
Summary:
- Root cause: `LocalVSCodeService.extensionQuery` (backing `/vscode/gallery/extensionquery`) **unconditionally fetched every active version** — all pre-releases included, unbounded by default — for every matched extension, solely to derive the single "latest version" for display, even when the client's query flags requested no version details at all.
- Fix: Added a target-platform-aware bulk "latest version per extension" query (ExtensionVersionJooqRepository.findLatest(ids, targetPlatform) / RepositoryService.findLatestVersions(ids, targetPlatform)), mirroring the efficient CROSS APPLY pattern already used by the REST search path (LocalRegistryService). LocalVSCodeService.extensionQuery now: (1) only fetches the full active-version list when a flag actually needs it (FLAG_INCLUDE_VERSIONS/FLAG_INCLUDE_VERSION_PROPERTIES/FLAG_INCLUDE_LATEST_VERSION_ONLY), and (2) always computes the "latest" metadata via the new direct DB query instead of pulling the full history into Java and sorting it.
