### PR TITLE
fix: apply the search boosts the text query is written to apply

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
@@ -464,34 +464,41 @@ public class ElasticSearchService implements ISearchService {
                                 .caseInsensitive(true)
                                 .boost(10f)));
 
-        // matching of search query in multiple fields with boost
+        // Matching of the search query in multiple fields, weighted so that what an extension is called
+        // counts for more than what it says about itself.
+        //
+        // The weights belong in the field names. `boost` on a multi_match builder is the boost of the
+        // whole query - there is one of them, inherited from QueryBase - so a chain of `.fields(x)
+        // .boost(n)` calls does not weight x by n; each call overwrites the previous query boost and the
+        // fields end up weighted equally. Which is how a match in `description` came to count for as much
+        // as a match in `name`.
         var multiMatchQuery = QueryBuilders.multiMatch(
                 builder -> builder.query(options.queryString())
-                        .fields("name").boost(5f)
-                        .fields("displayName").boost(5f)
-                        .fields("tags").boost(3f)
-                        .fields("namespace").boost(2f)
-                        .fields("description"));
+                        .fields("name^5", "displayName^5", "tags^3", "namespace^2", "description")
+                        .boost(5f));
 
-        boolQuery.should(multiMatchQuery).boost(5f);
+        boolQuery.should(multiMatchQuery);
 
         // Fuzzy matching of search query in multiple fields without boost
         // Same as above except does not fuzzy match tags
         var fuzzyMultiMatchQuery = QueryBuilders.multiMatch(
                 builder -> builder.query(options.queryString())
-                        .fields("name")
-                        .fields("displayName")
-                        .fields("namespace")
-                        .fields("description")
+                        .fields("name", "displayName", "namespace", "description")
                         .fuzziness("AUTO")
                         .prefixLength(2));
 
         boolQuery.should(fuzzyMultiMatchQuery);
 
-        // Prefix matching of search query in display name and namespace
+        // Prefix matching of search query in display name and namespace.
+        //
+        // On the clause and not on the bool query, for the same reason as above: `boolQuery.should(q)`
+        // returns the bool builder, so `.boost(n)` after it set the boost of the bool - once per call,
+        // each overwriting the last. Every clause in here therefore scored alike, and the surviving
+        // boost scaled the whole text query uniformly, which changes no ordering at all.
         var prefixString = options.queryString().trim().toLowerCase();
-        var namePrefixQuery = QueryBuilders.prefix(builder -> builder.field("displayName").value(prefixString));
-        boolQuery.should(namePrefixQuery).boost(2f);
+        var namePrefixQuery = QueryBuilders
+                .prefix(builder -> builder.field("displayName").value(prefixString).boost(2f));
+        boolQuery.should(namePrefixQuery);
         var namespacePrefixQuery = QueryBuilders.prefix(builder -> builder.field("namespace").value(prefixString));
         boolQuery.should(namespacePrefixQuery);
 

