### PR TITLE
feat(cli): forward vsce's --follow-symlinks, and document the pnpm story

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,7 @@ This change log covers only the command line interface (CLI) of Open VSX.
 
 #### Added
 
+- Add `--follow-symlinks` to `publish`, forwarding `vsce`'s option of the same name so that the file walk recurses into symlinked directories instead of packing each symlink as a file. Needed for a `node_modules` assembled out of symlinks, as pnpm's is ([#368](https://github.com/eclipse-openvsx/openvsx/issues/368))
 - Add `search` command to search the registry for extensions, mirroring the web UI's search: `--category`, `--target`, `--sort-by` and `--sort-order` narrow the query, `--size` and `--offset` page through the results, and `--json` prints the registry's raw response ([#2154](https://github.com/eclipse-openvsx/openvsx/pull/2154))
 - Add `list` command to print the extensions a namespace holds, sorted by name so the output stays stable across registries, with `--json` for the raw namespace metadata ([#2154](https://github.com/eclipse-openvsx/openvsx/pull/2154))
 - Add `show` command to print an extension's metadata, mirroring `vsce show`: identity, publisher, rating, notices and a version history listing each version's target platforms ([#2149](https://github.com/eclipse-openvsx/openvsx/issues/2149)). `namespace.extension@version` reports a single version, `--target` scopes the report to one target platform, `--all-versions` lists every published version instead of the most recent few, and `--json` prints the registry's raw metadata

--- a/cli/README.md
+++ b/cli/README.md
@@ -26,6 +26,15 @@ Variants:
 
 Before uploading, `ovsx` checks the packaged extension's size against the limit the registry reports on `/api/version`, so an oversized package is rejected locally instead of failing after the whole file has been uploaded.
 
+#### Package managers
+
+Packaging is done by `vsce`, which walks your production dependencies to decide what goes into the `.vsix`. It knows how to do that for two package managers only - npm, and yarn v1 via `--yarn` - and [will not be adding more](https://github.com/microsoft/vscode-vsce/issues/421#issuecomment-1853665094). For anything else, pnpm included, there are two options:
+
+ * `ovsx publish --no-dependencies`
+   skips the dependency walk altogether. This is the right answer for a bundled extension - one built with esbuild, webpack or similar, where the bundle already contains everything the extension needs at runtime - regardless of which package manager installed the sources.
+ * `ovsx publish --follow-symlinks`
+   recurses into symlinked directories instead of packing each symlink as a file. A `node_modules` assembled out of symlinks, as pnpm's is, needs this for the walk to reach the real dependency files.
+
 ### Trusted Publishing
 
 Instead of a long-lived personal access token, `ovsx` can publish from a CI workflow with a short-lived token that the registry issues in exchange for an OIDC ID token of the workflow. The registry only issues such a token if the workflow matches a trusted publisher that a namespace owner registered under [trusted publishers](https://open-vsx.org/user-settings/trusted-publishers). No access token needs to be stored as a secret.

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -56,6 +56,7 @@ module.exports = function (argv: string[]): void {
         .option('--baseContentUrl <url>', 'Prepend all relative links in README.md with this URL.')
         .option('--baseImagesUrl <url>', 'Prepend all relative image links in README.md with this URL.')
         .option('--yarn', 'Use yarn instead of npm while packing extension files.')
+        .option('--follow-symlinks', 'Recurse into symlinked directories instead of packing each symlink as a file.')
         .option('--pre-release', 'Mark this package as a pre-release')
         .option('--allow-missing-repository', 'Allow packaging an extension whose package.json has no repository field')
         .option('--no-dependencies', 'Disable dependency detection via npm or yarn')
@@ -64,7 +65,7 @@ module.exports = function (argv: string[]): void {
         .option('--trusted-publishing', 'Exchange an OIDC ID token for a short-lived publishing token. Enabled automatically when a CI system provides an ID token and no access token is given.')
         .option('--idToken <token>', 'The OIDC ID token to exchange. Only needed on CI systems that provide the token directly, e.g. GitLab CI.')
         .option('--oidcAudience <audience>', 'Audience to request for the OIDC ID token. Defaults to the registry URL.')
-        .action((extensionFile: string, { target, packagePath, baseContentUrl, baseImagesUrl, yarn, preRelease, allowMissingRepository, dependencies, skipDuplicate, packageVersion, trustedPublishing, idToken, oidcAudience }) => {
+        .action((extensionFile: string, { target, packagePath, baseContentUrl, baseImagesUrl, yarn, followSymlinks, preRelease, allowMissingRepository, dependencies, skipDuplicate, packageVersion, trustedPublishing, idToken, oidcAudience }) => {
             if (extensionFile !== undefined && packagePath !== undefined) {
                 console.error('\u274c  Please specify either a package file or a package path, but not both.\n');
                 publishCmd.help();
@@ -79,12 +80,14 @@ module.exports = function (argv: string[]): void {
                 console.warn("Ignoring option '--baseImagesUrl' for prepackaged extension.");
             if (extensionFile !== undefined && yarn !== undefined)
                 console.warn("Ignoring option '--yarn' for prepackaged extension.");
+            if (extensionFile !== undefined && followSymlinks !== undefined)
+                console.warn("Ignoring option '--follow-symlinks' for prepackaged extension.");
             if (extensionFile !== undefined && packageVersion !== undefined)
                 console.warn("Ignoring option '--packageVersion' for prepackaged extension.");
             if (extensionFile !== undefined && allowMissingRepository !== undefined)
                 console.warn("Ignoring option '--allow-missing-repository' for prepackaged extension.");
             const { registryUrl, pat } = program.opts();
-            publish({ extensionFile, registryUrl, pat, targets: typeof target === 'string' ? [target] : target, packagePath: typeof packagePath === 'string' ? [packagePath] : packagePath, baseContentUrl, baseImagesUrl, yarn, preRelease, allowMissingRepository, dependencies, skipDuplicate, packageVersion, trustedPublishing, idToken, oidcAudience })
+            publish({ extensionFile, registryUrl, pat, targets: typeof target === 'string' ? [target] : target, packagePath: typeof packagePath === 'string' ? [packagePath] : packagePath, baseContentUrl, baseImagesUrl, yarn, followSymlinks, preRelease, allowMissingRepository, dependencies, skipDuplicate, packageVersion, trustedPublishing, idToken, oidcAudience })
                 .then(results => {
                     const reasons = results.filter(result => result.status === 'rejected')
                         .map(rejectedResult => rejectedResult.reason);

--- a/cli/src/publish-options.ts
+++ b/cli/src/publish-options.ts
@@ -28,6 +28,12 @@ export interface PublishCommonOptions extends RegistryOptions, TrustedPublishing
      */
     yarn?: boolean;
     /**
+     * Recurse into symlinked directories when collecting the files to pack, instead of packing each
+     * symlink as a file. Needed for a `node_modules` built out of symlinks, as pnpm's is. Only valid
+     * with `packagePath`.
+     */
+    followSymlinks?: boolean;
+    /**
      * Mark this package as a pre-release. Only valid with `packagePath`.
      */
     preRelease?: boolean;

--- a/cli/src/publish.ts
+++ b/cli/src/publish.ts
@@ -177,6 +177,7 @@ async function packageExtension(options: InternalPublishOptions, registry: Regis
         baseContentUrl: options.baseContentUrl,
         baseImagesUrl: options.baseImagesUrl,
         useYarn: options.yarn,
+        followSymlinks: options.followSymlinks,
         dependencies: options.dependencies,
         preRelease: options.preRelease,
         allowMissingRepository: options.allowMissingRepository,

--- a/cli/test/unit/publish.spec.ts
+++ b/cli/test/unit/publish.spec.ts
@@ -17,8 +17,13 @@ import * as os from 'os';
 import * as path from 'path';
 import { AddressInfo } from 'net';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVSIX } from '@vscode/vsce';
 import { publish } from '../../src/publish';
 import { buildZip } from './support/zip';
+
+// Only the tests below that publish from a source directory reach this; every other one passes an
+// already-packaged file and never packages anything.
+vi.mock('@vscode/vsce', () => ({ createVSIX: vi.fn() }));
 
 interface RecordedRequest {
     pathname: string;
@@ -136,6 +141,36 @@ describe('publish', () => {
         tmpFiles.push(file);
         return file;
     }
+
+    // The packaging options ovsx hands to vsce are the whole of its packaging behaviour, so the ones a
+    // caller sets have to arrive there intact - `--follow-symlinks` above all, which is what makes the
+    // file walk work for a symlinked node_modules such as pnpm's.
+    it('forwards the packaging options to vsce', async () => {
+        const registry = await givenRegistry({ body: { version: '1.2.0' } });
+        vi.mocked(createVSIX).mockImplementation(async (options) => {
+            fs.writeFileSync(options!.packagePath!, await buildZip({
+                'extension/package.json': Buffer.from(JSON.stringify({ publisher: 'foo', name: 'bar', version: '1.0.0' }))
+            }));
+        });
+
+        const [result] = await publish({
+            packagePath: ['.'],
+            pat: 'the.pat',
+            registryUrl: registry.url,
+            yarn: true,
+            followSymlinks: true,
+            dependencies: false
+        });
+
+        expect(result.status).toBe('fulfilled');
+        expect(vi.mocked(createVSIX)).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(createVSIX).mock.calls[0][0]).toMatchObject({
+            cwd: '.',
+            useYarn: true,
+            followSymlinks: true,
+            dependencies: false
+        });
+    });
 
     it('publishes a package that is within the registry size limit', async () => {
         const registry = await givenRegistry({ body: { version: '1.2.0', maxExtensionSize: 1024 } });


### PR DESCRIPTION
Closes #368.

## Context

#368 (from 2021) asked how `ovsx publish` should handle pnpm. The answer it was waiting on has since arrived from upstream: microsoft/vscode-vsce#421 *"Support pnpm"* was closed as out of scope in December 2023 — *"we've decided to limit the amount of supported package managers to npm and yarn v1 only."* The condition set in the original discussion ("if `vsce` adds a dedicated flag for pnpm, we should adapt `ovsx` as well") therefore resolves in the negative, and `@vscode/vsce@3.7.1` — what we depend on today — contains no occurrence of `pnpm` anywhere in its compiled output.

That leaves two things worth doing on our side.

## `--follow-symlinks`

vsce collects the files to pack by walking production dependencies, and `collectFiles` treats a symlinked directory as a file unless `followSymlinks` says otherwise. A `node_modules` assembled out of symlinks — pnpm's — therefore packs the links rather than what they point at. vsce exposes `--follow-symlinks` on `ls`, `package` and `publish`; `ovsx` never passed it, so there was no way to ask for it from here.

Now forwarded, with the same "ignored for a prepackaged extension" warning `--yarn` already carries.

**Unset stays unset.** vsce's `collectFiles` defaults the parameter to `false`, and a JS default applies to an explicit `undefined`, so an invocation that doesn't pass the flag packs exactly what it packed before. This is strictly additive.

## Documentation

The substance of #368 was really *"what is a pnpm user supposed to do?"* — and the answer existed but was written down nowhere. The CLI README's 121 lines mentioned neither `--yarn`, `--no-dependencies` nor pnpm. It now has a short **Package managers** subsection saying:

- vsce supports npm and yarn v1 only, and won't be adding more (linked to the upstream decision);
- `--no-dependencies` skips the dependency walk entirely — the right answer for a bundled extension built with esbuild/webpack, which is most of them now, whatever installed the sources. It maps to vsce's `getDependenciesOption` → `'none'`, and is what upstream recommends;
- `--follow-symlinks` for the case where the walk really is wanted against a symlinked `node_modules`.

## Testing

`publish.spec.ts` gains a test that mocks `createVSIX` and asserts the packaging options arrive intact (`cwd`, `useYarn`, `followSymlinks`, `dependencies`). I checked it actually bites: reverting the one-line pass-through in `publish.ts` makes it fail.

Full CLI suite green (100 tests, 10 files), `tsc --noEmit` and `yarn lint` clean.

## Not done

The `--yarn` flag keeps its name. #368 floated renaming it to something generic, but it maps 1:1 onto vsce's `useYarn`, which selects `yarn list --json` over `npm list --production --parseable`; a generic name would describe less accurately what it does, not more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)