### PR TITLE
fix: default personal_access_token.version and .type

### DIFF
--- a/scripts/import-db-dump.sh
+++ b/scripts/import-db-dump.sh
@@ -347,13 +347,24 @@ if [ "${#DROPPED_COLUMNS[@]}" -gt 0 ]; then
   exit 1
 fi
 
-# --- A column the target has gained since the dump's era, if it's NOT NULL with no default,
-# can't just be left out of the \copy column list - Postgres would reject every imported row.
-# Known cases get a backfill: the constraint is dropped, the import runs, the same backfill the
-# introducing migration itself used runs, then the constraint is restored - all still inside the
-# one transaction. Add an entry here (keyed "table.column") for anything new, matching whatever
-# UPDATE the migration that introduced the column used for pre-existing rows; a gap with no entry
-# here fails the preflight check below instead of guessing.
+# --- A column the target has gained since the dump's era is left out of the \copy column list, and
+# the imported rows take whatever the target's schema gives them - its default, or NULL. Two kinds of
+# column need more than that, and both are handled by a backfill registered here.
+#
+# A column that is NOT NULL with no default can't be left out at all: Postgres would reject every
+# imported row. Those are dropped to nullable, imported, backfilled with the same UPDATE the
+# introducing migration used, and set back to NOT NULL - all inside the one transaction. A gap of
+# this kind with no entry here fails the preflight check below instead of guessing.
+#
+# A column whose default does not reproduce what the introducing migration computed needs a backfill
+# too, even though the import would succeed without one. personal_access_token.type is the case in
+# point: V1_74 defaults it to 'LLT' so hand-written INSERTs keep working, but V1_72 derived 'OTT' for
+# one-time tokens from their description, and importing those as 'LLT' would quietly turn a
+# used-once credential into a permanent one. So the gap set below is every target column the dump
+# lacks, and only the un-importable ones are *required* to have an entry.
+#
+# Add an entry (keyed "table.column") for anything new, matching whatever UPDATE the migration that
+# introduced the column used for pre-existing rows.
 declare -A KNOWN_BACKFILLS
 KNOWN_BACKFILLS["personal_access_token.version"]="UPDATE personal_access_token SET version = 0;"
 KNOWN_BACKFILLS["personal_access_token.type"]="
@@ -361,25 +372,31 @@ KNOWN_BACKFILLS["personal_access_token.type"]="
   UPDATE personal_access_token SET type = 'LLT' WHERE type IS NULL;
 "
 
-echo "Checking for target columns the dump doesn't have that require a value..."
-declare -A GAP_COLUMNS   # "table.column" -> 1, for every gap found (known or not)
+echo "Checking for target columns the dump doesn't have..."
+declare -A BACKFILL_COLUMNS   # "table.column" -> 1, for every gap that has a backfill to run
+declare -A REQUIRED_GAPS      # "table.column" -> 1, the subset that can't be imported without one
 declare -a UNKNOWN_GAPS=()
 for t in "${TABLES[@]}"; do
   IFS=',' read -r -a dump_cols <<< "${COLUMN_LISTS[${t}]}"
