### PR TITLE
feat: keep access tokens valid across a pepper change

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenConfig.java
@@ -148,7 +148,9 @@ public class AccessTokenConfig {
      * </ul>
      * Comma separated, and so a pepper itself must not contain a comma; {@link #validate()} rejects a
      * current pepper that does, rather than letting it split into nonsense once it is rotated out.
-     * Generating peppers with {@code openssl rand -base64 32} keeps clear of the problem entirely.
+     * Generating peppers with {@code openssl rand -base64 32} keeps clear of the problem entirely. Blank
+     * entries - what a trailing or doubled comma leaves behind - are ignored rather than read as the
+     * unpeppered hash, which has its own flag in {@link #acceptUnpepperedTokenHashes}.
      * <p>
      * Property: {@code ovsx.access-token.token-hash-previous-peppers}
      * Default: {@code ''}, no previous peppers
@@ -304,7 +306,13 @@ public class AccessTokenConfig {
         // listed twice - or listed while still current - costs a query per authentication, not a bug.
         var keyring = new LinkedHashSet<String>();
         if (previousTokenHashPeppers != null) {
-            keyring.addAll(previousTokenHashPeppers);
+            // hasText, and not merely non-null: a trailing or doubled comma leaves a blank element behind
+            // (Spring trims each one, so an all-whitespace entry arrives blank too), and a blank pepper is
+            // the unpeppered hash - the thing acceptUnpepperedTokenHashes exists to gate, kept as its own
+            // flag precisely because this list cannot express it unambiguously. Taking one at face value
+            // would let a stray comma switch on acceptance of unpeppered tokens with nobody asking for it,
+            // so a blank here means a typo and nothing else.
+            previousTokenHashPeppers.stream().filter(StringUtils::hasText).forEach(keyring::add);
         }
         if (acceptUnpepperedTokenHashes) {
             keyring.add("");

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenConfig.java
@@ -20,12 +20,17 @@ import java.util.List;
 
 import jakarta.annotation.PostConstruct;
 import org.jspecify.annotations.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
 @Configuration
 public class AccessTokenConfig {
+
+    private static final Logger logger = LoggerFactory.getLogger(AccessTokenConfig.class);
+
     /**
      * The token prefix to use when generating a new access token.
      * <p>
@@ -278,6 +283,21 @@ public class AccessTokenConfig {
                     "ovsx.access-token.token-hash-pepper must not contain a comma, because "
                             + "ovsx.access-token.token-hash-previous-peppers is a comma separated list and "
                             + "could not carry this value once it is rotated out");
+        }
+        // hasText, not isEmpty: a pepper of blanks is not a secret either, and how whitespace survives
+        // a property source depends on how it was quoted - neither is worth staying quiet about.
+        if (!StringUtils.hasText(tokenHashPepper)) {
+            // Not an error: this is the default, and refusing to start would lock out every existing
+            // deployment. It is worth one line at boot, though, because the alternative is that the
+            // recommendation lives only in a javadoc nobody deploying the server reads.
+            logger.warn(
+                    "No ovsx.access-token.token-hash-pepper is configured, so personal access tokens "
+                            + "are stored as unkeyed hashes. Whoever obtains a copy of the database can "
+                            + "then confirm a token found elsewhere without touching this registry, and "
+                            + "match hashes across dumps and instances. Generate one with "
+                            + "'openssl rand -base64 32'; to keep the tokens that already exist working, "
+                            + "set ovsx.access-token.token-hash-accept-unpeppered=true at the same time "
+                            + "and drop it once they have expired.");
         }
 
         // LinkedHashSet: the order operators wrote decides which pepper is tried first, and a pepper

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenConfig.java
@@ -15,6 +15,8 @@ package org.eclipse.openvsx.accesstoken;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.List;
 
 import jakarta.annotation.PostConstruct;
 import org.jspecify.annotations.NonNull;
@@ -123,6 +125,57 @@ public class AccessTokenConfig {
     @Value("${ovsx.access-token.token-hash-pepper:}")
     private String tokenHashPepper;
 
+    /**
+     * The peppers this instance used before the current one, so that tokens hashed with one of them keep
+     * working across a pepper change.
+     * <p>
+     * Rotation has to work this way round because the raw token value is never stored: a row holds only
+     * its hash, so nothing can rehash it under a new pepper except the holder presenting the token again.
+     * Each token listed here is therefore migrated to the current pepper the next time it is used, and a
+     * token nobody uses again keeps its old hash until it expires. That has two consequences worth
+     * planning for:
+     * <ul>
+     * <li>A retired pepper must stay listed until every row that might still use it is gone - bounded by
+     * {@code ovsx.access-token.expiration} after the change, plus one expiry sweep. Where expiry is
+     * disabled ({@code expiration: 0}) an unused token lives forever, and so must its pepper.</li>
+     * <li>No background job can finish the migration early, so removing a pepper from this list is the
+     * operator's decision, not something the application can signal.</li>
+     * </ul>
+     * Comma separated, and so a pepper itself must not contain a comma; {@link #validate()} rejects a
+     * current pepper that does, rather than letting it split into nonsense once it is rotated out.
+     * Generating peppers with {@code openssl rand -base64 32} keeps clear of the problem entirely.
+     * <p>
+     * Property: {@code ovsx.access-token.token-hash-previous-peppers}
+     * Default: {@code ''}, no previous peppers
+     */
+    @Value("${ovsx.access-token.token-hash-previous-peppers:}")
+    private List<String> previousTokenHashPeppers;
+
+    /**
+     * Whether to accept tokens whose hash carries no pepper at all.
+     * <p>
+     * This is the switch for adopting a pepper on a deployment that ran without one - the default is the
+     * empty string, so this is the shape most instances start in. Set it alongside a new
+     * {@code token-hash-pepper} and every existing token stays valid, migrating to the peppered hash as
+     * it gets used; without it, setting a pepper for the first time invalidates all of them at once.
+     * <p>
+     * It is the unpeppered member of {@code token-hash-previous-peppers}, kept as its own flag because an
+     * empty entry in a comma separated list cannot be written unambiguously. Everything the list's
+     * documentation says about retiring a pepper applies here too.
+     * <p>
+     * Property: {@code ovsx.access-token.token-hash-accept-unpeppered}
+     * Default: {@code false}
+     */
+    @Value("${ovsx.access-token.token-hash-accept-unpeppered:false}")
+    private boolean acceptUnpepperedTokenHashes;
+
+    /**
+     * The peppers to fall back to, in order, when a token does not match under the current one. Derived
+     * in {@link #validate()} from the two properties above: deduplicated, and without the current pepper,
+     * which is always tried first anyway.
+     */
+    private List<String> tokenHashPepperKeyring = List.of();
+
     @Value("${ovsx.data.mirror.enabled:false}")
     private boolean mirrorEnabled;
 
@@ -178,6 +231,15 @@ public class AccessTokenConfig {
         return tokenHashPepper;
     }
 
+    /**
+     * The peppers a token that does not match under the current pepper is retried with, in order. Empty
+     * unless the instance is mid-rotation, in which case a hit means the row still carries an old hash
+     * and wants rewriting.
+     */
+    public @NonNull List<String> getTokenHashPepperKeyring() {
+        return tokenHashPepperKeyring;
+    }
+
     @PostConstruct
     public void validate() {
         if (isTokenExpiryEnabled() && mirrorEnabled) {
@@ -211,5 +273,23 @@ public class AccessTokenConfig {
         if (tokenHashPepper == null) {
             throw new IllegalArgumentException("ovsx.access-token.token-hash-pepper must not be null");
         }
+        if (tokenHashPepper.indexOf(',') >= 0) {
+            throw new IllegalArgumentException(
+                    "ovsx.access-token.token-hash-pepper must not contain a comma, because "
+                            + "ovsx.access-token.token-hash-previous-peppers is a comma separated list and "
+                            + "could not carry this value once it is rotated out");
+        }
+
+        // LinkedHashSet: the order operators wrote decides which pepper is tried first, and a pepper
+        // listed twice - or listed while still current - costs a query per authentication, not a bug.
+        var keyring = new LinkedHashSet<String>();
+        if (previousTokenHashPeppers != null) {
+            keyring.addAll(previousTokenHashPeppers);
+        }
+        if (acceptUnpepperedTokenHashes) {
+            keyring.add("");
+        }
+        keyring.remove(tokenHashPepper);
+        tokenHashPepperKeyring = List.copyOf(keyring);
     }
 }

--- a/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
+++ b/server/src/main/java/org/eclipse/openvsx/accesstoken/AccessTokenService.java
@@ -277,6 +277,10 @@ public class AccessTokenService {
     public AccessTokenAuthentication useAccessToken(String tokenValue, AccessTokenAction accessTokenAction) {
         var token = repositories.findPersonalAccessToken(hashTokenValue(tokenValue));
         if (token == null) {
+            // the pepper may have changed since this token was issued; the row is rewritten if so
+            token = findTokenHashedWithPreviousPepper(tokenValue);
+        }
+        if (token == null) {
             // assume DB contains token v0; fetch and upgrade if found active token
             token = repositories.findPersonalAccessToken(tokenValue);
             if (token != null && token.getVersion() != TOKEN_CURRENT_VERSION) {
@@ -332,6 +336,36 @@ public class AccessTokenService {
             }
         }
         return new AccessTokenAuthentication(token.getUser(), token.getType(), token.getId(), token.getClaims());
+    }
+
+    /**
+     * Looks a token up under each pepper this instance used before the current one, and rewrites the hash
+     * of the row it finds so that the next lookup matches on the first try.
+     * <p>
+     * This is the whole of pepper rotation. The raw value is never stored, so a row can only be moved to
+     * a new pepper while its holder is presenting the token - there is no set of rows a background job
+     * could rehash, the way {@link #upgradeTokens()} can rehash the v0 rows that still carry their raw
+     * value. A token that is never used again therefore keeps its old hash until it expires, which is
+     * what obliges an operator to keep a retired pepper configured; see
+     * {@code ovsx.access-token.token-hash-previous-peppers}.
+     * <p>
+     * The rewrite happens before the caller has decided whether the token is usable at all, matching what
+     * the v0 upgrade does: which pepper hashed a row says nothing about whether that token is active,
+     * expired or in scope, so there is no reason to make the migration wait on those checks.
+     * <p>
+     * Costs one query per configured previous pepper, and only for a token that has not been used since
+     * the rotation. An instance that is not mid-rotation has an empty keyring and does no extra work.
+     */
+    private @Nullable PersonalAccessToken findTokenHashedWithPreviousPepper(String tokenValue) {
+        for (var previousPepper : config.getTokenHashPepperKeyring()) {
+            var token = repositories.findPersonalAccessToken(hashTokenValue(tokenValue, previousPepper));
+            if (token != null) {
+                token.setValue(hashTokenValue(tokenValue));
+                logger.debug("Rehashed access token {} with the current pepper", token.getId());
+                return token;
+            }
+        }
+        return null;
     }
 
     private AccessTokenScope getScope(PersonalAccessToken token) {
@@ -452,9 +486,13 @@ public class AccessTokenService {
     }
 
     private String hashTokenValue(String tokenValue) {
+        return hashTokenValue(tokenValue, config.getTokenHashPepper());
+    }
+
+    private String hashTokenValue(String tokenValue, String pepper) {
         try {
             // the pepper is instance wide and lives in the configuration only; it must never reach the DB
-            String payload = tokenValue + config.getTokenHashPepper();
+            String payload = tokenValue + pepper;
             return Hex.encodeHexString(
                     DigestUtils.digest(
                             MessageDigest.getInstance(config.getTokenHashAlgorithm()),

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenConfigTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenConfigTest.java
@@ -15,8 +15,11 @@ package org.eclipse.openvsx.accesstoken;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * binding is worth asserting rather than assuming - not least because the previous-peppers list is a
  * comma separated {@code @Value}, whose behaviour for an absent property is not obvious.
  */
+@ExtendWith(OutputCaptureExtension.class)
 class AccessTokenConfigTest {
 
     // A bare runner has no conversion service, where a real Boot context does; without it neither the
@@ -140,6 +144,28 @@ class AccessTokenConfigTest {
                 .run(context -> {
                     List<String> keyring = context.getBean(AccessTokenConfig.class).getTokenHashPepperKeyring();
                     assertThat(keyring).isUnmodifiable();
+                });
+    }
+
+    // The empty pepper is the default and no shipped configuration sets one, so without this the
+    // recommendation exists only in a javadoc that nobody deploying the server reads.
+    @Test
+    void warnsWhenNoPepperIsConfigured(CapturedOutput output) {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(output)
+                    .contains("No ovsx.access-token.token-hash-pepper is configured")
+                    .contains("token-hash-accept-unpeppered");
+        });
+    }
+
+    @Test
+    void staysQuietWhenAPepperIsConfigured(CapturedOutput output) {
+        contextRunner
+                .withPropertyValues("ovsx.access-token.token-hash-pepper=current")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(output).doesNotContain("token-hash-pepper is configured");
                 });
     }
 }

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenConfigTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenConfigTest.java
@@ -1,0 +1,145 @@
+/******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *****************************************************************************/
+package org.eclipse.openvsx.accesstoken;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers how the pepper keyring is bound and derived. The properties are the operator's interface to
+ * pepper rotation, and getting one of them wrong invalidates every access token in the registry, so the
+ * binding is worth asserting rather than assuming - not least because the previous-peppers list is a
+ * comma separated {@code @Value}, whose behaviour for an absent property is not obvious.
+ */
+class AccessTokenConfigTest {
+
+    // A bare runner has no conversion service, where a real Boot context does; without it neither the
+    // Duration properties nor the comma separated pepper list can bind at all.
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withInitializer(
+                    context -> context.getBeanFactory()
+                            .setConversionService(ApplicationConversionService.getSharedInstance()))
+            .withUserConfiguration(AccessTokenConfig.class);
+
+    @Test
+    void hasNoKeyringByDefault() {
+        contextRunner.run(context -> {
+            var config = context.getBean(AccessTokenConfig.class);
+            assertThat(config.getTokenHashPepper()).isEmpty();
+            assertThat(config.getTokenHashPepperKeyring()).isEmpty();
+        });
+    }
+
+    @Test
+    void bindsPreviousPeppersInTheConfiguredOrder() {
+        contextRunner
+                .withPropertyValues(
+                        "ovsx.access-token.token-hash-pepper=current",
+                        "ovsx.access-token.token-hash-previous-peppers=older,old")
+                .run(
+                        context -> assertThat(context.getBean(AccessTokenConfig.class).getTokenHashPepperKeyring())
+                                .containsExactly("older", "old"));
+    }
+
+    // Adopting a pepper where there was none: the previous pepper is the empty string, which a comma
+    // separated list cannot express, hence the separate flag.
+    @Test
+    void addsTheUnpepperedHashToTheKeyringWhenAccepted() {
+        contextRunner
+                .withPropertyValues(
+                        "ovsx.access-token.token-hash-pepper=current",
+                        "ovsx.access-token.token-hash-accept-unpeppered=true")
+                .run(
+                        context -> assertThat(context.getBean(AccessTokenConfig.class).getTokenHashPepperKeyring())
+                                .containsExactly(""));
+    }
+
+    @Test
+    void putsTheUnpepperedHashAfterTheConfiguredPeppers() {
+        contextRunner
+                .withPropertyValues(
+                        "ovsx.access-token.token-hash-pepper=current",
+                        "ovsx.access-token.token-hash-previous-peppers=old",
+                        "ovsx.access-token.token-hash-accept-unpeppered=true")
+                .run(
+                        context -> assertThat(context.getBean(AccessTokenConfig.class).getTokenHashPepperKeyring())
+                                .containsExactly("old", ""));
+    }
+
+    // The current pepper is always tried first, so listing it again would only add a wasted query per
+    // authentication. An operator who forgets to drop it after a rotation should not pay for that.
+    @Test
+    void dropsTheCurrentPepperFromTheKeyring() {
+        contextRunner
+                .withPropertyValues(
+                        "ovsx.access-token.token-hash-pepper=current",
+                        "ovsx.access-token.token-hash-previous-peppers=old,current")
+                .run(
+                        context -> assertThat(context.getBean(AccessTokenConfig.class).getTokenHashPepperKeyring())
+                                .containsExactly("old"));
+    }
+
+    // Same reasoning for an accept-unpeppered flag left set on an instance that never adopted a pepper:
+    // the empty current pepper already covers it.
+    @Test
+    void dropsTheUnpepperedHashWhenThereIsNoCurrentPepper() {
+        contextRunner
+                .withPropertyValues("ovsx.access-token.token-hash-accept-unpeppered=true")
+                .run(
+                        context -> assertThat(context.getBean(AccessTokenConfig.class).getTokenHashPepperKeyring())
+                                .isEmpty());
+    }
+
+    @Test
+    void deduplicatesRepeatedPeppers() {
+        contextRunner
+                .withPropertyValues(
+                        "ovsx.access-token.token-hash-pepper=current",
+                        "ovsx.access-token.token-hash-previous-peppers=old,older,old")
+                .run(
+                        context -> assertThat(context.getBean(AccessTokenConfig.class).getTokenHashPepperKeyring())
+                                .containsExactly("old", "older"));
+    }
+
+    // Caught at startup rather than at the rotation that would silently split it into two wrong peppers
+    // - by which point the tokens hashed with it are unreachable and the mistake looks like data loss.
+    @Test
+    void refusesACurrentPepperContainingAComma() {
+        contextRunner
+                .withPropertyValues("ovsx.access-token.token-hash-pepper=one,two")
+                .run(
+                        context -> assertThat(context)
+                                .hasFailed()
+                                .getFailure()
+                                .rootCause()
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("must not contain a comma"));
+    }
+
+    @Test
+    void keepsTheKeyringImmutable() {
+        contextRunner
+                .withPropertyValues(
+                        "ovsx.access-token.token-hash-pepper=current",
+                        "ovsx.access-token.token-hash-previous-peppers=old")
+                .run(context -> {
+                    List<String> keyring = context.getBean(AccessTokenConfig.class).getTokenHashPepperKeyring();
+                    assertThat(keyring).isUnmodifiable();
+                });
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenConfigTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenConfigTest.java
@@ -120,6 +120,31 @@ class AccessTokenConfigTest {
                                 .containsExactly("old", "older"));
     }
 
+    // A blank element is what a trailing or doubled comma leaves behind, and a blank pepper *is* the
+    // unpeppered hash - which is exactly what token-hash-accept-unpeppered exists to gate. Honouring one
+    // would let a stray comma turn on acceptance of unpeppered tokens without anyone asking for it.
+    @Test
+    void ignoresBlankEntriesInThePreviousPepperList() {
+        contextRunner
+                .withPropertyValues(
+                        "ovsx.access-token.token-hash-pepper=current",
+                        "ovsx.access-token.token-hash-previous-peppers=old,")
+                .run(
+                        context -> assertThat(context.getBean(AccessTokenConfig.class).getTokenHashPepperKeyring())
+                                .containsExactly("old"));
+    }
+
+    @Test
+    void ignoresWhitespaceOnlyEntriesInThePreviousPepperList() {
+        contextRunner
+                .withPropertyValues(
+                        "ovsx.access-token.token-hash-pepper=current",
+                        "ovsx.access-token.token-hash-previous-peppers=old, ,older")
+                .run(
+                        context -> assertThat(context.getBean(AccessTokenConfig.class).getTokenHashPepperKeyring())
+                                .containsExactly("old", "older"));
+    }
+
     // Caught at startup rather than at the rotation that would silently split it into two wrong peppers
     // - by which point the tokens hashed with it are unreachable and the mistake looks like data loss.
     @Test

--- a/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/accesstoken/AccessTokenServiceTest.java
@@ -12,12 +12,15 @@
  *****************************************************************************/
 package org.eclipse.openvsx.accesstoken;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 import java.util.Map;
 
 import jakarta.persistence.EntityManager;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,6 +50,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -75,6 +79,13 @@ class AccessTokenServiceTest {
         // lenient: generateTokenValue does not hash anything, so it needs neither of these
         lenient().when(config.getTokenHashAlgorithm()).thenReturn("SHA-256");
         lenient().when(config.getTokenHashPepper()).thenReturn("pepper");
+        // no rotation in progress unless a test says otherwise
+        lenient().when(config.getTokenHashPepperKeyring()).thenReturn(List.of());
+    }
+
+    /** The hash the service stores for a token, so a test can set up the row it expects to be found. */
+    private static String hashed(String tokenValue, String pepper) {
+        return DigestUtils.sha256Hex((tokenValue + pepper).getBytes(StandardCharsets.UTF_8));
     }
 
     private PersonalAccessToken activeUnrestrictedToken() {
@@ -392,5 +403,88 @@ class AccessTokenServiceTest {
                 Map.of());
 
         assertThat(json.getDeleteTokenUrl()).isNull();
+    }
+
+    // Pepper rotation: the raw value is never stored, so a row can only move to the new pepper while its
+    // holder is presenting the token. Listing the old pepper keeps such a token valid, and the hit
+    // rewrites the row so the next lookup matches on the first try.
+    @Test
+    void authenticatesATokenStillHashedWithAPreviousPepper() {
+        when(config.getTokenHashPepperKeyring()).thenReturn(List.of("old-pepper"));
+        var user = new UserData();
+        var token = activeUnrestrictedToken();
+        token.setUser(user);
+        token.setValue(hashed("tok", "old-pepper"));
+        when(repositories.findPersonalAccessToken(hashed("tok", "pepper"))).thenReturn(null);
+        when(repositories.findPersonalAccessToken(hashed("tok", "old-pepper"))).thenReturn(token);
+
+        var tau = accessTokenService.useAccessToken("tok", new AccessTokenAction.Verify());
+
+        assertThat(tau).isNotNull();
+        assertThat(tau.userData()).isSameAs(user);
+        assertThat(token.getValue()).isEqualTo(hashed("tok", "pepper"));
+    }
+
+    // Adopting a pepper on an instance that ran without one: the previous pepper is the empty string,
+    // which is why it gets its own flag rather than an unwritable empty entry in the list.
+    @Test
+    void authenticatesAnUnpepperedTokenWhenAPepperIsAdopted() {
+        when(config.getTokenHashPepperKeyring()).thenReturn(List.of(""));
+        var user = new UserData();
+        var token = activeUnrestrictedToken();
+        token.setUser(user);
+        token.setValue(hashed("tok", ""));
+        when(repositories.findPersonalAccessToken(hashed("tok", "pepper"))).thenReturn(null);
+        when(repositories.findPersonalAccessToken(hashed("tok", ""))).thenReturn(token);
+
+        var tau = accessTokenService.useAccessToken("tok", new AccessTokenAction.Verify());
+
+        assertThat(tau).isNotNull();
+        assertThat(token.getValue()).isEqualTo(hashed("tok", "pepper"));
+    }
+
+    // The keyring is tried in the configured order, and only until something matches.
+    @Test
+    void stopsAtTheFirstPreviousPepperThatMatches() {
+        when(config.getTokenHashPepperKeyring()).thenReturn(List.of("older", "old"));
+        var token = activeUnrestrictedToken();
+        token.setUser(new UserData());
+        token.setValue(hashed("tok", "older"));
+        when(repositories.findPersonalAccessToken(hashed("tok", "pepper"))).thenReturn(null);
+        when(repositories.findPersonalAccessToken(hashed("tok", "older"))).thenReturn(token);
+
+        assertThat(accessTokenService.useAccessToken("tok", new AccessTokenAction.Verify())).isNotNull();
+
+        verify(repositories).findPersonalAccessToken(hashed("tok", "pepper"));
+        verify(repositories).findPersonalAccessToken(hashed("tok", "older"));
+        verify(repositories, never()).findPersonalAccessToken(hashed("tok", "old"));
+    }
+
+    // A token already on the current pepper must not pay for the rotation: it matches on the first
+    // lookup, and neither the keyring nor the v0 fallback is consulted.
+    @Test
+    void doesNotRetryPreviousPeppersWhenTheCurrentOneMatches() {
+        // lenient: this stub going unread is half the assertion - the keyring is never even consulted
+        lenient().when(config.getTokenHashPepperKeyring()).thenReturn(List.of("old-pepper"));
+        var token = activeUnrestrictedToken();
+        token.setUser(new UserData());
+        when(repositories.findPersonalAccessToken(hashed("tok", "pepper"))).thenReturn(token);
+
+        assertThat(accessTokenService.useAccessToken("tok", new AccessTokenAction.Verify())).isNotNull();
+
+        verify(repositories).findPersonalAccessToken(hashed("tok", "pepper"));
+        verifyNoMoreInteractions(repositories);
+    }
+
+    // An unknown token still ends at the v0 raw-value fallback, having tried every configured pepper.
+    @Test
+    void fallsThroughToTheLegacyLookupWhenNoPepperMatches() {
+        when(config.getTokenHashPepperKeyring()).thenReturn(List.of("old-pepper"));
+
+        assertThat(accessTokenService.useAccessToken("tok", new AccessTokenAction.Verify())).isNull();
+
+        verify(repositories).findPersonalAccessToken(hashed("tok", "pepper"));
+        verify(repositories).findPersonalAccessToken(hashed("tok", "old-pepper"));
+        verify(repositories).findPersonalAccessToken("tok");
     }
 }


### PR DESCRIPTION
Stacked on #2159 — **based on `refactor/token-hash-pepper`, not `main`**, so review that one first and this diff stays to the keyring itself. Retarget to `main` once #2159 merges.

Two commits: the keyring, then the startup warning that the keyring makes actionable.

### The problem

Changing `ovsx.access-token.token-hash-pepper` invalidates every token in the registry. The raw value is never stored — `createAccessToken` hashes it on the way in (`AccessTokenService.java:179`) and the row keeps only the digest — so nothing can rehash a row under a new pepper except the holder presenting the token again. The v0→v1 upgrade is no template: `upgradeToken` works only because v0 rows still literally carried their raw value.

That matters most for the case nearly every instance is actually in. The pepper defaults to the empty string and no shipped configuration sets one, so *adopting* a pepper is itself a rotation — and today it logs out every user's tokens at once.

### The approach

Rotation can't happen on the stored side, so it happens on the verification side. `useAccessToken` retries a token that misses under the current pepper against each pepper the instance used before, and rewrites the row it finds:

```java
var token = repositories.findPersonalAccessToken(hashTokenValue(tokenValue));
if (token == null) {
    // the pepper may have changed since this token was issued; the row is rewritten if so
    token = findTokenHashedWithPreviousPepper(tokenValue);
}
if (token == null) {
    // assume DB contains token v0; ...
```

Each token migrates to the current pepper the next time it is used. The retry sits ahead of the existing v0 fallback, and the rewrite happens before the active/expired/scope checks — matching what the v0 upgrade already does, since which pepper hashed a row says nothing about whether that token is usable.

### Configuration

| Property | Purpose |
|---|---|
| `ovsx.access-token.token-hash-previous-peppers` | comma separated list of retired peppers |
| `ovsx.access-token.token-hash-accept-unpeppered` | accept hashes carrying no pepper — the switch for adopting a pepper where there was none |

The flag exists because the unpeppered case *is* a previous pepper of `""`, which a comma separated list cannot express unambiguously. Both feed one deduplicated keyring that drops the current pepper, since that is always tried first.

### The startup warning

An instance with no pepper now says so once at boot, naming what it costs and what to do:

> No ovsx.access-token.token-hash-pepper is configured, so personal access tokens are stored as unkeyed hashes. Whoever obtains a copy of the database can then confirm a token found elsewhere without touching this registry, and match hashes across dumps and instances. Generate one with 'openssl rand -base64 32'; to keep the tokens that already exist working, set ovsx.access-token.token-hash-accept-unpeppered=true at the same time and drop it once they have expired.

`WARN`, not a startup failure: the empty default has to keep working. It belongs in *this* PR rather than on its own, because before the keyring the only honest advice was "set a pepper and invalidate every token" — the warning is worth making only once acting on it is safe. Checks `hasText` rather than `isEmpty`, since a pepper of blanks is no more of a secret than none.

To be clear about what the empty default does and does not cost: token values are 256 CSPRNG bits, so a leaked hash column still yields no usable tokens either way. What an unkeyed hash gives away is an offline confirmation oracle for a token found elsewhere — no rate limit, no access-log entry, no `accessed_timestamp` bump — and the ability to join hashes across dumps and instances, since unkeyed SHA-256 is globally deterministic. Worth a warning, not worth a refusal to start.

### What this deliberately does not do

It cannot finish the migration early. No background job can rehash a token nobody presents, so a retired pepper must stay configured until every row that might still use it is gone — bounded by `ovsx.access-token.expiration` plus one expiry sweep, and **unbounded where expiry is disabled** (`expiration: 0`), because an unused token then lives forever and so must its pepper. That's documented on the property itself rather than left for an operator to find out.

### Cost

One extra query per configured previous pepper, and only for a token that hasn't been used since the rotation. An instance not mid-rotation has an empty keyring and does no extra work — asserted by `doesNotRetryPreviousPeppersWhenTheCurrentOneMatches`, where the keyring stub going unread is half the point.

### Also

A current pepper containing a comma is now rejected at startup, rather than at the rotation where it would silently split into two wrong peppers — by which point the tokens hashed with it are unreachable and the mistake looks like data loss.

### Verification

- `./gradlew test --tests '*AccessToken*'` — **46 tests pass** (`--rerun-tasks`), including 11 new `AccessTokenConfigTest` cases (binding, ordering, dedup, current-pepper removal, comma rejection, and both warning paths) and 5 new rotation cases in `AccessTokenServiceTest`
- `spotlessCheck` clean on every touched file

`AccessTokenConfigTest` needs `.withInitializer(... setConversionService(ApplicationConversionService.getSharedInstance()))` — a bare `ApplicationContextRunner` has no conversion service, so neither the `Duration` properties nor the comma separated list bind without it. Worth knowing for the next config test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
