### PR TITLE
feat: expose the extension package size in the API and web UI

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
+++ b/server/src/main/java/org/eclipse/openvsx/LocalRegistryService.java
@@ -1101,14 +1101,16 @@ public class LocalRegistryService implements IExtensionRegistry {
         }
 
         json.setAllVersions(allVersionsJson);
-        var fileUrls = storageUtil.getFileUrls(
-                List.of(extVersion),
-                serverUrl,
-                withFileTypes(DOWNLOAD, MANIFEST, ICON, README, LICENSE, CHANGELOG, VSIXMANIFEST));
-        json.setFiles(fileUrls.get(extVersion.getId()));
-        if (json.getFiles().containsKey(DOWNLOAD_SIG)) {
-            json.getFiles().put(PUBLIC_KEY, UrlUtil.getPublicKeyUrl(extVersion));
-        }
+        // getFiles rather than getFileUrls: the package size is read from the same rows as the URLs, so
+        // this path stays one query, and toFilesJson is the same mapping the two builders below already
+        // use - including the public key it adds alongside a signature.
+        var resources = storageUtil
+                .getFiles(
+                        List.of(extVersion),
+                        withFileTypes(DOWNLOAD, MANIFEST, ICON, README, LICENSE, CHANGELOG, VSIXMANIFEST))
+                .get(extVersion.getId());
+        json.setFiles(toFilesJson(extVersion, resources, UrlUtil.createApiFileBaseUrl(serverUrl, extVersion)));
+        json.setDownloadSize(downloadSize(resources));
         if (json.getDependencies() != null) {
             for (var ref : json.getDependencies()) {
                 ref.setUrl(createApiUrl(serverUrl, "api", ref.getNamespace(), ref.getExtension()));
@@ -1189,6 +1191,7 @@ public class LocalRegistryService implements IExtensionRegistry {
         }
 
         json.setFiles(files);
+        json.setDownloadSize(downloadSize(resources));
         if (json.getDependencies() != null) {
             for (var ref : json.getDependencies()) {
                 ref.setUrl(createApiUrl(serverUrl, "api", ref.getNamespace(), ref.getExtension()));
@@ -1238,6 +1241,7 @@ public class LocalRegistryService implements IExtensionRegistry {
                 json.getTargetPlatform(),
                 json.getVersion());
         json.setFiles(toFilesJson(extVersion, resources, fileBaseUrl));
+        json.setDownloadSize(downloadSize(resources));
         setExtensionReferenceUrls(json.getDependencies(), serverUrl);
         setExtensionReferenceUrls(json.getBundledExtensions(), serverUrl);
         return json;
@@ -1295,6 +1299,20 @@ public class LocalRegistryService implements IExtensionRegistry {
         }
 
         return allVersionsJson;
+    }
+
+    /**
+     * The size of the extension package itself, read from the {@code download} resource rather than summed
+     * over the version's files: readme, icon, changelog and license are stored as rows of their own but
+     * hold content that is already inside the package, so a sum would count it twice. Null where the
+     * package predates the size column and has not been backfilled yet.
+     */
+    private Long downloadSize(List<FileResource> resources) {
+        return resources.stream()
+                .filter(resource -> DOWNLOAD.equals(resource.getType()))
+                .findFirst()
+                .map(FileResource::getSize)
+                .orElse(null);
     }
 
     private Map<String, String> toFilesJson(

--- a/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/ExtensionJson.java
@@ -48,6 +48,15 @@ public class ExtensionJson extends ResultJson {
     )
     private Map<String, String> files;
 
+    @Schema(
+        description = "Size in bytes of the extension package - the file behind the 'download' entry of "
+                + "'files' - for this version and target platform. Null where the size is not known, which "
+                + "is the case for packages published before the registry started recording it and not yet "
+                + "backfilled. This is the download size; the installed extension is larger, by whatever "
+                + "the package's compression ratio happens to be."
+    )
+    private Long downloadSize;
+
     @Schema(description = "Name of the extension")
     @NotNull
     private String name;
@@ -257,6 +266,14 @@ public class ExtensionJson extends ResultJson {
 
     public void setFiles(Map<String, String> files) {
         this.files = files;
+    }
+
+    public Long getDownloadSize() {
+        return downloadSize;
+    }
+
+    public void setDownloadSize(Long downloadSize) {
+        this.downloadSize = downloadSize;
     }
 
     public String getName() {
@@ -647,6 +664,7 @@ public class ExtensionJson extends ResultJson {
         return Objects.equals(namespaceUrl, that.namespaceUrl)
                 && Objects.equals(reviewsUrl, that.reviewsUrl)
                 && Objects.equals(files, that.files)
+                && Objects.equals(downloadSize, that.downloadSize)
                 && Objects.equals(name, that.name)
                 && Objects.equals(namespace, that.namespace)
                 && Objects.equals(targetPlatform, that.targetPlatform)
@@ -698,6 +716,7 @@ public class ExtensionJson extends ResultJson {
                 namespaceUrl,
                 reviewsUrl,
                 files,
+                downloadSize,
                 name,
                 namespace,
                 targetPlatform,

--- a/server/src/main/java/org/eclipse/openvsx/repositories/FileResourceJooqRepository.java
+++ b/server/src/main/java/org/eclipse/openvsx/repositories/FileResourceJooqRepository.java
@@ -44,7 +44,13 @@ public class FileResourceJooqRepository {
         }
 
         var extVersionsById = extVersions.stream().collect(Collectors.toMap(ExtensionVersion::getId, ev -> ev));
-        return dsl.select(FILE_RESOURCE.ID, FILE_RESOURCE.EXTENSION_ID, FILE_RESOURCE.NAME, FILE_RESOURCE.TYPE)
+        return dsl
+                .select(
+                        FILE_RESOURCE.ID,
+                        FILE_RESOURCE.EXTENSION_ID,
+                        FILE_RESOURCE.NAME,
+                        FILE_RESOURCE.TYPE,
+                        FILE_RESOURCE.SIZE)
                 .from(FILE_RESOURCE)
                 .where(FILE_RESOURCE.EXTENSION_ID.in(extVersionsById.keySet())).and(FILE_RESOURCE.TYPE.in(types))
                 .fetch()
@@ -52,7 +58,13 @@ public class FileResourceJooqRepository {
     }
 
     public List<FileResource> findAll(Collection<Long> extensionIds, Collection<String> types) {
-        return dsl.select(FILE_RESOURCE.ID, FILE_RESOURCE.EXTENSION_ID, FILE_RESOURCE.NAME, FILE_RESOURCE.TYPE)
+        return dsl
+                .select(
+                        FILE_RESOURCE.ID,
+                        FILE_RESOURCE.EXTENSION_ID,
+                        FILE_RESOURCE.NAME,
+                        FILE_RESOURCE.TYPE,
+                        FILE_RESOURCE.SIZE)
                 .from(FILE_RESOURCE)
                 .where(FILE_RESOURCE.EXTENSION_ID.in(extensionIds).and(FILE_RESOURCE.TYPE.in(types)))
                 .fetch()
@@ -76,6 +88,9 @@ public class FileResourceJooqRepository {
         fileResource.setId(row.get(FILE_RESOURCE.ID));
         fileResource.setName(row.get(FILE_RESOURCE.NAME));
         fileResource.setType(row.get(FILE_RESOURCE.TYPE));
+        // Null for a resource stored before V1_73 added the column that FileResourceSizeJobRequestHandler
+        // has not backfilled yet, so every reader has to treat the size as unknown rather than as zero.
+        fileResource.setSize(row.get(FILE_RESOURCE.SIZE));
         fileResource.setExtension(extVersion);
 
         return fileResource;

--- a/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
+++ b/server/src/main/java/org/eclipse/openvsx/storage/StorageUtilService.java
@@ -298,6 +298,28 @@ public class StorageUtilService implements IStorageService {
     }
 
     /**
+     * The stored files of these versions, by version id, in one query.
+     * <p>
+     * {@link #getFileUrls} is the URL-only shorthand over this; a caller that needs more than the URL of a
+     * file - its size, say - takes the resources themselves rather than paying for a second query to read
+     * the other column.
+     */
+    public Map<Long, List<FileResource>> getFiles(Collection<ExtensionVersion> extVersions, String... types) {
+        var byVersion = extVersions.stream()
+                .map(ev -> Map.<Long, List<FileResource>>entry(ev.getId(), new ArrayList<>(types.length)))
+                .collect(
+                        Collectors.<Map.Entry<Long, List<FileResource>>, Long, List<FileResource>>toMap(
+                                Map.Entry::getKey,
+                                Map.Entry::getValue));
+
+        for (var resource : repositories.findFilesByType(extVersions, Arrays.asList(types))) {
+            byVersion.get(resource.getExtension().getId()).add(resource);
+        }
+
+        return byVersion;
+    }
+
+    /**
      * Returns URLs for the given file types as a map of ExtensionVersion.id by a map of type by file URL, to be used in JSON response data.
      */
     public Map<Long, Map<String, String>> getFileUrls(
@@ -305,19 +327,17 @@ public class StorageUtilService implements IStorageService {
             String serverUrl,
             String... types
     ) {
-        var type2Url = extVersions.stream()
-                .map(ev -> Map.<Long, Map<String, String>>entry(ev.getId(), new LinkedHashMap<>(types.length)))
-                .collect(
-                        Collectors.<Map.Entry<Long, Map<String, String>>, Long, Map<String, String>>toMap(
-                                Map.Entry::getKey,
-                                Map.Entry::getValue));
+        var type2Url = HashMap.<Long, Map<String, String>>newHashMap(extVersions.size());
+        getFiles(extVersions, types).forEach((extVersionId, resources) -> {
+            var urls = new LinkedHashMap<String, String>(types.length);
+            for (var resource : resources) {
+                urls.put(
+                        resource.getType(),
+                        createApiFileUrl(serverUrl, resource.getExtension(), resource.getName()));
+            }
 
-        var resources = repositories.findFilesByType(extVersions, Arrays.asList(types));
-        for (var resource : resources) {
-            var extVersion = resource.getExtension();
-            type2Url.get(extVersion.getId())
-                    .put(resource.getType(), createApiFileUrl(serverUrl, extVersion, resource.getName()));
-        }
+            type2Url.put(extVersionId, urls);
+        });
 
         return type2Url;
     }

--- a/server/src/test/java/org/eclipse/openvsx/LocalRegistryServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/LocalRegistryServiceTest.java
@@ -169,7 +169,7 @@ class LocalRegistryServiceTest {
         when(extensions.createExtensionFile(any())).thenReturn(tempFile);
         when(tokens.useAccessToken(eq("tok"), any())).thenReturn(tau);
         when(extensions.publishVersion(any(ExtensionProcessor.class), eq(tau))).thenReturn(extVersion);
-        when(storageUtilService.getFileUrls(any(), any(), any(String[].class))).thenReturn(Map.of(42L, Map.of()));
+        when(storageUtilService.getFiles(any(), any(String[].class))).thenReturn(Map.of(42L, List.of()));
 
         registryService.publish(new ByteArrayInputStream(new byte[0]), "tok");
 

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -140,6 +140,9 @@ class RegistryAPITest {
      */
     private static final Duration CHANGES_FEED_LAG = Duration.ofSeconds(30);
 
+    /** The size the mocked extension's .vsix reports, in bytes. */
+    private static final long DOWNLOAD_SIZE = 1_234_567L;
+
     @MockitoSpyBean
     UserService users;
 
@@ -218,6 +221,31 @@ class RegistryAPITest {
                     e.setTimestamp("2000-01-01T10:00Z");
                     e.setDisplayName("Foo Bar");
                 })));
+    }
+
+    // The size travels from file_resource.size to the JSON untouched, so that a client - the web UI's
+    // More Info box among them - can show how big the download is without fetching it.
+    @Test
+    void testExtensionDownloadSize() throws Exception {
+        var extVersion = mockExtension();
+        Mockito.when(repositories.findExtensionVersion("foo", "bar", null, VersionAlias.LATEST)).thenReturn(extVersion);
+
+        mockMvc.perform(get("/api/{namespace}/{extension}", "foo", "bar"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.downloadSize").value(DOWNLOAD_SIZE));
+    }
+
+    // Null for anything published before the column existed that the backfill has not reached yet.
+    // Omitted rather than sent as 0, which a client would have no way to tell from a genuinely empty file.
+    @Test
+    void testExtensionDownloadSizeUnknown() throws Exception {
+        var extVersion = mockExtension();
+        Mockito.when(repositories.findExtensionVersion("foo", "bar", null, VersionAlias.LATEST)).thenReturn(extVersion);
+        repositories.findFilesByType(List.of(extVersion), List.of(DOWNLOAD)).forEach(file -> file.setSize(null));
+
+        mockMvc.perform(get("/api/{namespace}/{extension}", "foo", "bar"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.downloadSize").doesNotExist());
     }
 
     @Test
@@ -3022,6 +3050,7 @@ class RegistryAPITest {
         download.setType(DOWNLOAD);
         download.setStorageType(STORAGE_LOCAL);
         download.setName("extension-1.0.0.vsix");
+        download.setSize(DOWNLOAD_SIZE);
         var signature = new FileResource();
         if (withSignature) {
             signature.setExtension(extVersion);

--- a/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/UserAPITest.java
@@ -416,12 +416,8 @@ class UserAPITest {
                                                         TargetPlatform.NAME_UNIVERSAL,
                                                         true,
                                                         false)))));
-        Mockito.when(
-                storageUtil.getFileUrls(
-                        Mockito.anyCollection(),
-                        Mockito.anyString(),
-                        Mockito.any(String[].class)))
-                .thenReturn(java.util.Map.of(42L, new java.util.HashMap<>()));
+        Mockito.when(storageUtil.getFiles(Mockito.anyCollection(), Mockito.any(String[].class)))
+                .thenReturn(java.util.Map.of(42L, java.util.List.of()));
         mockMvc.perform(
                 get("/user/extension/{namespace}/{extension}", "foobar", "baz")
                         .with(user("test_user")))
@@ -472,12 +468,8 @@ class UserAPITest {
                                                         TargetPlatform.NAME_UNIVERSAL,
                                                         true,
                                                         false)))));
-        Mockito.when(
-                storageUtil.getFileUrls(
-                        Mockito.anyCollection(),
-                        Mockito.anyString(),
-                        Mockito.any(String[].class)))
-                .thenReturn(java.util.Map.of(42L, new java.util.HashMap<>()));
+        Mockito.when(storageUtil.getFiles(Mockito.anyCollection(), Mockito.any(String[].class)))
+                .thenReturn(java.util.Map.of(42L, java.util.List.of()));
         mockMvc.perform(
                 get("/user/extension/{namespace}/{extension}", "foobar", "baz")
                         .with(user("test_user")))
@@ -500,12 +492,8 @@ class UserAPITest {
         Mockito.when(repositories.findLatestVersion(eq("foobar"), eq("baz"), any(), eq(false), eq(false)))
                 .thenReturn(latest);
         Mockito.when(repositories.findTargetPlatformsGroupedByVersion(extension)).thenReturn(List.of());
-        Mockito.when(
-                storageUtil.getFileUrls(
-                        Mockito.anyCollection(),
-                        Mockito.anyString(),
-                        Mockito.any(String[].class)))
-                .thenReturn(java.util.Map.of(42L, new java.util.HashMap<>()));
+        Mockito.when(storageUtil.getFiles(Mockito.anyCollection(), Mockito.any(String[].class)))
+                .thenReturn(java.util.Map.of(42L, java.util.List.of()));
 
         var scan = new ExtensionScan();
         scan.setStatus(ScanStatus.QUARANTINED);

--- a/webui/src/extension-registry-types.ts
+++ b/webui/src/extension-registry-types.ts
@@ -70,6 +70,12 @@ export interface Extension {
     reviewsUrl: UrlString;
     // key: file type, value: url
     files: { [id: string]: UrlString };
+    /**
+     * Size in bytes of the .vsix behind `files.download`. Absent where the registry does not know it yet,
+     * which is the case for extensions published before it started recording sizes. This is the download
+     * size, not the size the extension takes up once installed.
+     */
+    downloadSize?: number;
 
     name: string;
     namespace: string;

--- a/webui/src/pages/extension-detail/extension-detail-overview.tsx
+++ b/webui/src/pages/extension-detail/extension-detail-overview.tsx
@@ -16,7 +16,7 @@ import GitHubIcon from '@mui/icons-material/GitHub';
 import BugReportIcon from '@mui/icons-material/BugReport';
 import QuestionAnswerIcon from '@mui/icons-material/QuestionAnswer';
 import { MainContext } from '../../context';
-import { addQuery, createRoute, getTargetPlatformDisplayName, getEngineDisplayName } from '../../utils';
+import { addQuery, createRoute, formatFileSize, getTargetPlatformDisplayName, getEngineDisplayName } from '../../utils';
 import { DelayedLoadIndicator } from '../../components/delayed-load-indicator';
 import { SanitizedMarkdown } from '../../components/sanitized-markdown';
 import { Timestamp } from '../../components/timestamp';
@@ -159,6 +159,19 @@ export const ExtensionDetailOverview: FunctionComponent<ExtensionDetailOverviewP
                 <Typography variant='body2'>
                     <code>{`${extension.namespace}.${extension.name}`}</code>
                 </Typography>
+            </>
+        );
+    };
+
+    // The size of the .vsix, which is what the download costs - not what the extension takes up once
+    // installed, which is larger by however well the package happened to compress. Rendered only when the
+    // registry knows it: extensions published before it started recording sizes have none until the
+    // backfill reaches them, and a missing size is not a zero-byte one.
+    const renderSizeSection = (downloadSize: number): ReactNode => {
+        return (
+            <>
+                <Typography variant='h6'>Size</Typography>
+                <Typography variant='body2'>{formatFileSize(downloadSize)}</Typography>
             </>
         );
     };
@@ -361,6 +374,9 @@ export const ExtensionDetailOverview: FunctionComponent<ExtensionDetailOverviewP
 
                 <Box sx={resourcesGroup}>
                     <Box>{renderIdentifierSection()}</Box>
+                    {extension.downloadSize !== undefined ? (
+                        <Box mt={2}>{renderSizeSection(extension.downloadSize)}</Box>
+                    ) : null}
                 </Box>
 
                 <Box sx={resourcesGroup}>

--- a/webui/test/unit/pages/extension-detail/extension-detail-overview.spec.tsx
+++ b/webui/test/unit/pages/extension-detail/extension-detail-overview.spec.tsx
@@ -1,0 +1,60 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { ExtensionDetailOverview } from '../../../../src/pages/extension-detail/extension-detail-overview';
+import { Extension } from '../../../../src/extension-registry-types';
+import { renderWithProviders } from '../../support/test-providers';
+
+const extension = (overrides: Partial<Extension> = {}): Extension =>
+    ({
+        name: 'bar',
+        namespace: 'foo',
+        namespaceDisplayName: 'Foo',
+        version: '1.0.0',
+        displayName: 'Bar Tools',
+        // Empty, so the component takes its "no README available" path and needs no service.
+        files: {},
+        allVersions: { '1.0.0': 'https://example.com/api/foo/bar/1.0.0' },
+        versionAlias: [],
+        // The detail endpoint always sets this, and the "Works With" section reads it unguarded.
+        downloads: {},
+        downloadCount: 0,
+        reviewCount: 0,
+        deprecated: false,
+        verified: true,
+        publishedBy: { loginName: 'test_user', homepage: 'https://example.com/test_user' },
+        ...overrides
+    }) as unknown as Extension;
+
+const renderOverview = (overrides: Partial<Extension> = {}) =>
+    renderWithProviders(<ExtensionDetailOverview extension={extension(overrides)} selectVersion={() => {}} />);
+
+describe('ExtensionDetailOverview', () => {
+    it('shows the download size of the extension package', async () => {
+        renderOverview({ downloadSize: 5 * 1024 * 1024 });
+
+        expect(await screen.findByText('Size')).toBeInTheDocument();
+        expect(screen.getByText('5.00 MB')).toBeInTheDocument();
+    });
+
+    // An extension published before the registry recorded sizes has none until the backfill reaches it.
+    // The section is left out entirely rather than shown empty or as a misleading zero.
+    it('omits the size when the registry does not know it', async () => {
+        renderOverview();
+
+        expect(await screen.findByText('Unique Identifier')).toBeInTheDocument();
+        expect(screen.queryByText('Size')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Closes #367.

## Context

The issue asks for the extension size to be displayed, packagephobia-style. Half of what that needs already exists: `file_resource.size` has been recorded since `V1_73__File_Resource_Size.sql` (#2089, #2095), set on publish in `PublishExtensionVersionService` and `StorageUtilService`, and backfilled for older rows by `FileResourceSizeJobRequestHandler`. Nothing ever read it back out, though — it reached no API response and no page.

## Change

- **`ExtensionJson.downloadSize`** — size in bytes of the file behind `files.download`, for this version and target platform. Set by all three JSON builders, so `/api/{ns}/{ext}`, the query API and v2 all carry it.
- **Web UI** — a `Size` entry in the More Info box, next to the unique identifier, which is where the issue suggested it. Rendered with the existing `formatFileSize` helper.

Two decisions worth calling out:

**It reads the `download` resource, not a `SUM` over the version's files.** Readme, icon, changelog and license are stored as rows of their own but hold content that is already inside the `.vsix`, so summing counts it twice. (Web resources don't distort it either way — those are extracted to a cache on demand, not stored as rows.)

**Unknown is omitted, not zero.** A package published before the column existed that the backfill hasn't reached has `size = null`; `ExtensionJson` is `@JsonInclude(NON_NULL)`, so the field is simply absent, and the UI leaves the section out. A client has no way to tell a zero-byte file from an unknown one, so it gets neither.

## Download size, not install size

The issue asks about install size — the reporter's example is a ~110MB `.vsix` that's over 200MB on disk — and this is the download size. The two differ by the package's compression ratio, which is exactly the reporter's point about bundled `.map` files and stray `node_modules`.

Install size isn't stored and isn't cheaply derivable. It's computable at publish (the code already walks zip entries in `ArchiveUtil` and `SecretDetector`, and `ExtensionVersionIntegrityService` sums `entry.getSize()` into the signature manifest), but backfilling it means re-reading every existing `.vsix` out of storage — a much larger job than V1_73's was. That seems worth its own issue and its own decision, rather than holding up the number we already have.

## One query, not two

The detail path used `StorageUtilService.getFileUrls`, which discards everything but the URL. Rather than add a second query for the size, `getFiles` now returns the resources and `getFileUrls` is a shorthand over it, unchanged for its nine other callers. The detail builder then uses the `toFilesJson` mapping the other two builders already share, which also removes the duplicated public-key-alongside-signature handling it had grown.

## Testing

- `RegistryAPITest.testExtensionDownloadSize` / `testExtensionDownloadSizeUnknown` — the value reaches the JSON; a null size leaves the field out.
- `extension-detail-overview.spec.tsx` (new) — the Size section renders, and is absent when the registry doesn't know the size.
- Full server suite green (1165 tests), full webui suite green (278 tests, 55 files), `tsc --noEmit` and `yarn lint` clean.

Three existing tests stubbed `getFileUrls` for the detail path and now stub `getFiles`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)