### PR TITLE
fix: record why an async publish failed, and restore the retry #1529 disabled

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/UserAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/UserAPI.java
@@ -331,6 +331,20 @@ public class UserAPI {
             return;
         }
 
+        // A version whose publish never finished is not waiting on anything, whatever the scan says, so
+        // this is reported ahead of every state below: the work that would have activated it stopped, and
+        // a scan that was never reached leaves the row looking exactly like one still queued. "Rejected"
+        // is the closest of the three statuses this vocabulary has - the version will not become live
+        // without someone intervening - where "under review" would promise attention nothing is giving it.
+        // The recorded reason itself stays out of the response: it names server internals, and there is
+        // nothing in it the publisher could act on.
+        if (extVersion.getPublishError() != null) {
+            json.setReviewStatus("rejected");
+            json.setReviewMessage(
+                    "Publishing this version did not complete. Please contact the registry operator.");
+            return;
+        }
+
         if (scanResult == null) {
             // No scan result found - show as under review
             json.setReviewStatus("under_review");

--- a/server/src/main/java/org/eclipse/openvsx/entities/ExtensionVersion.java
+++ b/server/src/main/java/org/eclipse/openvsx/entities/ExtensionVersion.java
@@ -119,6 +119,18 @@ public class ExtensionVersion implements Serializable {
 
     private boolean active;
 
+    /**
+     * Why the last publish attempt for this version did not finish, or {@code null} when none failed.
+     * <p>
+     * The work that follows a successful upload - storing the files, signing, checksumming - runs after
+     * the response has gone out, so a failure in it reaches nobody. This is where it is written down, so
+     * that a version sitting at {@code active == false} can be asked why rather than guessed at. Cleared
+     * on activation, so it describes the latest attempt and not the history of them.
+     */
+    @Column(name = "publish_error", columnDefinition = "text")
+    @Nullable
+    private String publishError;
+
     private boolean potentiallyMalicious;
 
     /**
@@ -406,6 +418,14 @@ public class ExtensionVersion implements Serializable {
         this.active = active;
     }
 
+    public @Nullable String getPublishError() {
+        return publishError;
+    }
+
+    public void setPublishError(@Nullable String publishError) {
+        this.publishError = publishError;
+    }
+
     public boolean isPotentiallyMalicious() {
         return potentiallyMalicious;
     }
@@ -624,6 +644,7 @@ public class ExtensionVersion implements Serializable {
                 && preview == that.preview
                 && active == that.active
                 && potentiallyMalicious == that.potentiallyMalicious
+                && Objects.equals(publishError, that.publishError)
                 && removed == that.removed
                 && Objects.equals(removedTimestamp, that.removedTimestamp)
                 && Objects.equals(getId(removedBy), getId(that.removedBy)) // use id to prevent infinite recursion
@@ -670,6 +691,7 @@ public class ExtensionVersion implements Serializable {
                 publishedWithTt,
                 active,
                 potentiallyMalicious,
+                publishError,
                 removed,
                 removedTimestamp,
                 getId(removedBy),

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -524,11 +524,26 @@ public class PublishExtensionVersionHandler {
                     .addArgument(() -> NamingUtil.toLogFormat(extensionFile.getResource().getExtension()))
                     .setCause(failure)
                     .log();
-            // Null-safe: markScanAsErrored returns immediately when there is no scan to mark, which is
-            // every instance that does not run scanning - the case with nowhere to record this today.
+            service.recordPublishError(extensionFile.getResource().getExtension(), describe(failure));
+            // Null-safe: markScanAsErrored returns immediately when there is no scan to mark. An instance
+            // that does not run scanning has only the column above.
             scanService.markScanAsErrored(scan, "Async processing failed: " + failure);
             throw failure;
         }
+    }
+
+    /**
+     * The recorded form of a failure: its type and message, and nothing deeper.
+     * <p>
+     * A cause chain would carry file system paths, host names and connection strings out of the server
+     * and into a column that admin tooling reads back, and none of it tells an operator more than the log
+     * already has - which is where the stack trace stays.
+     */
+    private static String describe(Throwable failure) {
+        var message = failure.getMessage();
+        return message == null || message.isBlank()
+                ? failure.getClass().getName()
+                : failure.getClass().getName() + ": " + message;
     }
 
     /**

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandler.java
@@ -485,26 +485,55 @@ public class PublishExtensionVersionHandler {
     }
 
     @Async
+    @Retryable(includes = Exception.class)
     public void publishAsync(TempFile extensionFile, ExtensionService extensionService) {
-        doPublish(extensionFile, extensionService, null);
+        publishReportingFailure(extensionFile, extensionService, null);
     }
 
     @Async
+    @Retryable(includes = Exception.class)
     public void publishAsync(TempFile extensionFile, ExtensionService extensionService, ExtensionScan scan) {
+        publishReportingFailure(extensionFile, extensionService, scan);
+    }
+
+    /**
+     * Runs the publish and makes sure a failure leaves something behind that names the version it was
+     * working on.
+     * <p>
+     * Everything below this point runs after the request that started it has already been answered, so a
+     * failure here is invisible to whoever published: the row keeps {@code active = false} and the client
+     * has been told the upload succeeded. What did get logged was Spring's
+     * {@code SimpleAsyncUncaughtExceptionHandler} line, which names this method and not the extension, so
+     * the version had to be matched up to the stack trace by hand - see #1450.
+     * <p>
+     * {@code Throwable} rather than {@code Exception}, because the failure that prompted this was an
+     * {@link OutOfMemoryError}: an {@code Error} walked straight past the previous {@code catch}, so even
+     * an instance with scanning enabled recorded nothing at all. Rethrown either way, so that the advice
+     * around this still sees it and Spring's own handler keeps its account.
+     */
+    private void publishReportingFailure(
+            TempFile extensionFile,
+            ExtensionService extensionService,
+            ExtensionScan scan
+    ) {
         try {
             doPublish(extensionFile, extensionService, scan);
-        } catch (Exception e) {
-            if (scan != null) {
-                scanService.markScanAsErrored(scan, "Async processing failed: " + e.getMessage());
-            }
-            throw e;
+        } catch (Throwable failure) {
+            logger.atError()
+                    .setMessage("Publishing {} failed, the version stays inactive")
+                    .addArgument(() -> NamingUtil.toLogFormat(extensionFile.getResource().getExtension()))
+                    .setCause(failure)
+                    .log();
+            // Null-safe: markScanAsErrored returns immediately when there is no scan to mark, which is
+            // every instance that does not run scanning - the case with nowhere to record this today.
+            scanService.markScanAsErrored(scan, "Async processing failed: " + failure);
+            throw failure;
         }
     }
 
     /**
      * Publish an extension - store files and optionally submit for scanning.
      */
-    @Retryable
     private void doPublish(TempFile extensionFile, ExtensionService extensionService, ExtensionScan scan) {
         var download = extensionFile.getResource();
         var extVersion = download.getExtension();

--- a/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionService.java
+++ b/server/src/main/java/org/eclipse/openvsx/publish/PublishExtensionVersionService.java
@@ -58,6 +58,27 @@ public class PublishExtensionVersionService {
         repositories.deleteFiles(extVersion);
     }
 
+    /**
+     * Writes down why the publish of a version did not finish, so that a row left at
+     * {@code active == false} can account for itself.
+     * <p>
+     * Its own transaction, and the only column it touches, because the transaction the failure happened
+     * in is on its way to being rolled back: recording the reason must not be rolled back with it.
+     * <p>
+     * find-then-set rather than merge, per the rule the rest of this class follows: the version handed in
+     * has been through a failed attempt and may carry a stale snapshot of every other column.
+     */
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    public void recordPublishError(ExtensionVersion extVersion, String reason) {
+        var current = entityManager.find(ExtensionVersion.class, extVersion.getId());
+        if (current == null) {
+            // Nothing left to annotate; the row was purged while the attempt was running.
+            return;
+        }
+
+        current.setPublishError(reason);
+    }
+
     @Retryable
     public void storeResource(TempFile tempFile) {
         storageUtil.uploadFile(tempFile);
@@ -126,6 +147,8 @@ public class PublishExtensionVersionService {
         // log is append-only: recording it again would report a second publication that never happened.
         var alreadyActive = current.isActive();
         current.setActive(true);
+        // Whatever a previous attempt failed on has been superseded by the one that got here.
+        current.setPublishError(null);
         if (!alreadyActive) {
             // The version becomes publicly visible here, which is what the changes feed reports as its
             // publication. It is reported at the current instant rather than at the timestamp the version

--- a/server/src/main/resources/db/migration/V1_75__ExtensionVersion_PublishError.sql
+++ b/server/src/main/resources/db/migration/V1_75__ExtensionVersion_PublishError.sql
@@ -1,0 +1,12 @@
+-- Why a version that never became active did not.
+--
+-- Storing files, signing and checksumming a published package happen after the upload request has been
+-- answered - deliberately, they are slow - so a failure there cannot be reported in the response. Until
+-- now it was not reported anywhere else either: the row simply kept active = false, and the only account
+-- of what went wrong was a stack trace in the server log naming the async method rather than the version
+-- it was working on. An operator finding an inactive version had nothing to read (see #1450).
+--
+-- Null means no failed attempt is on record, which is the state of every row that published normally and
+-- of every row that existed before this column. It is cleared when a version is activated, so it always
+-- describes the most recent attempt rather than accumulating history; the log keeps the full account.
+ALTER TABLE extension_version ADD COLUMN IF NOT EXISTS publish_error TEXT;

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerRetryTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerRetryTest.java
@@ -44,6 +44,7 @@ import org.eclipse.openvsx.util.TargetPlatform;
 import org.eclipse.openvsx.util.TempFile;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -140,6 +141,33 @@ class PublishExtensionVersionHandlerRetryTest {
         }
 
         verify(publishService, times(1)).storeResource(any());
+    }
+
+    // The point of #1450: an operator who finds a version stuck at active = false has, until this is
+    // recorded, no way to learn what stopped it short of correlating the row against a stack trace.
+    @Test
+    void recordsWhyThePublishDidNotFinish() throws IOException {
+        doThrow(new OutOfMemoryError("Java heap space")).when(publishService).storeResource(any());
+
+        try (var extensionFile = givenExtensionFile()) {
+            handler.publishAsync(extensionFile, extensionService);
+        }
+
+        verify(publishService)
+                .recordPublishError(any(), eq("java.lang.OutOfMemoryError: Java heap space"));
+    }
+
+    // The type alone when there is no message, rather than a bare "null" appended to it.
+    @Test
+    void recordsTheFailureTypeWhenItCarriesNoMessage() throws IOException {
+        doThrow(new IllegalStateException()).when(publishService).storeResource(any());
+
+        try (var extensionFile = givenExtensionFile()) {
+            handler.publishAsync(extensionFile, extensionService);
+        }
+
+        verify(publishService, times(ATTEMPTS))
+                .recordPublishError(any(), argThat("java.lang.IllegalStateException"::equals));
     }
 
     // The Error used to walk past a catch of Exception, so the scan of a version that died this way was

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerRetryTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionHandlerRetryTest.java
@@ -1,0 +1,201 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.publish;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+
+import jakarta.persistence.EntityManager;
+import org.jobrunr.scheduling.JobRequestScheduler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.resilience.annotation.EnableResilientMethods;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import org.eclipse.openvsx.ExtensionService;
+import org.eclipse.openvsx.ExtensionValidator;
+import org.eclipse.openvsx.UserService;
+import org.eclipse.openvsx.entities.Extension;
+import org.eclipse.openvsx.entities.ExtensionScan;
+import org.eclipse.openvsx.entities.ExtensionVersion;
+import org.eclipse.openvsx.entities.FileResource;
+import org.eclipse.openvsx.entities.Namespace;
+import org.eclipse.openvsx.extension_control.ExtensionControlService;
+import org.eclipse.openvsx.repositories.RepositoryService;
+import org.eclipse.openvsx.scanning.ExtensionScanService;
+import org.eclipse.openvsx.util.TargetPlatform;
+import org.eclipse.openvsx.util.TempFile;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * What {@code publishAsync} does when the work it runs after the request has been answered fails.
+ * <p>
+ * Built on a real proxy rather than a bare handler, because that is where the behaviour lives: both
+ * {@code @Async} and {@code @Retryable} are advice, and #1529 moved {@code @Retryable} onto a private
+ * method where no proxy could ever apply it, which turned the retry off without changing a line of the
+ * logic. Nothing failed as a result - it just quietly stopped happening. These tests are here so that it
+ * cannot happen again unnoticed.
+ * <p>
+ * The executor is synchronous so an {@code @Async} call runs on the calling thread and the assertions do
+ * not have to wait for anything.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = PublishExtensionVersionHandlerRetryTest.TestConfig.class)
+@MockitoBean(
+    types = {
+        PublishExtensionVersionService.class,
+        ExtensionVersionIntegrityService.class,
+        EntityManager.class,
+        RepositoryService.class,
+        JobRequestScheduler.class,
+        UserService.class,
+        ExtensionValidator.class,
+        ExtensionControlService.class,
+        ExtensionScanService.class,
+        ExtensionService.class
+    }
+)
+class PublishExtensionVersionHandlerRetryTest {
+
+    /** One attempt plus the three retries {@code @Retryable} allows by default. */
+    private static final int ATTEMPTS = 4;
+
+    @Autowired
+    PublishExtensionVersionHandler handler;
+
+    @Autowired
+    PublishExtensionVersionService publishService;
+
+    @Autowired
+    ExtensionScanService scanService;
+
+    @Autowired
+    ExtensionService extensionService;
+
+    private static TempFile givenExtensionFile() throws IOException {
+        var namespace = new Namespace();
+        namespace.setName("foo");
+
+        var extension = new Extension();
+        extension.setName("bar");
+        extension.setNamespace(namespace);
+
+        var extVersion = new ExtensionVersion();
+        extVersion.setVersion("1.0.0");
+        extVersion.setTargetPlatform(TargetPlatform.NAME_UNIVERSAL);
+        extVersion.setExtension(extension);
+
+        var download = new FileResource();
+        download.setExtension(extVersion);
+
+        var extensionFile = new TempFile("test", ".vsix");
+        extensionFile.setResource(download);
+        return extensionFile;
+    }
+
+    // A storage hiccup is the case the retry was put there for, and the reason doPublish clears the
+    // version's file resources before it starts: an attempt has to be able to follow a half-done one.
+    @Test
+    void retriesAFailedPublish() throws IOException {
+        doThrow(new RuntimeException("storage is having a moment")).when(publishService).storeResource(any());
+
+        try (var extensionFile = givenExtensionFile()) {
+            handler.publishAsync(extensionFile, extensionService);
+        }
+
+        verify(publishService, times(ATTEMPTS)).storeResource(any());
+    }
+
+    // An OutOfMemoryError is what #1450 hit, and retrying it means allocating the same package three more
+    // times on a JVM that has just said it has no room. Errors are left to fail on the first attempt.
+    @Test
+    void doesNotRetryAnError() throws IOException {
+        doThrow(new OutOfMemoryError("Java heap space")).when(publishService).storeResource(any());
+
+        try (var extensionFile = givenExtensionFile()) {
+            handler.publishAsync(extensionFile, extensionService);
+        }
+
+        verify(publishService, times(1)).storeResource(any());
+    }
+
+    // The Error used to walk past a catch of Exception, so the scan of a version that died this way was
+    // left sitting in its pre-publish state with nothing saying why.
+    @Test
+    void recordsAnErrorAgainstTheScan() throws IOException {
+        var scan = new ExtensionScan();
+        doThrow(new OutOfMemoryError("Java heap space")).when(publishService).storeResource(any());
+
+        try (var extensionFile = givenExtensionFile()) {
+            handler.publishAsync(extensionFile, extensionService, scan);
+        }
+
+        verify(scanService).markScanAsErrored(eq(scan), contains("OutOfMemoryError"));
+    }
+
+    @Configuration
+    @EnableAsync
+    @EnableResilientMethods
+    static class TestConfig {
+
+        /** Runs an {@code @Async} method on the calling thread, so the tests need no waiting. */
+        @Bean
+        Executor taskExecutor() {
+            return new SyncTaskExecutor();
+        }
+
+        @Bean
+        PublishingConfig publishingConfig() {
+            return new PublishingConfig();
+        }
+
+        @Bean
+        PublishExtensionVersionHandler publishExtensionVersionHandler(
+                PublishingConfig publishingConfig,
+                PublishExtensionVersionService publishService,
+                ExtensionVersionIntegrityService integrityService,
+                EntityManager entityManager,
+                RepositoryService repositories,
+                JobRequestScheduler scheduler,
+                UserService users,
+                ExtensionValidator validator,
+                ExtensionControlService extensionControl,
+                ExtensionScanService scanService
+        ) {
+            return new PublishExtensionVersionHandler(
+                    publishingConfig,
+                    publishService,
+                    integrityService,
+                    entityManager,
+                    repositories,
+                    scheduler,
+                    users,
+                    validator,
+                    extensionControl,
+                    scanService);
+        }
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/publish/PublishExtensionVersionServiceTest.java
@@ -37,6 +37,7 @@ import org.eclipse.openvsx.util.TempFile;
 import org.eclipse.openvsx.util.TimeUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -82,6 +83,39 @@ class PublishExtensionVersionServiceTest {
 
         assertThat(extVersion.isActive()).isTrue();
         verify(extensions).updateExtension(extVersion.getExtension());
+    }
+
+    // The column answers "why is this version not active", so it has no business outliving the version
+    // being active: an attempt that got there supersedes whatever an earlier one failed on.
+    @Test
+    void activateExtension_clearsAnEarlierPublishFailure() {
+        var extVersion = version(1L, false);
+        extVersion.setPublishError("java.lang.OutOfMemoryError: Java heap space");
+        when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
+
+        svc.activateExtension(extVersion, extensions);
+
+        assertThat(extVersion.getPublishError()).isNull();
+    }
+
+    @Test
+    void recordPublishError_writesTheReasonOntoTheVersion() {
+        var extVersion = version(1L, false);
+        when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(extVersion);
+
+        svc.recordPublishError(extVersion, "java.lang.OutOfMemoryError: Java heap space");
+
+        assertThat(extVersion.getPublishError()).isEqualTo("java.lang.OutOfMemoryError: Java heap space");
+    }
+
+    // The row can be purged while the attempt that failed is still unwinding; there is then nothing left
+    // to annotate, and trying to would turn a failed publish into a second, unrelated failure.
+    @Test
+    void recordPublishError_ignoresAVersionThatIsGone() {
+        var extVersion = version(1L, false);
+        when(entityManager.find(ExtensionVersion.class, 1L)).thenReturn(null);
+
+        assertThatCode(() -> svc.recordPublishError(extVersion, "boom")).doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #2170, covering the second half of #1450: a version whose publish fails just stays inactive.

Async publishing is a deliberate design decision — storing, signing and checksumming a package are slow and have no business holding the upload request open. The gap is that **when that work fails, nothing writes down why**.

## Nothing recorded the reason

A failed attempt left the row at `active = false` and that was the whole of it. The only account was Spring's `SimpleAsyncUncaughtExceptionHandler` line, which names `PublishExtensionVersionHandler.publishAsync` and not the extension it was working on — so an operator finding an inactive version had to correlate it against a stack trace by hand, which is exactly what the reporter did.

`V1_75` adds `extension_version.publish_error`, set when an attempt fails and cleared when a version is activated, so it always describes the latest attempt rather than accumulating history.

Two deliberate choices in it:

- **Type and message only, no cause chain.** A chain carries file system paths, host names and connection strings out of the server and into a column that admin tooling reads back, and none of it tells an operator more than the log already has — which is where the stack trace stays.
- **Its own transaction** (`REQUIRES_NEW`), because the transaction the failure happened in is on its way to being rolled back and would take the record with it.

## The user-facing side of the same gap

`UserAPI.enrichWithReviewStatus` is driven entirely by scan records. On an instance that does not run scanning — the reporter's setup — `scanResult` is null, so an inactive version reported *"Your extension is being reviewed"* indefinitely, for a version nothing was reviewing or ever would.

A recorded failure now outranks every scan state there. `rejected` is the closest of the three statuses that vocabulary has (the version will not become live without someone intervening) where `under_review` promises attention nothing is giving it. The recorded reason itself stays out of that response — it names server internals and there is nothing in it a publisher could act on — so they are pointed at the operator, who has the column.

## The Error walked past the catch

`publishAsync` caught `Exception` in order to call `markScanAsErrored`. `OutOfMemoryError` is an `Error`, so the very failure that prompted #1450 slipped past it — even on an instance running scanning, nothing was recorded. Now it catches `Throwable`, records the reason, names the version in the log, and marks the scan where there is one.

## The retry has not run since #1529

`doPublish` carries `@Retryable`, and the comment above its file-resource cleanup — *"Delete file resources in case publishAsync is retried"* — exists to make an attempt repeatable. Neither has done anything for a while.

Before #1529 the method was:

```java
@Async
@Retryable
public void publishAsync(TempFile extensionFile, ExtensionService extensionService) {
```

Public, called from `ExtensionService` through the proxy, so both annotations applied. #1529 extracted the body into a private `doPublish` and moved `@Retryable` onto it — a method reached only by self-invocation, where no proxy can ever apply it. Nothing failed; the retry just quietly stopped happening. (`@EnableResilientMethods` is on `RegistryApplication`, and the `@Retryable` on the public `createExtensionVersion` does still work, which is what makes this easy to miss.)

Moved back onto the public methods, with one deliberate change: `includes = Exception.class`, so an `Error` fails on the first attempt instead of being retried three more times into a JVM that has just said it has no room — the exact scenario in #1450. That also matches what was retried before the move: spring-retry's `SimpleRetryPolicy` defaults to `Exception`, not `Throwable`.

## Tests

`PublishExtensionVersionHandlerRetryTest` builds the handler behind real async and retry advice, rather than constructing it directly the way the existing handler test does — the behaviour under test *is* the advice, so a bare object cannot show it. A synchronous executor makes `@Async` run inline so nothing has to wait.

- `recordsWhyThePublishDidNotFinish` — the reason reaches the version.
- `recordsTheFailureTypeWhenItCarriesNoMessage` — the type alone, not a bare `null` appended to it.
- `retriesAFailedPublish` — a storage failure is attempted four times (one plus three retries).
- `doesNotRetryAnError` — an `OutOfMemoryError` is attempted once.
- `recordsAnErrorAgainstTheScan` — the scan is marked errored with the `OutOfMemoryError` named.

Plus, on the service: the reason is written onto the managed row, a purged row is ignored rather than turning a failed publish into a second failure, and activation clears an earlier failure.

I checked the retry test actually bites rather than trusting a green run: with `@Retryable` back on the private `doPublish`, it fails with one attempt instead of four. The migration was applied against a real Postgres 16 to confirm the column lands nullable with no default — which also means `import-db-dump.sh` correctly treats it as needing no backfill.

Full server suite green (1175 tests), formatter clean.

## Not in here

Surfacing the recorded reason through the admin API, so an operator can read it without reaching for `psql`. The column is the prerequisite; where it gets displayed is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)