### PR TITLE
fix: serve the public API's CORS headers whatever ovsx.webui.url says

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
@@ -10,9 +10,11 @@
 package org.eclipse.openvsx.web;
 
 import java.net.URI;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.server.servlet.CookieSameSiteSupplier;
 import org.springframework.context.annotation.Bean;
@@ -50,10 +52,11 @@ public class WebConfig implements WebMvcConfigurer {
      */
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        if (!StringUtils.isEmpty(webuiUrl) && URI.create(webuiUrl).isAbsolute()) {
-            // The Web UI is given with an absolute URL, so we need to enable CORS with credentials. Where
-            // it is served from the same origin as the API these are unnecessary: a same-origin request
-            // does not use CORS at all.
+        var webuiOrigin = webuiOrigin();
+        if (webuiOrigin != null) {
+            // The Web UI is on an origin of its own, so we need to enable CORS with credentials. Where it
+            // is served from the same origin as the API these are unnecessary: a same-origin request does
+            // not use CORS at all.
             var authorizedEndpoints = new String[] {
                 "/user/**",
                 "/logout",
@@ -65,12 +68,12 @@ public class WebConfig implements WebMvcConfigurer {
             };
             for (var endpoint : authorizedEndpoints) {
                 registry.addMapping(endpoint)
-                        .allowedOrigins(webuiUrl)
+                        .allowedOrigins(webuiOrigin)
                         .allowedMethods("GET", "HEAD", "POST", "DELETE", "PUT")
                         .allowCredentials(true);
             }
             registry.addMapping("/login-providers")
-                    .allowedOrigins(webuiUrl);
+                    .allowedOrigins(webuiOrigin);
         }
 
         // The public, unauthenticated surface: the registry API, the VS Code gallery adapter and the
@@ -92,6 +95,45 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins("*");
         registry.addMapping("/documents/**")
                 .allowedOrigins("*");
+    }
+
+    /**
+     * The origin the Web UI is served from, or {@code null} when it does not have one of its own.
+     * <p>
+     * Derived rather than used as configured, because the two are not the same thing.
+     * {@code allowedOrigins} is matched against the browser's {@code Origin} header, which is a
+     * serialized origin - a scheme, a host and a non-default port, and never a path.
+     * {@code ovsx.webui.url} is a URL and may carry one, for a registry served at
+     * {@code https://example.com/openvsx} say; {@code CorsConfiguration.checkOrigin} trims one trailing
+     * slash and then compares what is left exactly, so a configured path meant the credentialed mappings
+     * matched nothing and CORS quietly did not apply to them at all.
+     * <p>
+     * A default port is dropped for the same reason: a browser leaves it out of the header it sends.
+     */
+    private @Nullable String webuiOrigin() {
+        if (StringUtils.isEmpty(webuiUrl)) {
+            return null;
+        }
+
+        var uri = URI.create(webuiUrl);
+        // Relative, or absolute but with no authority to take a host from - neither names an origin, so
+        // there is no separate Web UI to allow.
+        if (!uri.isAbsolute() || uri.getHost() == null) {
+            return null;
+        }
+
+        var scheme = uri.getScheme();
+        var origin = new StringBuilder(scheme).append("://").append(uri.getHost());
+        var defaultPort = switch (scheme.toLowerCase(Locale.ROOT)) {
+            case "https" -> 443;
+            case "http" -> 80;
+            default -> -1;
+        };
+        if (uri.getPort() != -1 && uri.getPort() != defaultPort) {
+            origin.append(':').append(uri.getPort());
+        }
+
+        return origin.toString();
     }
 
     /**

--- a/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.server.servlet.CookieSameSiteSupplier;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -39,10 +41,19 @@ public class WebConfig implements WebMvcConfigurer {
         mirrorExtensionHandlerInterceptor.ifPresent(service -> this.mirrorInterceptor = service);
     }
 
+    /**
+     * Registration order is load-bearing. {@code UrlBasedCorsConfigurationSource} walks its mappings in the
+     * order they were added and returns the configuration of the <em>first</em> pattern that matches - it
+     * neither combines them nor prefers the more specific one. Every credentialed mapping below is also
+     * matched by the {@code /api/**} catch-all, so the credentialed ones have to be registered first or
+     * they would silently lose their configuration to it.
+     */
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         if (!StringUtils.isEmpty(webuiUrl) && URI.create(webuiUrl).isAbsolute()) {
-            // The Web UI is given with an absolute URL, so we need to enable CORS with credentials.
+            // The Web UI is given with an absolute URL, so we need to enable CORS with credentials. Where
+            // it is served from the same origin as the API these are unnecessary: a same-origin request
+            // does not use CORS at all.
             var authorizedEndpoints = new String[] {
                 "/user/**",
                 "/logout",
@@ -60,13 +71,48 @@ public class WebConfig implements WebMvcConfigurer {
             }
             registry.addMapping("/login-providers")
                     .allowedOrigins(webuiUrl);
-            registry.addMapping("/documents/**")
-                    .allowedOrigins("*");
-            registry.addMapping("/api/**")
-                    .allowedOrigins("*");
-            registry.addMapping("/vscode/**")
-                    .allowedOrigins("*");
         }
+
+        // The public, unauthenticated surface: the registry API, the VS Code gallery adapter and the
+        // static documents, readable from any origin and never with credentials.
+        //
+        // Registered whatever ovsx.webui.url says, because it has nothing to do with them. These used to
+        // sit inside the branch above, so a deployment serving the Web UI from the same origin as the API
+        // - where that property is empty or relative - emitted no CORS headers at all, and the browser
+        // clients that need them (vscode.dev, Gitpod, Theia and anything else querying the gallery from
+        // page script) could only be served by putting the headers back on at the CDN. Which is a poor
+        // place for them: the edge cannot tell the public surface from the credentialed one, and a rule
+        // permissive enough to cover the first is a rule that hands the second to any origin that asks.
+        //
+        // Clients that are not browsers - VS Code desktop fetches the gallery from its node extension
+        // host - never consult these headers at all, and are unaffected either way.
+        registry.addMapping("/api/**")
+                .allowedOrigins("*");
+        registry.addMapping("/vscode/**")
+                .allowedOrigins("*");
+        registry.addMapping("/documents/**")
+                .allowedOrigins("*");
+    }
+
+    /**
+     * Marks every cookie this application sets {@code SameSite=Lax}.
+     *
+     * <p>Without the attribute the decision falls to the browser, and browsers do not agree: Chromium
+     * treats an unmarked cookie as Lax, others have not always. That left the session cookie's behaviour
+     * on a cross-site {@code fetch} - whether it rides along and makes the request an authenticated one -
+     * a property of the visitor's browser rather than of this server. It is the last thing standing
+     * between a misconfigured CORS layer and a credentialed cross-origin read of {@code /user/**}, which
+     * is not a job to leave to a default.
+     *
+     * <p>Lax and not Strict deliberately. Strict withholds the cookie from cross-site top-level
+     * navigations too, which is exactly what the return leg of an OAuth2 login is: the provider redirects
+     * the browser back here, and Spring Security needs the session to find the authorization request it
+     * saved. Lax sends the cookie on that navigation and withholds it from the subresource requests -
+     * {@code fetch}, {@code XMLHttpRequest}, images, frames - that an attacking page would have to use.
+     */
+    @Bean
+    CookieSameSiteSupplier laxCookieSameSiteSupplier() {
+        return CookieSameSiteSupplier.ofLax();
     }
 
     @Override

--- a/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/WebConfig.java
@@ -10,6 +10,7 @@
 package org.eclipse.openvsx.web;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -38,6 +39,32 @@ public class WebConfig implements WebMvcConfigurer {
         "${ovsx.webui.frontendRoutes:/extension/**,/namespace/**,/search,/user-settings/**,/publish,/admin-dashboard/**}"
     )
     String[] frontendRoutes;
+
+    /**
+     * The origins allowed to read the public, unauthenticated surface - the registry API, the VS Code
+     * gallery adapter and the static documents - from a browser. Comma separated; {@code *} for any.
+     * <p>
+     * Any by default, because that surface exists to be consumed: a public registry is read by clients
+     * that are not its own Web UI, and the ones running in a browser (VS Code for the Web, Gitpod, Theia,
+     * anything querying the gallery from page script) get nothing back without these headers. Clients
+     * that are not browsers - VS Code desktop fetches the gallery from its node extension host - never
+     * consult them and are unaffected by whatever this says.
+     * <p>
+     * Worth narrowing, or emptying, on a registry that is not meant to be read from the open web. The
+     * endpoints are unauthenticated, so this is not what keeps their contents private - anything that can
+     * reach them can read them - but on an instance reachable only from an internal network it does stop
+     * a page in an employee's browser being used to reach it from outside. Set to an empty value to
+     * register no public CORS mappings at all.
+     * <p>
+     * Deliberately not derived from {@code ovsx.webui.url}: where the Web UI is served from has nothing
+     * to do with which third parties may read the API, and tying the two together left a registry serving
+     * its UI from the same origin as its API emitting no CORS headers for the public surface at all.
+     * <p>
+     * Property: {@code ovsx.cors.public-origins}
+     * Default: {@code *}
+     */
+    @Value("${ovsx.cors.public-origins:*}")
+    String[] publicCorsOrigins;
 
     public WebConfig(Optional<MirrorExtensionHandlerInterceptor> mirrorExtensionHandlerInterceptor) {
         mirrorExtensionHandlerInterceptor.ifPresent(service -> this.mirrorInterceptor = service);
@@ -76,25 +103,34 @@ public class WebConfig implements WebMvcConfigurer {
                     .allowedOrigins(webuiOrigin);
         }
 
-        // The public, unauthenticated surface: the registry API, the VS Code gallery adapter and the
-        // static documents, readable from any origin and never with credentials.
-        //
-        // Registered whatever ovsx.webui.url says, because it has nothing to do with them. These used to
-        // sit inside the branch above, so a deployment serving the Web UI from the same origin as the API
-        // - where that property is empty or relative - emitted no CORS headers at all, and the browser
-        // clients that need them (vscode.dev, Gitpod, Theia and anything else querying the gallery from
-        // page script) could only be served by putting the headers back on at the CDN. Which is a poor
-        // place for them: the edge cannot tell the public surface from the credentialed one, and a rule
-        // permissive enough to cover the first is a rule that hands the second to any origin that asks.
-        //
-        // Clients that are not browsers - VS Code desktop fetches the gallery from its node extension
-        // host - never consult these headers at all, and are unaffected either way.
-        registry.addMapping("/api/**")
-                .allowedOrigins("*");
-        registry.addMapping("/vscode/**")
-                .allowedOrigins("*");
-        registry.addMapping("/documents/**")
-                .allowedOrigins("*");
+        // The public, unauthenticated surface, on its own setting rather than on wherever the Web UI
+        // happens to live - see publicCorsOrigins above for why the two were never related. Never with
+        // credentials, whatever it names: it is the pairing of a permissive origin with credentials that
+        // turns any origin into an authenticated reader, and nothing here needs a session.
+        var publicOrigins = publicCorsOrigins();
+        if (publicOrigins.length > 0) {
+            registry.addMapping("/api/**")
+                    .allowedOrigins(publicOrigins);
+            registry.addMapping("/vscode/**")
+                    .allowedOrigins(publicOrigins);
+            registry.addMapping("/documents/**")
+                    .allowedOrigins(publicOrigins);
+        }
+    }
+
+    /**
+     * The configured public origins, without the blanks.
+     * <p>
+     * A trailing or doubled comma leaves an empty element behind, and Spring trims each one, so an
+     * all-whitespace entry arrives blank too. Registering a mapping for a blank origin would match no
+     * request and only obscure what the setting actually allows.
+     */
+    private String[] publicCorsOrigins() {
+        if (publicCorsOrigins == null) {
+            return new String[0];
+        }
+
+        return Arrays.stream(publicCorsOrigins).filter(StringUtils::isNotBlank).toArray(String[]::new);
     }
 
     /**

--- a/server/src/test/java/org/eclipse/openvsx/web/WebConfigTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/WebConfigTest.java
@@ -84,6 +84,36 @@ class WebConfigTest {
         assertThat(userMapping.getAllowCredentials()).isTrue();
     }
 
+    /**
+     * {@code ovsx.webui.url} is a URL; {@code allowedOrigins} is matched against the browser's
+     * {@code Origin} header, which never carries a path. A registry whose UI is served under one - at
+     * {@code https://example.com/openvsx} - configured a value that could match no browser's header, and
+     * the credentialed mappings silently applied to nothing.
+     */
+    @Test
+    void derivesAnOriginFromAWebUiUrlThatCarriesAPath() {
+        var mappings = mappingsFor("https://ui.example.com/openvsx");
+
+        var userMapping = mappings.get("/user/**");
+        assertThat(userMapping.getAllowedOrigins()).containsExactly(UI_ORIGIN);
+        assertThat(userMapping.checkOrigin(UI_ORIGIN)).isEqualTo(UI_ORIGIN);
+    }
+
+    // A browser leaves a default port out of the Origin it sends, so a configured one has to come out
+    // here too or it would be compared against a header that never has it.
+    @Test
+    void dropsADefaultPortFromTheDerivedOrigin() {
+        assertThat(mappingsFor("https://ui.example.com:443/").get("/user/**").checkOrigin(UI_ORIGIN))
+                .isEqualTo(UI_ORIGIN);
+    }
+
+    // And keeps one that is not the default - which is the development setup, where the UI runs on 3000.
+    @Test
+    void keepsANonDefaultPortInTheDerivedOrigin() {
+        assertThat(mappingsFor("http://localhost:3000").get("/user/**").getAllowedOrigins())
+                .containsExactly("http://localhost:3000");
+    }
+
     @Test
     void neverAllowsCredentialsFromAnOriginItWasNotGiven() {
         var mappings = mappingsFor(UI_ORIGIN);

--- a/server/src/test/java/org/eclipse/openvsx/web/WebConfigTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/WebConfigTest.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.boot.web.server.Cookie;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -42,12 +44,65 @@ class WebConfigTest {
         }
     }
 
+    /** With the public origins left at what the property defaults to; see {@link #defaultsToAnyOrigin()}. */
     private static Map<String, CorsConfiguration> mappingsFor(String webuiUrl) {
+        return mappingsFor(webuiUrl, "*");
+    }
+
+    private static Map<String, CorsConfiguration> mappingsFor(String webuiUrl, String... publicOrigins) {
         var config = new WebConfig(Optional.empty());
         config.webuiUrl = webuiUrl;
+        config.publicCorsOrigins = publicOrigins;
         var registry = new ReadableCorsRegistry();
         config.addCorsMappings(registry);
         return registry.configurations();
+    }
+
+    /**
+     * The property default, asserted through a context because the tests above construct {@link WebConfig}
+     * directly and never see it. Any origin, because the public surface exists to be consumed and a
+     * registry that wants it closed can say so; see the field's own documentation.
+     */
+    @Test
+    void defaultsToAnyOrigin() {
+        new ApplicationContextRunner()
+                .withInitializer(
+                        context -> context.getBeanFactory()
+                                .setConversionService(ApplicationConversionService.getSharedInstance()))
+                .withUserConfiguration(WebConfig.class)
+                .run(
+                        context -> assertThat(context.getBean(WebConfig.class).publicCorsOrigins)
+                                .containsExactly("*"));
+    }
+
+    // An operator who wants the public surface closed to the open web empties the setting, and then there
+    // is nothing to register rather than a mapping that allows nothing.
+    @Test
+    void registersNoPublicMappingsWhenTheSettingIsEmpty() {
+        var noOrigins = new String[0];
+
+        assertThat(mappingsFor("", noOrigins)).isEmpty();
+        assertThat(mappingsFor(UI_ORIGIN, noOrigins))
+                .doesNotContainKeys("/api/**", "/vscode/**", "/documents/**")
+                .containsKey("/user/**");
+    }
+
+    @Test
+    void allowsOnlyTheOriginsTheSettingNames() {
+        var mappings = mappingsFor("", "https://vscode.dev", "https://gitpod.io");
+
+        assertThat(mappings.get("/api/**").getAllowedOrigins())
+                .containsExactly("https://vscode.dev", "https://gitpod.io");
+        assertThat(mappings.get("/api/**").checkOrigin("https://elsewhere.example")).isNull();
+        assertThat(mappings.get("/api/**").getAllowCredentials()).isNull();
+    }
+
+    // Same reasoning as the pepper keyring: a trailing or doubled comma leaves a blank element behind,
+    // and a mapping for a blank origin would match nothing while obscuring what is actually allowed.
+    @Test
+    void ignoresBlankEntriesInTheSetting() {
+        assertThat(mappingsFor("", "https://vscode.dev", "", " ").get("/api/**").getAllowedOrigins())
+                .containsExactly("https://vscode.dev");
     }
 
     // The registry API, the VS Code gallery adapter and the static documents are public, and the browser

--- a/server/src/test/java/org/eclipse/openvsx/web/WebConfigTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/WebConfigTest.java
@@ -1,0 +1,130 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.web;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The CORS mappings this application registers, and which of them depend on where the Web UI lives.
+ * <p>
+ * Asserted against the registry rather than over HTTP because registration <em>order</em> is part of the
+ * behaviour: {@code UrlBasedCorsConfigurationSource} returns the configuration of the first pattern that
+ * matches a request and stops looking, so what the map holds and the order it holds it in are together
+ * the whole of the policy.
+ */
+class WebConfigTest {
+
+    private static final String UI_ORIGIN = "https://ui.example.com";
+
+    /** {@link CorsRegistry#getCorsConfigurations()} is protected, and this test is what wants to read it. */
+    private static class ReadableCorsRegistry extends CorsRegistry {
+        Map<String, CorsConfiguration> configurations() {
+            return getCorsConfigurations();
+        }
+    }
+
+    private static Map<String, CorsConfiguration> mappingsFor(String webuiUrl) {
+        var config = new WebConfig(Optional.empty());
+        config.webuiUrl = webuiUrl;
+        var registry = new ReadableCorsRegistry();
+        config.addCorsMappings(registry);
+        return registry.configurations();
+    }
+
+    // The registry API, the VS Code gallery adapter and the static documents are public, and the browser
+    // clients that read them - vscode.dev, Gitpod, anything querying the gallery from page script - need
+    // these headers whether or not the Web UI happens to sit on its own origin. Gating them on that left
+    // a same-origin deployment serving none at all.
+    @Test
+    void offersThePublicApiToEveryOriginWithoutAWebUiUrl() {
+        var mappings = mappingsFor("");
+
+        assertThat(mappings).containsOnlyKeys("/api/**", "/vscode/**", "/documents/**");
+        assertThat(mappings.values())
+                .allSatisfy(config -> {
+                    assertThat(config.getAllowedOrigins()).containsExactly("*");
+                    // Never credentials on a wildcard origin: a browser refuses the combination, and it is
+                    // the combination that would make any origin an authenticated reader.
+                    assertThat(config.getAllowCredentials()).isNull();
+                });
+    }
+
+    // A relative value names no origin, so there is no cross-origin Web UI to allow.
+    @Test
+    void treatsARelativeWebUiUrlAsNoSeparateOrigin() {
+        assertThat(mappingsFor("/")).containsOnlyKeys("/api/**", "/vscode/**", "/documents/**");
+    }
+
+    @Test
+    void allowsTheWebUiOriginWithCredentialsWhenItIsAbsolute() {
+        var mappings = mappingsFor(UI_ORIGIN);
+
+        assertThat(mappings).containsKey("/user/**");
+        var userMapping = mappings.get("/user/**");
+        assertThat(userMapping.getAllowedOrigins()).containsExactly(UI_ORIGIN);
+        assertThat(userMapping.getAllowCredentials()).isTrue();
+    }
+
+    @Test
+    void neverAllowsCredentialsFromAnOriginItWasNotGiven() {
+        var mappings = mappingsFor(UI_ORIGIN);
+
+        assertThat(mappings)
+                .allSatisfy((pattern, config) -> {
+                    if (Boolean.TRUE.equals(config.getAllowCredentials())) {
+                        assertThat(config.getAllowedOrigins()).containsExactly(UI_ORIGIN);
+                        assertThat(config.checkOrigin("https://attacker.example")).isNull();
+                    }
+                });
+    }
+
+    /**
+     * The trap in hoisting the public mappings: {@code /api/user/publish} and the other credentialed
+     * {@code /api} endpoints are all matched by {@code /api/**} as well, and the first pattern registered
+     * is the one that answers. Registered the other way round they would quietly serve the public,
+     * credential-less configuration instead, and nothing about the request would look wrong.
+     */
+    @Test
+    void registersTheCredentialedApiEndpointsAheadOfTheCatchAll() {
+        var patterns = List.copyOf(mappingsFor(UI_ORIGIN).keySet());
+
+        assertThat(patterns).contains("/api/**");
+        var catchAll = patterns.indexOf("/api/**");
+        assertThat(patterns.subList(0, catchAll))
+                .as("credentialed /api mappings must be registered before the catch-all that also matches them")
+                .contains(
+                        "/api/user/publish",
+                        "/api/user/namespace/create",
+                        "/api/*/*/review/**",
+                        "/api/-/trusted-publishing/status");
+    }
+
+    // Left to the browser, an unmarked cookie is Lax in Chromium and has not always been elsewhere. It is
+    // what stops a cross-site fetch from carrying the session, so it is stated rather than assumed.
+    @Test
+    void marksCookiesLaxRatherThanLeavingItToTheBrowser() {
+        var supplier = new WebConfig(Optional.empty()).laxCookieSameSiteSupplier();
+
+        assertThat(supplier.getSameSite(new jakarta.servlet.http.Cookie("JSESSIONID", "value")))
+                .isEqualTo(Cookie.SameSite.LAX);
+    }
+}


### PR DESCRIPTION
> **Updated after review:** the public mappings are now on their own setting, `ovsx.cors.public-origins` (default `*`), rather than being registered unconditionally. See *Which origins* below.

## The gap

`/api/**`, `/vscode/**` and `/documents/**` are public and unauthenticated, and the browser clients that read them — VS Code for the Web, Gitpod, Theia, anything querying the gallery from page script — need `Access-Control-Allow-Origin` whether or not the Web UI sits on its own origin.

All three mappings were registered *inside* the branch that only runs when `ovsx.webui.url` is an absolute URL. That property defaults to empty and is only set absolute in the dev profile, where the UI runs on its own port. A deployment serving the Web UI from the same origin as the API — where it is empty or relative — therefore emitted **no CORS headers at all** for its public surface.

That is a gap someone has to fill, and the obvious place to fill it is the CDN, which is the wrong place: the edge cannot tell the public surface from the credentialed one, and a rule permissive enough to cover the first hands the second to any origin that asks. Registering them unconditionally removes the reason for an edge rule to exist.

Clients that aren't browsers are unaffected either way — VS Code desktop fetches the gallery from its node extension host, which never consults these headers.

## Which origins

Registering them *unconditionally* would have answered a different question badly. Which third parties may read the registry API from a browser has nothing to do with where this instance serves its Web UI — that was the bug — but it doesn't follow that the answer is always "anyone".

A registry reachable only from an internal network gets something real from these headers being absent: the endpoints are unauthenticated, so this is not what keeps their contents private, but it does stop a page in an employee's browser being used to reach an instance the page itself cannot. Those deployments have that protection today precisely *because* they don't configure `ovsx.webui.url` — accidentally, but they have it, and hardcoding `*` would have removed it silently.

So the three public mappings read `ovsx.cors.public-origins`:

- **default `*`** — a public registry still works with no configuration, matching what the absolute-`webuiUrl` case already did;
- **a list of origins** — narrowed to the browser clients a deployment actually serves;
- **empty** — no public CORS mappings registered at all.

Never with credentials, whatever it names: it's the pairing of a permissive origin with credentials that turns any origin into an authenticated reader, and nothing on this surface needs a session. Blank entries are dropped, for the same reason as in the pepper keyring — a trailing comma shouldn't leave behind a mapping that matches nothing.

## An origin is not a URL

`allowedOrigins` is matched against the browser's `Origin` header, which is a serialized origin — scheme, host, non-default port, never a path. `ovsx.webui.url` is a URL and may well carry one, for a registry served at `https://example.com/openvsx`. `CorsConfiguration.checkOrigin` trims a single trailing slash and compares the rest exactly, so such a value matched no header any browser sends and the credentialed mappings silently applied to nothing.

Pre-existing, spotted in review against the moved code. The origin is now derived from the URI: a default port is dropped (a browser omits it) and a non-default one kept — the latter matters because it is the development setup, `http://localhost:3000`.

## Registration order is load-bearing

The public mappings stay registered *after* the credentialed block, and there is now a test saying so.

`UrlBasedCorsConfigurationSource.getCorsConfiguration` walks its mappings in insertion order and returns the configuration of the **first** pattern that matches, then stops — it does not combine them and does not prefer the more specific one. I checked the bytecode rather than assuming, because `/api/user/publish`, `/api/user/namespace/create`, `/api/*/*/review/**` and `/api/-/trusted-publishing/status` are all matched by `/api/**` as well. Hoisted above the credentialed block, they would quietly answer with the public, credential-less configuration and nothing about the request would look wrong.

`registersTheCredentialedApiEndpointsAheadOfTheCatchAll` fails if the two are swapped — I verified that by swapping them.

## SameSite

Every cookie the application sets is now marked `SameSite=Lax` via a `CookieSameSiteSupplier` bean, rather than leaving the attribute off and the decision to the browser.

Unmarked, Chromium treats a cookie as Lax and other engines have not always. That made *"does the session cookie ride along on a cross-site `fetch`"* — the thing that decides whether such a request is authenticated at all — a property of the visitor's browser rather than of this server. It is the last thing standing between a misconfigured CORS layer and a credentialed cross-origin read of `/user/**`, which is not a job to leave to a default.

A bean rather than `server.servlet.session.cookie.same-site`, so it holds for every deployment without each operator having to know to set it.

**Lax, not Strict**, deliberately: Strict withholds the cookie from cross-site top-level navigations too, and that is exactly the return leg of an OAuth2 login — the provider redirects the browser back here and Spring Security needs the session to find the authorization request it saved. Lax sends it on that navigation and withholds it from the subresource requests (`fetch`, `XMLHttpRequest`, images, frames) an attacking page would have to use.

## Tests

`WebConfigTest` asserts against the registry rather than over HTTP, because order is part of the policy and only the registry shows it:

- the public API is offered to every origin, with no credentials, when `ovsx.webui.url` is unset;
- `ovsx.cors.public-origins` defaults to `*`, allows only what it names, drops blanks, and registers nothing when empty;
- an origin is derived from a `webui.url` carrying a path, dropping a default port and keeping a non-default one;
- a relative value is treated as no separate origin;
- an absolute value adds the credentialed mappings for that origin only, and `checkOrigin` rejects anything else;
- no mapping anywhere combines credentials with an origin it was not given;
- the credentialed `/api` endpoints precede the catch-all;
- cookies come back `SameSite=Lax`.

Full server suite green (1188 tests), formatter clean.

## Not in here

Nothing at the edge. Once this ships, the Fastly snippet can be deleted rather than rewritten — and the one thing worth keeping there is the opposite of what it does now: stripping `Vary: Origin` on the paths that answer `*`, since a constant value doesn't vary by origin and the header only fragments the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