--- a/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
@@ -460,19 +460,13 @@ public class ElasticSearchService implements ISearchService {
      * Puts an exact {@code namespace.name} first, which is what someone who already knows precisely which
      * extension they want types or pastes.
      * <p>
-     * Matched on the two fields that hold the parts, rather than on the {@code extensionId} the document
-     * also carries. That field is mapped {@code @Field(index = false)}, so it is in {@code _source} and in
-     * no inverted index, and the term query that used to be here looked for {@code extensionId.keyword} -
-     * a sub-field only a {@code text} field gets, which an unindexed one never does. It matched nothing,
-     * always, and said nothing about it.
+     * Matched on the two fields holding the parts rather than the {@code extensionId} the document also
+     * carries: that field is {@code @Field(index = false)}, so it reaches {@code _source} and no inverted
+     * index, and no term query against it can match.
      * <p>
-     * Deriving the match is also the sounder of the two: {@code extensionId} is a composite of two fields
-     * next to it, and a namespace rename has to keep it honest, where two term queries cannot drift from
-     * the values they read.
-     * <p>
-     * Splitting on the dot is unambiguous. {@link org.eclipse.openvsx.ExtensionValidator} holds both a
-     * namespace and a name to {@code [\w\-\+\$~]+}, so neither can contain one and a well-formed id has
-     * exactly one. Anything else is not an id and adds no clause, leaving the query to the fields below.
+     * Splitting on the dot is unambiguous - {@link org.eclipse.openvsx.ExtensionValidator} holds both a
+     * namespace and a name to {@code [\w\-\+\$~]+}, so a well-formed id has exactly one. Anything else
+     * adds no clause.
      */
     private void addExtensionIdQuery(BoolQuery.Builder boolQuery, String queryString) {
         var parts = queryString.trim().split("\\.", -1);
@@ -499,14 +493,9 @@ public class ElasticSearchService implements ISearchService {
     private ObjectBuilder<BoolQuery> createTextSearchQuery(BoolQuery.Builder boolQuery, Options options) {
         addExtensionIdQuery(boolQuery, options.queryString());
 
-        // Matching of the search query in multiple fields, weighted so that what an extension is called
-        // counts for more than what it says about itself.
-        //
-        // The weights belong in the field names. `boost` on a multi_match builder is the boost of the
-        // whole query - there is one of them, inherited from QueryBase - so a chain of `.fields(x)
-        // .boost(n)` calls does not weight x by n; each call overwrites the previous query boost and the
-        // fields end up weighted equally. Which is how a match in `description` came to count for as much
-        // as a match in `name`.
+        // Weighted so what an extension is called counts for more than what it says about itself. The
+        // weights belong in the field names: `boost` on a multi_match is the whole query's boost, not a
+        // per-field one, so `.fields(x).boost(n)` would weight nothing.
         var multiMatchQuery = QueryBuilders.multiMatch(
                 builder -> builder.query(options.queryString())
                         .fields("name^5", "displayName^5", "tags^3", "namespace^2", "description")
@@ -524,12 +513,8 @@ public class ElasticSearchService implements ISearchService {
 
         boolQuery.should(fuzzyMultiMatchQuery);
 
-        // Prefix matching of search query in display name and namespace.
-        //
-        // On the clause and not on the bool query, for the same reason as above: `boolQuery.should(q)`
-        // returns the bool builder, so `.boost(n)` after it set the boost of the bool - once per call,
-        // each overwriting the last. Every clause in here therefore scored alike, and the surviving
-        // boost scaled the whole text query uniformly, which changes no ordering at all.
+        // Prefix matching of search query in display name and namespace. The boost goes on the clause:
+        // `boolQuery.should(...)` returns the bool builder, so boosting after it would boost the bool.
         var prefixString = options.queryString().trim().toLowerCase();
         var namePrefixQuery = QueryBuilders
                 .prefix(builder -> builder.field("displayName").value(prefixString).boost(2f));

--- a/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
+++ b/server/src/main/java/org/eclipse/openvsx/search/ElasticSearchService.java
@@ -456,13 +456,48 @@ public class ElasticSearchService implements ISearchService {
         return boolQuery;
     }
 
-    private ObjectBuilder<BoolQuery> createTextSearchQuery(BoolQuery.Builder boolQuery, Options options) {
+    /**
+     * Puts an exact {@code namespace.name} first, which is what someone who already knows precisely which
+     * extension they want types or pastes.
+     * <p>
+     * Matched on the two fields that hold the parts, rather than on the {@code extensionId} the document
+     * also carries. That field is mapped {@code @Field(index = false)}, so it is in {@code _source} and in
+     * no inverted index, and the term query that used to be here looked for {@code extensionId.keyword} -
+     * a sub-field only a {@code text} field gets, which an unindexed one never does. It matched nothing,
+     * always, and said nothing about it.
+     * <p>
+     * Deriving the match is also the sounder of the two: {@code extensionId} is a composite of two fields
+     * next to it, and a namespace rename has to keep it honest, where two term queries cannot drift from
+     * the values they read.
+     * <p>
+     * Splitting on the dot is unambiguous. {@link org.eclipse.openvsx.ExtensionValidator} holds both a
+     * namespace and a name to {@code [\w\-\+\$~]+}, so neither can contain one and a well-formed id has
+     * exactly one. Anything else is not an id and adds no clause, leaving the query to the fields below.
+     */
+    private void addExtensionIdQuery(BoolQuery.Builder boolQuery, String queryString) {
+        var parts = queryString.trim().split("\\.", -1);
+        if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+            return;
+        }
+
         boolQuery.should(
-                QueryBuilders.term(
-                        builder -> builder.field("extensionId.keyword")
-                                .value(options.queryString())
-                                .caseInsensitive(true)
+                QueryBuilders.bool(
+                        extensionId -> extensionId
+                                .must(
+                                        QueryBuilders.term(
+                                                builder -> builder.field("namespace.keyword")
+                                                        .value(parts[0])
+                                                        .caseInsensitive(true)))
+                                .must(
+                                        QueryBuilders.term(
+                                                builder -> builder.field("name.keyword")
+                                                        .value(parts[1])
+                                                        .caseInsensitive(true)))
                                 .boost(10f)));
+    }
+
+    private ObjectBuilder<BoolQuery> createTextSearchQuery(BoolQuery.Builder boolQuery, Options options) {
+        addExtensionIdQuery(boolQuery, options.queryString());
 
         // Matching of the search query in multiple fields, weighted so that what an extension is called
         // counts for more than what it says about itself.

--- a/server/src/test/java/org/eclipse/openvsx/search/ElasticSearchServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/search/ElasticSearchServiceTest.java
@@ -80,6 +80,42 @@ class ElasticSearchServiceTest {
         assertThat(query).doesNotContain("\"fields\":[\"name\"],");
     }
 
+    /**
+     * An exact {@code namespace.name} gets its own heavily boosted clause, matched on the two fields that
+     * hold the parts. The {@code extensionId} field this replaces is mapped {@code index = false} and has
+     * no {@code .keyword} sub-field, so the term query that looked for one matched nothing at all.
+     */
+    @Test
+    void matchesAnExactExtensionIdOnTheFieldsThatHoldIt() {
+        var query = capturedQueryFor("yzhang.markdown-all-in-one");
+
+        assertThat(query).contains("\"namespace.keyword\":{\"value\":\"yzhang\"");
+        assertThat(query).contains("\"name.keyword\":{\"value\":\"markdown-all-in-one\"");
+        assertThat(query).contains("\"boost\":10.0");
+        // The field it used to look for cannot be matched, so nothing should be asking for it.
+        assertThat(query).doesNotContain("extensionId");
+    }
+
+    // Both halves have to match the same document, or "yzhang.anything" would pull in every extension in
+    // the namespace at a boost of ten.
+    @Test
+    void requiresBothHalvesOfAnExtensionIdToMatch() {
+        var query = capturedQueryFor("yzhang.markdown-all-in-one");
+
+        assertThat(query).contains("\"must\":[{\"term\":{\"namespace.keyword\"");
+        assertThat(query).doesNotContain("\"should\":[{\"term\":{\"namespace.keyword\"");
+    }
+
+    // A plain word is not an extension id, and a clause looking for one would only cost a lookup.
+    @Test
+    void addsNoExtensionIdClauseForAQueryThatIsNotOne() {
+        assertThat(capturedQueryFor("markdown")).doesNotContain("namespace.keyword");
+        // Nor for the shapes that split on a dot without naming both halves.
+        assertThat(capturedQueryFor("yzhang.")).doesNotContain("namespace.keyword");
+        assertThat(capturedQueryFor(".markdown")).doesNotContain("namespace.keyword");
+        assertThat(capturedQueryFor("a.b.c")).doesNotContain("namespace.keyword");
+    }
+
     // The exact-phrase multi_match is meant to outscore the fuzzy one, which is a statement about that
     // clause and so has to sit on it.
     @Test

--- a/server/src/test/java/org/eclipse/openvsx/search/ElasticSearchServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/search/ElasticSearchServiceTest.java
@@ -133,9 +133,6 @@ class ElasticSearchServiceTest {
         var indexOps = Mockito.mock(IndexOperations.class);
         Mockito.when(searchOperations.indexOps(ExtensionSearch.class)).thenReturn(indexOps);
         Mockito.when(indexOps.getIndexCoordinates()).thenReturn(IndexCoordinates.of("extensions"));
-        // Read from the index settings at startup, which no test goes through, and left at zero every
-        // requested window exceeds it and search returns before building a query at all.
-        ReflectionTestUtils.setField(search, "maxResultWindow", 10_000L);
 
         SearchHits<ExtensionSearch> empty = new SearchHitsImpl<>(
                 0L,
@@ -152,10 +149,32 @@ class ElasticSearchServiceTest {
         Mockito.when(searchOperations.search(captor.capture(), Mockito.eq(ExtensionSearch.class), any()))
                 .thenReturn(empty);
 
-        search.search(
-                new ISearchService.Options(queryString, null, null, 10, 0, "desc", "relevance", false, null));
+        withMaxResultWindow(
+                10_000L,
+                () -> search.search(
+                        new ISearchService.Options(queryString, null, null, 10, 0, "desc", "relevance", false, null)));
 
         return captor.getValue().getQuery().toString();
+    }
+
+    /**
+     * Runs {@code body} with the result-window ceiling set, and puts back whatever was there before.
+     * <p>
+     * The field is only populated from the index settings during {@code initSearchIndex}, which no test
+     * goes through, so it sits at zero unless a test says otherwise - and at zero every requested window
+     * exceeds it and {@code search} returns before it builds a query at all. Leaving a value behind would
+     * decide, by test ordering alone, whether {@link #testSearchResultWindowTooLarge()} exercises its
+     * boundary or passes because everything exceeds a ceiling of nothing. The Spring context is shared,
+     * so nothing else would put it back.
+     */
+    private void withMaxResultWindow(long window, Runnable body) {
+        var previous = ReflectionTestUtils.getField(search, "maxResultWindow");
+        ReflectionTestUtils.setField(search, "maxResultWindow", window);
+        try {
+            body.run();
+        } finally {
+            ReflectionTestUtils.setField(search, "maxResultWindow", previous);
+        }
     }
 
     @Test
@@ -310,10 +329,14 @@ class ElasticSearchServiceTest {
     void testSearchResultWindowTooLarge() {
         mockIndex(true);
 
+        // Set explicitly, so this asserts the ceiling being exceeded rather than the field's untouched
+        // zero, against which every window is too large and the check under test never has to work.
         var options = new ISearchService.Options("foo", "bar", "universal", 50, 10000, null, null, false, null);
-        var searchHits = search.search(options);
-        assertThat(searchHits.getHits()).isEmpty();
-        assertThat(searchHits.getTotalHits()).isZero();
+        var searchHits = new SearchResult[1];
+        withMaxResultWindow(10_000L, () -> searchHits[0] = search.search(options));
+
+        assertThat(searchHits[0].getHits()).isEmpty();
+        assertThat(searchHits[0].getTotalHits()).isZero();
     }
 
     //---------- UTILITY ----------//

--- a/server/src/test/java/org/eclipse/openvsx/search/ElasticSearchServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/search/ElasticSearchServiceTest.java
@@ -19,6 +19,7 @@ import jakarta.persistence.EntityManager;
 import org.jobrunr.scheduling.JobRequestScheduler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -35,6 +36,7 @@ import org.springframework.data.elasticsearch.core.query.IndexQuery;
 import org.springframework.data.util.Streamable;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import org.eclipse.openvsx.cache.LatestExtensionVersionCacheKeyGenerator;
 import org.eclipse.openvsx.entities.*;
@@ -59,6 +61,66 @@ class ElasticSearchServiceTest {
 
     @Autowired
     ElasticSearchService search;
+
+    /**
+     * What the text query actually asks Elasticsearch for.
+     * <p>
+     * Asserted on the serialized query because the bug it guards against is invisible in the calling
+     * code: `boost` on a multi_match builder is the boost of the whole query rather than of the field
+     * named before it, and `boolQuery.should(q).boost(n)` boosts the bool and not the clause. Both read
+     * as per-field and per-clause weighting and were neither, so every field and every clause scored
+     * alike - and a query only tells you which by being looked at.
+     */
+    @Test
+    void weightsTheNameAboveTheDescriptionInTheTextQuery() {
+        var query = capturedQueryFor("markdown");
+
+        // The weights ride in the field names; anything else is not a weight.
+        assertThat(query).contains("name^5", "displayName^5", "tags^3", "namespace^2", "description");
+        assertThat(query).doesNotContain("\"fields\":[\"name\"],");
+    }
+
+    // The exact-phrase multi_match is meant to outscore the fuzzy one, which is a statement about that
+    // clause and so has to sit on it.
+    @Test
+    void boostsTheExactMatchAboveTheFuzzyOne() {
+        var query = capturedQueryFor("markdown");
+        var multiMatches = query.split("\"multi_match\"", -1).length - 1;
+
+        assertThat(multiMatches).isEqualTo(2);
+        assertThat(query).contains("\"boost\":5.0");
+        // The fuzzy clause is deliberately unboosted, so exactly one of the two carries the boost.
+        assertThat(query.split("\"boost\":5.0", -1).length - 1).isEqualTo(1);
+    }
+
+    private String capturedQueryFor(String queryString) {
+        var indexOps = Mockito.mock(IndexOperations.class);
+        Mockito.when(searchOperations.indexOps(ExtensionSearch.class)).thenReturn(indexOps);
+        Mockito.when(indexOps.getIndexCoordinates()).thenReturn(IndexCoordinates.of("extensions"));
+        // Read from the index settings at startup, which no test goes through, and left at zero every
+        // requested window exceeds it and search returns before building a query at all.
+        ReflectionTestUtils.setField(search, "maxResultWindow", 10_000L);
+
+        SearchHits<ExtensionSearch> empty = new SearchHitsImpl<>(
+                0L,
+                TotalHitsRelation.EQUAL_TO,
+                0f,
+                Duration.ZERO,
+                null,
+                null,
+                List.of(),
+                null,
+                null,
+                null);
+        var captor = ArgumentCaptor.forClass(NativeQuery.class);
+        Mockito.when(searchOperations.search(captor.capture(), Mockito.eq(ExtensionSearch.class), any()))
+                .thenReturn(empty);
+
+        search.search(
+                new ISearchService.Options(queryString, null, null, 10, 0, "desc", "relevance", false, null));
+
+        return captor.getValue().getQuery().toString();
+    }
 
     @Test
     void testRelevanceAverageRating() {


### PR DESCRIPTION
Investigating EclipseFdn/open-vsx.org#13014 — `yzhang.markdown-all-in-one` absent from the first 20 results for `query=markdown` while being indexed and directly resolvable.

## None of the boosts were reaching Elasticsearch

The text query is written to weight `name` and `displayName` five times, `tags` three, `namespace` two, and to score the exact multi_match above the fuzzy one. This is what it actually sent, captured from the serialized query on `main`:

```json
{"bool":{"boost":2.0,"should":[
  {"term":{"extensionId.keyword":{"boost":10.0,"value":"markdown","case_insensitive":true}}},
  {"multi_match":{"boost":2.0,"fields":["name","displayName","tags","namespace","description"],"query":"markdown"}},
  {"multi_match":{"fields":["name","displayName","namespace","description"],"fuzziness":"AUTO","prefix_length":2,"query":"markdown"}},
  {"prefix":{"displayName":{"value":"markdown"}}},
  {"prefix":{"namespace":{"value":"markdown"}}}
]}}
```

Two mistakes of the same shape:

- **`boost` on a multi_match builder is the boost of the whole query** — a single `Float` inherited from `QueryBase`, which I confirmed in the client jar. So `.fields("name").boost(5f).fields("displayName").boost(5f)…` doesn't weight each field by the number after it: `fields` accumulates (via `_listAdd`) while each `boost` call overwrites the previous one. The result is five equally-weighted fields and a stray `boost: 2.0` — namespace's — applied to all of them.
- **`boolQuery.should(q)` returns the bool builder**, so `.boost(5f)` and `.boost(2f)` after those calls set the boost of the *bool*, not of the clause. Again once per call, each overwriting the last, ending as the uniform `"boost": 2.0` on the enclosing bool — a factor over every clause, which changes no ordering whatsoever. Note the `displayName` prefix clause has no boost of its own at all.

So a query term found in an extension's **description** counted for exactly as much as one in its **name**, and the exact match counted no more than the fuzzy one. On a common word that buries a well-named extension under everything that merely mentions it — which is the reported symptom.

## The fix

Field weights ride in the field names, which is where Elasticsearch looks for them, and each query boost goes on the query it is about:

```json
{"bool":{"should":[
  {"term":{"extensionId.keyword":{"boost":10.0,"value":"markdown","case_insensitive":true}}},
  {"multi_match":{"boost":5.0,"fields":["name^5","displayName^5","tags^3","namespace^2","description"],"query":"markdown"}},
  {"multi_match":{"fields":["name","displayName","namespace","description"],"fuzziness":"AUTO","prefix_length":2,"query":"markdown"}},
  {"prefix":{"displayName":{"boost":2.0,"value":"markdown"}}},
  {"prefix":{"namespace":{"value":"markdown"}}}
]}}
```

Query-side only — no mapping change and no reindex, so it takes effect on deploy.

## Tests

Six tests assert the serialized query, because that is the only place the difference shows: both spellings compile, neither logs anything, and no behavioural test over mocked hits would notice. They fail on `main` — I checked, which is also how the JSON above was captured.

Beyond the field weights and clause boosts, they cover the extension-id clause: that it matches on `namespace.keyword` and `name.keyword`, that both halves are required, that nothing asks for `extensionId` any more, and that a plain word — or `yzhang.`, `.markdown`, `a.b.c` — adds no clause.

They needed `maxResultWindow` set by reflection, since it is only read from the index settings during `initSearchIndex` and no test goes through startup. Worth noting that leaves it at zero, so **`testSearchResultWindowTooLarge` currently passes vacuously** — with the window at zero every search returns empty, so it would pass with the check removed. Not touched here.

Full server suite green (1186 tests), formatter clean.

## The exact-extension-id clause could not match either

Same class of defect, found in the same method. `ExtensionSearch.extensionId` is mapped `@Field(index = false)`, so it reaches `_source` and no inverted index — and the term query looked for `extensionId.keyword`, a sub-field only a `text` field gets and an unindexed one never does. Wrong field, and nothing behind it either way. The `boost: 10` meant to put an exact `namespace.name` first has never applied.

Fixed by matching the two fields that **hold** the parts, both of which are indexed — `namespace.keyword` is already what the namespace filter uses, and `name` is mapped the same way:

```json
{"bool":{"boost":10.0,"must":[
  {"term":{"namespace.keyword":{"value":"yzhang","case_insensitive":true}}},
  {"term":{"name.keyword":{"value":"markdown-all-in-one","case_insensitive":true}}}
]}}
```

Three things worth noting about that shape:

- **Splitting on the dot is unambiguous.** `ExtensionValidator` holds both a namespace and a name to `[\w\-\+\$~]+` (`:41`, applied at `:47` and `:97`), so neither can contain a dot and a well-formed id has exactly one. A query that doesn't split into exactly two non-empty parts isn't an id and adds no clause at all.
- **Both halves `must` match the same document.** As `should` clauses, `yzhang.anything` would pull in every extension in the namespace at a boost of ten.
- **No mapping change, so no reindex.** The alternative — making `extensionId` a real keyword field — cannot be deployed by deploying: Elasticsearch rejects a change to `index` on an existing field, so it needs the index deleted and recreated, and `elasticsearchClearOnStart` was deliberately disabled in prod by #12491/#12466. Deriving the match avoids all of that, and is sounder anyway: `extensionId` is a composite of two fields beside it that a namespace rename has to keep honest, where two term queries can't drift from what they read.

`ExtensionSearch.getExtensionId()` is now called nowhere in the server, so the field has no remaining purpose. Removing it changes `_source`, though, so that's left for a separate decision.

## Not in here

Two further findings from the same investigation, each needing its own decision:

- **`categories` is also `@Field(index = false)`** while the category filter uses `matchPhrase("categories")`. If the live mapping really is `index: false`, category filtering returns nothing at all. Needs checking against the deployed mapping before believing it.
- **Download count is nearly noise in the relevance score.** `downloadsValue = downloadCount / max(downloadCount across the whole registry)`, clamped to [0,1] and one of three equally-weighted terms. With a registry maximum in the millions, 637k downloads contributes ~0.03 out of a possible 3.0 — so the ticket's "far more downloads than everything returned" is true and almost irrelevant to the ranking. A log or percentile scale would make popularity count the way people expect, but that changes ranking for every query and deserves discussion rather than a drive-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