-  gap_cols=$(target_psql -t -c "
-    select column_name from information_schema.columns
+  gap_cols=$(target_psql -t -A -F',' -c "
+    select column_name, (is_nullable = 'NO' and column_default is null)
+    from information_schema.columns
     where table_schema='public' and table_name='${t}'
-    and is_nullable='NO' and column_default is null
     and column_name not in ($(printf "'%s'," "${dump_cols[@]}" | sed 's/,$//'));
-  " | tr -d ' ' | grep -v '^$' || true)
-  while IFS= read -r col; do
+  " | grep -v '^$' || true)
+  while IFS=',' read -r col required; do
     [ -z "${col}" ] && continue
     key="${t}.${col}"
-    GAP_COLUMNS["${key}"]=1
-    if [ -z "${KNOWN_BACKFILLS[${key}]:-}" ]; then
+    [ "${required}" = "t" ] && REQUIRED_GAPS["${key}"]=1
+    if [ -n "${KNOWN_BACKFILLS[${key}]:-}" ]; then
+      BACKFILL_COLUMNS["${key}"]=1
+      if [ "${required}" = "t" ]; then
+        echo "  ${key}: no value in the dump, not nullable, no default - will backfill (known)"
+      else
+        echo "  ${key}: no value in the dump - will backfill (known) instead of taking the default"
+      fi
+    elif [ "${required}" = "t" ]; then
       UNKNOWN_GAPS+=("${key}")
-    else
-      echo "  ${key}: no value in the dump, not nullable, no default - will backfill (known)"
     fi
   done <<< "${gap_cols}"
 done
@@ -469,16 +486,24 @@ SQL_FILE="${WORKDIR}/reload.sql"
     [ -n "${t}" ] && echo "DELETE FROM ${t};"
   done
   for t in "${IMPORT_ORDER_ARR[@]}"; do
-    gap_cols_for_table=()
-    for key in "${!GAP_COLUMNS[@]}"; do
-      [ "${key%%.*}" = "${t}" ] && gap_cols_for_table+=("${key#*.}")
+    # Only the columns the dump can't supply at all lose their NOT NULL for the duration of the
+    # import; a column that has a default imports fine as it is and just gets its backfill after.
+    required_cols_for_table=()
+    for key in "${!REQUIRED_GAPS[@]}"; do
+      [ "${key%%.*}" = "${t}" ] && required_cols_for_table+=("${key#*.}")
     done
-    for col in "${gap_cols_for_table[@]}"; do
+    backfill_cols_for_table=()
+    for key in "${!BACKFILL_COLUMNS[@]}"; do
+      [ "${key%%.*}" = "${t}" ] && backfill_cols_for_table+=("${key#*.}")
+    done
+    for col in "${required_cols_for_table[@]}"; do
       echo "ALTER TABLE ${t} ALTER COLUMN ${col} DROP NOT NULL;"
     done
     echo "\\copy ${t} (${COLUMN_LISTS[${t}]}) from '${DUMP_DIR}/${t}.csv' with (${COPY_FORMAT})"
-    for col in "${gap_cols_for_table[@]}"; do
+    for col in "${backfill_cols_for_table[@]}"; do
       echo "${KNOWN_BACKFILLS[${t}.${col}]}"
+    done
+    for col in "${required_cols_for_table[@]}"; do
       echo "ALTER TABLE ${t} ALTER COLUMN ${col} SET NOT NULL;"
     done
   done

--- a/scripts/import-db-dump.sh
+++ b/scripts/import-db-dump.sh
@@ -149,16 +149,18 @@ target_docker_host() {
 # --- Run the psql client against the target, either the host's own psql or, if that isn't
 # installed, a throwaway containerized one (see target_docker_host above for how it reaches the
 # target).
+# -X because the first branch runs the caller's own psql: a ~/.psqlrc that turns on \timing, or
+# echoes anything at all, would be read back as schema metadata by the queries below.
 target_psql() {
   if command -v psql >/dev/null 2>&1; then
-    PGPASSWORD="${TARGET_PASSWORD}" psql -h "${TARGET_HOST}" -p "${TARGET_PORT}" -U "${TARGET_USER}" -d "${TARGET_DB}" -v ON_ERROR_STOP=1 "$@"
+    PGPASSWORD="${TARGET_PASSWORD}" psql -X -h "${TARGET_HOST}" -p "${TARGET_PORT}" -U "${TARGET_USER}" -d "${TARGET_DB}" -v ON_ERROR_STOP=1 "$@"
   else
     # -f references a file under WORKDIR; -c/\copy reference dump files under DUMP_DIR - both
     # need to be visible inside the container at the same absolute path the SQL text uses.
     docker run --rm -i --add-host=host.docker.internal:host-gateway \
       -v "${DUMP_DIR}:${DUMP_DIR}:ro" -v "${WORKDIR}:${WORKDIR}" \
       -e PGPASSWORD="${TARGET_PASSWORD}" "${POSTGRES_IMAGE}" \
-      psql -h "$(target_docker_host)" -p "${TARGET_PORT}" -U "${TARGET_USER}" -d "${TARGET_DB}" -v ON_ERROR_STOP=1 "$@"
+      psql -X -h "$(target_docker_host)" -p "${TARGET_PORT}" -U "${TARGET_USER}" -d "${TARGET_DB}" -v ON_ERROR_STOP=1 "$@"
   fi
 }
 
@@ -315,6 +317,12 @@ fi
 # list would fail with a bare 'column does not exist' well into the run. Caught here instead,
 # before anything on the target is touched, with a pointer at the import-into-empty-DB route
 # that lets the real migrations decide what becomes of those columns.
+#
+# sed rather than grep to strip the blank line psql's tuples-only output leaves behind: grep exits 1
+# when it matches nothing, which under `pipefail` is indistinguishable from psql itself having
+# failed, and the `|| true` needed to tolerate the former swallowed the latter too - leaving the
+# check silently concluding that nothing was dropped. sed exits 0 either way, so a psql that cannot
+# reach the target aborts the script here instead. Same in the gap query below.
 echo "Checking that every column in the dump still exists on the target..."
 declare -a DROPPED_COLUMNS=()
 for t in "${TABLES[@]}"; do
@@ -325,7 +333,7 @@ for t in "${TABLES[@]}"; do
       select column_name from information_schema.columns
       where table_schema='public' and table_name='${t}'
     );
-  " | tr -d ' ' | grep -v '^$' || true)
+  " | tr -d ' ' | sed '/^$/d')
   while IFS= read -r col; do
     [ -z "${col}" ] && continue
     DROPPED_COLUMNS+=("${t}.${col}")
@@ -383,7 +391,7 @@ for t in "${TABLES[@]}"; do
     from information_schema.columns
     where table_schema='public' and table_name='${t}'
     and column_name not in ($(printf "'%s'," "${dump_cols[@]}" | sed 's/,$//'));
-  " | grep -v '^$' || true)
+  " | sed '/^$/d')
   while IFS=',' read -r col required; do
     [ -z "${col}" ] && continue
     key="${t}.${col}"

--- a/server/src/main/java/org/eclipse/openvsx/entities/PersonalAccessToken.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/PersonalAccessToken.java
@@ -48,7 +48,11 @@ public class PersonalAccessToken implements Serializable {
     @JoinColumn(name = "user_data")
     private UserData user;
 
-    @Column(length = 64)
+    // 128, matching the width V1_72 gave the column: enough for the hex digest of any algorithm
+    // `ovsx.access-token.token-hash-algorithm` may name (SHA-512's is 128 characters; the default
+    // SHA-256's is 64), and for a still-unhashed version 0 value, whose 43-character body sits behind
+    // a type marker and a deployment prefix.
+    @Column(length = 128)
     private String value;
 
     private boolean active;

--- a/server/src/main/resources/db/migration/V1_74__PersonalAccessToken_Column_Defaults.sql
+++ b/server/src/main/resources/db/migration/V1_74__PersonalAccessToken_Column_Defaults.sql
@@ -1,0 +1,25 @@
+-- personal_access_token.version and .type became NOT NULL in V1_72__Trusted_Publisher.sql without a
+-- default, so every INSERT has to name them. The application always does - PersonalAccessToken has no
+-- @DynamicInsert, so Hibernate lists every column on every insert - but hand-written SQL now has to
+-- know about two columns it previously didn't, and the bootstrap procedure documented for registries
+-- without a login provider (deploy/kubernetes/README.md, and the wiki) fails on a current schema.
+--
+-- These defaults are chosen so that an INSERT written against the pre-V1_72 schema still produces a
+-- working token: the row it creates is exactly the row that migration's own backfill would have left
+-- behind.
+
+ALTER TABLE ONLY public.personal_access_token
+    -- The oldest token format, deliberately, and it must stay pinned at 0 rather than tracking
+    -- AccessTokenService.TOKEN_CURRENT_VERSION. Version 0 means "the value column still holds the raw
+    -- token": the hash pepper lives in the application configuration and never reaches the database, so
+    -- a value inserted by hand cannot be anything else. AccessTokenService#useAccessToken falls back to
+    -- a plaintext lookup, hashes the row in place and bumps its version on first use, and the startup
+    -- upgrade job does the same for tokens that are never used. Raising this default to a newer version
+    -- would make such a row be read as an already-hashed value in that format, and it would silently
+    -- never authenticate again - so version 0 has to keep being understood by upgradeToken for as long
+    -- as this default stands.
+    ALTER COLUMN version SET DEFAULT 0,
+    -- The only type an operator would create by hand: a normal long-lived token. OTT and TPT are issued
+    -- by the server itself, are ephemeral, and carry state (a scope, a trusted publisher registration,
+    -- OIDC claims) that an INSERT omitting the type would not be supplying either.
+    ALTER COLUMN type SET DEFAULT 'LLT';

--- a/server/src/main/resources/db/migration/V1_74__PersonalAccessToken_Column_Defaults.sql
+++ b/server/src/main/resources/db/migration/V1_74__PersonalAccessToken_Column_Defaults.sql
@@ -5,8 +5,10 @@
 -- without a login provider (deploy/kubernetes/README.md, and the wiki) fails on a current schema.
 --
 -- These defaults are chosen so that an INSERT written against the pre-V1_72 schema still produces a
--- working token: the row it creates is exactly the row that migration's own backfill would have left
--- behind.
+-- working token - the row that migration's own backfill would have left behind for an ordinary
+-- long-lived one. They do not reproduce that backfill in full: it also derived type = 'OTT' from the
+-- description of the one-time publish tokens the server used to create, which is a classification of
+-- rows that already existed, not something a hand-written INSERT has any reason to be creating.
 
 ALTER TABLE ONLY public.personal_access_token
     -- The oldest token format, deliberately, and it must stay pinned at 0 rather than tracking


### PR DESCRIPTION
## Problem

`V1_72__Trusted_Publisher.sql` added `personal_access_token.version` and `.type` as `NOT NULL` with no default, so every INSERT into the table now has to name them. The bootstrap procedure documented for registries deployed without a login provider — `deploy/kubernetes/README.md:197`, and the wiki's *Deleting Extensions* page — fails outright on a current schema:

```
null value in column "version" of relation "personal_access_token" violates not-null constraint
```

The dev seed in `server/src/dev/resources/db/migration/V1_0_1__Super_user.sql` only still works because Flyway runs it before V1_72, which then backfills it.

## Change

`V1_74` defaults the two columns to exactly what V1_72's own backfill would have left behind, so an INSERT written against the pre-V1_72 schema still produces a working token.

`version` defaults to `0` — deliberately the *oldest* format, not the current one. The hash pepper lives in the application configuration and never reaches the database, so a value inserted by hand cannot be anything but plaintext; `AccessTokenService#useAccessToken` falls back to a plaintext lookup and hashes the row in place on first use, and the startup upgrade job does the same for tokens that are never used. The migration comment spells out that this must stay pinned at `0` rather than tracking `TOKEN_CURRENT_VERSION`, and that version 0 has to keep being understood by `upgradeToken` for as long as the default stands — raising it would make such a row read as an already-hashed value and silently never authenticate.

`type` defaults to `LLT`, the only type an operator would create by hand; `OTT` and `TPT` are issued by the server and carry state an INSERT omitting the type wouldn't be supplying either.

**This can't mask a bug in the application's own inserts.** `PersonalAccessToken` has `@DynamicUpdate` but not `@DynamicInsert`, so Hibernate lists every column on every insert — a code path that forgets `setType` still sends an explicit NULL and still fails on the constraint. The defaults are only ever reachable from hand-written SQL that omits the columns.

## `import-db-dump.sh`

The script's gap detection keyed on `is_nullable='NO' and column_default is null`, which these two columns now stop matching — and with them `KNOWN_BACKFILLS["personal_access_token.type"]`, the backfill that classifies pre-V1_72 one-time tokens as `OTT` by description. Without it they'd import as `LLT`, quietly turning a used-once credential into a permanent one.

Split the two things that check was conflating:

- **every** target column the dump lacks may carry a backfill, which runs after the `\copy`;
- only those that can't be imported at all (`NOT NULL`, no default) are *required* to have one, and only those get their `NOT NULL` dropped around the copy.

## Testing

Exercised the rewritten detection against a scratch Postgres in three shapes:

| target schema | `REQUIRED_GAPS` | `BACKFILL_COLUMNS` | `UNKNOWN_GAPS` |
| --- | --- | --- | --- |
| with the V1_74 defaults | – | `version`, `type` | – |
| V1_72/V1_73, no defaults | `version`, `type` | `version`, `type` | – |
| unregistered `NOT NULL` column | + `brand_new` | `version`, `type` | `brand_new` (refused) |

Newly-gained nullable columns (`scope_extension_id`, `claims`) are correctly ignored, and an older target still behaves exactly as before. Also ran the simulated import — dump-era column list, then the registered backfill — and confirmed a `One time use publish token` row still lands as `OTT` while the rest default to `LLT` at `version = 0`, and applied `V1_74` itself against a post-V1_72 table.

## Stale entity mapping

V1_72 also widened `personal_access_token.value` to 128 characters — the digest of whichever algorithm `ovsx.access-token.token-hash-algorithm` names need not be SHA-256's 64 hex characters — while `PersonalAccessToken` kept declaring `@Column(length = 64)`. Nothing reads it under `ddl-auto: none`; it was just wrong about the schema it maps. Corrected, with a note on where the number comes from.

## Wiki

The *Deleting Extensions* page documents the required columns in detail and needs the matching edit; that's prepared separately and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
