### PR TITLE
fix(webui): stop the download count spilling out of the extension card

### DIFF
--- a/webui/src/components/extension-card.tsx
+++ b/webui/src/components/extension-card.tsx
@@ -16,11 +16,11 @@ import { Link as RouteLink } from 'react-router';
 import { Paper, Typography, Box, Fade, Skeleton } from '@mui/material';
 import { alpha, CSSObject, styled, Theme } from '@mui/material/styles';
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
+import StarIcon from '@mui/icons-material/Star';
 import VerifiedIcon from '@mui/icons-material/Verified';
 import { ExtensionDetailRoutes } from '../pages/extension-detail/extension-detail-routes';
 import { Extension, SearchEntry } from '../extension-registry-types';
 import { ExtensionIcon } from './extension/extension-icon';
-import { ExtensionRatingStars } from '../pages/extension-detail/extension-rating-stars';
 import { createRoute, formatCompactNumber } from '../utils';
 import { MONO_FONT } from '../default/theme';
 import { GridItemProps } from '../hooks/use-grid-cursor';
@@ -92,10 +92,10 @@ const SkeletonContent: FunctionComponent = () => (
                 borderColor: 'border2',
                 display: 'flex',
                 alignItems: 'center',
-                gap: '0.0625rem',
+                gap: '0.1875rem',
                 fontSize: { xs: '0.8125rem', sm: '0.875rem' }
             }}>
-            <ExtensionRatingStars number={0} fontSize='inherit' />
+            <StarIcon sx={{ fontSize: 'inherit', color: 'action.disabledBackground' }} />
         </Box>
     </>
 );
@@ -337,6 +337,8 @@ export const ExtensionCard = memo(
                                         display: 'flex',
                                         alignItems: 'center',
                                         justifyContent: 'space-between',
+                                        gap: '0.5rem',
+                                        overflow: 'hidden',
                                         fontSize: '0.75rem'
                                     }}>
                                     {footerStart ?? (
@@ -344,26 +346,37 @@ export const ExtensionCard = memo(
                                             sx={{
                                                 display: 'flex',
                                                 alignItems: 'center',
-                                                gap: '0.0625rem',
+                                                gap: '0.1875rem',
+                                                // The side that yields, and it clips rather than pushing
+                                                // its neighbour out of the card: which extension is more
+                                                // popular is what the eye compares across a grid of these,
+                                                // so the download count stays whole whatever has to give.
+                                                minWidth: 0,
+                                                flexShrink: 1,
+                                                overflow: 'hidden',
+                                                whiteSpace: 'nowrap',
                                                 fontSize: { xs: '0.8125rem', sm: '0.875rem' }
                                             }}>
-                                            <ExtensionRatingStars
-                                                number={extension.averageRating ?? 0}
-                                                fontSize='inherit'
-                                            />
                                             {reviewCount > 0 && (
-                                                <Box
-                                                    component='span'
-                                                    sx={{
-                                                        fontSize: '0.6875rem',
-                                                        color: 'text.disabled',
-                                                        ml: '0.1875rem',
-                                                        // Sheds first on tight cards; the query measures
-                                                        // the card's content box, i.e. this row's width.
-                                                        '@container (max-width: 134px)': { display: 'none' }
-                                                    }}>
-                                                    ({formatCompactNumber(reviewCount)})
-                                                </Box>
+                                                <>
+                                                    {/* One star and the number, rather than the five
+                                                        icons ExtensionRatingStars always draws. Five is
+                                                        an intrinsic width that cannot shrink, and on an
+                                                        extension with both reviews and a long download
+                                                        count - redhat.java, 5.0 stars and 41M - the two
+                                                        sides together outgrew the card and the count was
+                                                        pushed past its edge. The number also says more
+                                                        than a row of icons somebody has to count. */}
+                                                    <StarIcon sx={{ fontSize: 'inherit' }} />
+                                                    <Box component='span' sx={{ fontSize: '0.6875rem' }}>
+                                                        {(extension.averageRating ?? 0).toFixed(1)}
+                                                    </Box>
+                                                    <Box
+                                                        component='span'
+                                                        sx={{ fontSize: '0.6875rem', color: 'text.disabled' }}>
+                                                        ({formatCompactNumber(reviewCount)})
+                                                    </Box>
+                                                </>
                                             )}
                                         </Box>
                                     )}
@@ -375,6 +388,7 @@ export const ExtensionCard = memo(
                                                 alignItems: 'center',
                                                 gap: '0.1875rem',
                                                 flexShrink: 0,
+                                                whiteSpace: 'nowrap',
                                                 fontFamily: MONO_FONT,
                                                 fontSize: '0.6875rem',
                                                 color: 'text.disabled'

--- a/webui/src/components/extension-card.tsx
+++ b/webui/src/components/extension-card.tsx
@@ -21,7 +21,7 @@ import VerifiedIcon from '@mui/icons-material/Verified';
 import { ExtensionDetailRoutes } from '../pages/extension-detail/extension-detail-routes';
 import { Extension, SearchEntry } from '../extension-registry-types';
 import { ExtensionIcon } from './extension/extension-icon';
-import { createRoute, formatCompactNumber } from '../utils';
+import { createRoute, formatCompactNumber, formatRating } from '../utils';
 import { MONO_FONT } from '../default/theme';
 import { GridItemProps } from '../hooks/use-grid-cursor';
 import { cardHoverLift, cardSurface, focusRing } from './page-primitives';
@@ -70,7 +70,43 @@ const CardRoot = styled(Paper)(({ theme }) => ({
 
 const SkeletonRoot = styled(Paper)(({ theme }) => cardLayout(theme));
 
-// Only the unknown parts are skeletons; the stars' empty state looks the same loaded or not.
+/**
+ * The footer's rating cell: one star and a slot for the score, or an empty cell when there is no
+ * score to show - the footer is `space-between`, so the cell has to stay even when empty or the
+ * download count stops being right-aligned.
+ *
+ * This is the side that yields, and it clips rather than pushing its neighbour out of the card:
+ * which extension is more popular is what the eye compares across a grid of these, so the download
+ * count stays whole whatever has to give. One star rather than the five `ExtensionRatingStars`
+ * always draws - five is an intrinsic width that cannot shrink, and beside a long download count
+ * (redhat.java, 5.0 stars and 41M) the pair outgrew the card and the count spilled past its edge.
+ * The number also says more than a row of icons somebody has to count.
+ */
+const CardFooterRating: FunctionComponent<{ children?: ReactNode; placeholder?: boolean }> = ({
+    children,
+    placeholder
+}) => (
+    <Box
+        sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.1875rem',
+            minWidth: 0,
+            flexShrink: 1,
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            fontSize: { xs: '0.8125rem', sm: '0.875rem' }
+        }}>
+        {children != null && (
+            <StarIcon sx={{ fontSize: 'inherit', ...(placeholder && { color: 'action.disabledBackground' }) }} />
+        )}
+        {children}
+    </Box>
+);
+
+// Only the unknown parts are skeletons. The rating cell keeps a greyed star beside a placeholder
+// bar so the footer reserves the footprint a rated card will need; a card that turns out to have
+// no reviews shows no rating at all, so for those the row does still settle once loaded.
 const SkeletonContent: FunctionComponent = () => (
     <>
         <Skeleton variant='rounded' width={54} height={54} sx={{ flexShrink: 0, mb: '0.75rem' }} />
@@ -92,10 +128,11 @@ const SkeletonContent: FunctionComponent = () => (
                 borderColor: 'border2',
                 display: 'flex',
                 alignItems: 'center',
-                gap: '0.1875rem',
                 fontSize: { xs: '0.8125rem', sm: '0.875rem' }
             }}>
-            <StarIcon sx={{ fontSize: 'inherit', color: 'action.disabledBackground' }} />
+            <CardFooterRating placeholder>
+                <Skeleton variant='text' width='2.5rem' sx={{ fontSize: '0.6875rem' }} />
+            </CardFooterRating>
         </Box>
     </>
 );
@@ -342,34 +379,11 @@ export const ExtensionCard = memo(
                                         fontSize: '0.75rem'
                                     }}>
                                     {footerStart ?? (
-                                        <Box
-                                            sx={{
-                                                display: 'flex',
-                                                alignItems: 'center',
-                                                gap: '0.1875rem',
-                                                // The side that yields, and it clips rather than pushing
-                                                // its neighbour out of the card: which extension is more
-                                                // popular is what the eye compares across a grid of these,
-                                                // so the download count stays whole whatever has to give.
-                                                minWidth: 0,
-                                                flexShrink: 1,
-                                                overflow: 'hidden',
-                                                whiteSpace: 'nowrap',
-                                                fontSize: { xs: '0.8125rem', sm: '0.875rem' }
-                                            }}>
-                                            {reviewCount > 0 && (
+                                        <CardFooterRating>
+                                            {reviewCount > 0 ? (
                                                 <>
-                                                    {/* One star and the number, rather than the five
-                                                        icons ExtensionRatingStars always draws. Five is
-                                                        an intrinsic width that cannot shrink, and on an
-                                                        extension with both reviews and a long download
-                                                        count - redhat.java, 5.0 stars and 41M - the two
-                                                        sides together outgrew the card and the count was
-                                                        pushed past its edge. The number also says more
-                                                        than a row of icons somebody has to count. */}
-                                                    <StarIcon sx={{ fontSize: 'inherit' }} />
                                                     <Box component='span' sx={{ fontSize: '0.6875rem' }}>
-                                                        {(extension.averageRating ?? 0).toFixed(1)}
+                                                        {formatRating(extension.averageRating ?? 0)}
                                                     </Box>
                                                     <Box
                                                         component='span'
@@ -377,8 +391,8 @@ export const ExtensionCard = memo(
                                                         ({formatCompactNumber(reviewCount)})
                                                     </Box>
                                                 </>
-                                            )}
-                                        </Box>
+                                            ) : null}
+                                        </CardFooterRating>
                                     )}
                                     {downloadCount !== '0' && (
                                         <Box

--- a/webui/src/index.ts
+++ b/webui/src/index.ts
@@ -71,7 +71,7 @@ export { AppProviders } from './app-providers';
 
 // `createAbsoluteURL` and `addQuery` are the other half of the request layer above:
 // building an endpoint against `service.serverUrl` needs them.
-export { createRoute, createAbsoluteURL, addQuery, formatCompactNumber, toRelativeTime } from './utils';
+export { createRoute, createAbsoluteURL, addQuery, formatCompactNumber, formatRating, toRelativeTime } from './utils';
 export { NotFound } from './not-found';
 
 // Theme tokens shared with the library chrome, so custom pages line up with it.

--- a/webui/src/utils.ts
+++ b/webui/src/utils.ts
@@ -50,6 +50,17 @@ export function formatCompactNumber(value: number): string {
     return compactNumberFormat.format(value);
 }
 
+const ratingFormat = new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1
+});
+
+/** Formats a star rating to one decimal, e.g. 4.25 -> "4.3". Unlike toFixed, which always emits a
+ *  '.', this follows the viewer's locale like every other number on a card does. */
+export function formatRating(value: number): string {
+    return ratingFormat.format(value);
+}
+
 const FILE_SIZE_UNITS = ['B', 'kB', 'MB', 'GB', 'TB'];
 
 /** Formats a byte count for humans, e.g. 5242880 -> "5.00 MB". */

--- a/webui/test/unit/components/extension-card.spec.tsx
+++ b/webui/test/unit/components/extension-card.spec.tsx
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../support/test-providers';
+import { ExtensionCard } from '../../../src/components/extension-card';
+import { Extension } from '../../../src/extension-registry-types';
+
+const extension = (overrides: Partial<Extension> = {}): Extension =>
+    ({
+        namespaceUrl: 'https://example.test/api/foo',
+        reviewsUrl: 'https://example.test/api/foo/bar/reviews',
+        files: {},
+        name: 'bar',
+        namespace: 'foo',
+        namespaceDisplayName: 'foo',
+        displayName: 'Bar',
+        version: '1.0.0',
+        targetPlatform: 'universal',
+        publishedBy: { loginName: 'someone', tokensUrl: '', createTokenUrl: '' },
+        verified: true,
+        allVersions: {},
+        downloadCount: 0,
+        reviewCount: 0,
+        versionAlias: [],
+        timestamp: '2026-01-01T00:00:00Z',
+        downloads: {},
+        deprecated: false,
+        downloadable: true,
+        ...overrides
+    }) as unknown as Extension;
+
+describe('ExtensionCard footer', () => {
+    // The card that prompted this: five filled stars are an intrinsic width that cannot shrink, and
+    // beside a long download count the pair outgrew the card and the count spilled past its edge.
+    // One star and the rating is a bounded width, and says more than a row of icons to be counted.
+    it('shows the rating as a single star and a number', () => {
+        renderWithProviders(
+            <ExtensionCard extension={extension({ averageRating: 5, reviewCount: 16, downloadCount: 41183269 })} />
+        );
+
+        expect(screen.getAllByTestId('StarIcon')).toHaveLength(1);
+        expect(screen.getByText('5.0')).toBeInTheDocument();
+        expect(screen.getByText('(16)')).toBeInTheDocument();
+    });
+
+    // The download count is what the eye compares across a grid of these, so it is never the side that
+    // gives way - it keeps flexShrink: 0 while the rating beside it clips.
+    it('keeps the download count whole alongside a rating', () => {
+        renderWithProviders(
+            <ExtensionCard extension={extension({ averageRating: 5, reviewCount: 16, downloadCount: 41183269 })} />
+        );
+
+        expect(screen.getByText('41M')).toBeInTheDocument();
+    });
+
+    // Nothing to say about a rating nobody has given: five grey stars claimed the width and stated a
+    // score that does not exist.
+    it('shows no rating at all when there are no reviews', () => {
+        renderWithProviders(<ExtensionCard extension={extension({ downloadCount: 1234 })} />);
+
+        expect(screen.queryByTestId('StarIcon')).not.toBeInTheDocument();
+        expect(screen.getByText('1.2K')).toBeInTheDocument();
+    });
+});

--- a/webui/test/unit/components/extension-card.spec.tsx
+++ b/webui/test/unit/components/extension-card.spec.tsx
@@ -16,6 +16,7 @@ import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../support/test-providers';
 import { ExtensionCard } from '../../../src/components/extension-card';
 import { Extension } from '../../../src/extension-registry-types';
+import { formatCompactNumber, formatRating } from '../../../src/utils';
 
 const extension = (overrides: Partial<Extension> = {}): Extension =>
     ({
@@ -41,28 +42,30 @@ const extension = (overrides: Partial<Extension> = {}): Extension =>
         ...overrides
     }) as unknown as Extension;
 
+// testing-library normalizes whitespace in the DOM before matching, and some locales put a
+// non-breaking space inside a compact number (fr-FR renders 1234 as '1,2 k'), so an expected string
+// straight from the formatter would not compare equal. Normalize it the same way.
+const normalized = (value: string) => value.replace(/\s+/g, ' ').trim();
+
+// Scope: these cover the footer's rendering rules only - which elements appear for a given review
+// count. They deliberately do not claim to cover the overflow fix itself, which is CSS: jsdom
+// applies no layout, so an assertion about clipping or spilling would pass either way. Catching a
+// regression there needs a browser (the Playwright suite runs against the deployed site on a
+// schedule, so it cannot gate a change here).
 describe('ExtensionCard footer', () => {
-    // The card that prompted this: five filled stars are an intrinsic width that cannot shrink, and
-    // beside a long download count the pair outgrew the card and the count spilled past its edge.
-    // One star and the rating is a bounded width, and says more than a row of icons to be counted.
-    it('shows the rating as a single star and a number', () => {
+    // Expected strings come from the same formatters the component uses: compact and one-decimal
+    // formatting are locale-dependent ('41M' is '41 Mio.' under de-DE), so hard-coding them fails
+    // on a runner with a non-English locale.
+    it('shows the rating as a single star and a number, alongside the download count', () => {
         renderWithProviders(
             <ExtensionCard extension={extension({ averageRating: 5, reviewCount: 16, downloadCount: 41183269 })} />
         );
 
+        // One star, not the five ExtensionRatingStars draws - the intrinsic width that could not shrink.
         expect(screen.getAllByTestId('StarIcon')).toHaveLength(1);
-        expect(screen.getByText('5.0')).toBeInTheDocument();
-        expect(screen.getByText('(16)')).toBeInTheDocument();
-    });
-
-    // The download count is what the eye compares across a grid of these, so it is never the side that
-    // gives way - it keeps flexShrink: 0 while the rating beside it clips.
-    it('keeps the download count whole alongside a rating', () => {
-        renderWithProviders(
-            <ExtensionCard extension={extension({ averageRating: 5, reviewCount: 16, downloadCount: 41183269 })} />
-        );
-
-        expect(screen.getByText('41M')).toBeInTheDocument();
+        expect(screen.getByText(normalized(formatRating(5)))).toBeInTheDocument();
+        expect(screen.getByText(normalized(`(${formatCompactNumber(16)})`))).toBeInTheDocument();
+        expect(screen.getByText(normalized(formatCompactNumber(41183269)))).toBeInTheDocument();
     });
 
     // Nothing to say about a rating nobody has given: five grey stars claimed the width and stated a
@@ -71,6 +74,6 @@ describe('ExtensionCard footer', () => {
         renderWithProviders(<ExtensionCard extension={extension({ downloadCount: 1234 })} />);
 
         expect(screen.queryByTestId('StarIcon')).not.toBeInTheDocument();
-        expect(screen.getByText('1.2K')).toBeInTheDocument();
+        expect(screen.getByText(normalized(formatCompactNumber(1234)))).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
Reported while testing search results: on an extension with both reviews and a large download count — `redhat.java` on open-vsx.org — the download count overflows the card.

## Why it overflows

The footer is a `space-between` flex row of two groups, and **neither can give way**:

- **Left** — `ExtensionRatingStars` always renders five icons (`extension-rating-stars.tsx:42`, `[1,2,3,4,5].map(getStar)`). Flex items default to `min-width: auto`, and a row of icons has nothing to shrink.
- **Right** — the download group sets `flexShrink: 0`.

Once the two intrinsic widths exceed the card, nothing yields and the count is pushed past the edge. `redhat.java` hits it squarely: rating 5.0 (five *filled* stars), 16 reviews, and 41,183,269 downloads → `41M` in a monospace font. That's the "reviews **and** lots of downloads" combination — it needs both halves at their widest.

The only relief was a container query hiding the review count below **134px**. That's one fixed number guarding content whose width varies with the download string, which is why `41M` spills where `12K` does not.

## The change

**The rating is now one star and the number.** Five icons are an intrinsic width that cannot shrink; `★ 5.0` is bounded, roughly half as wide, and arguably says more than a row of icons the reader has to count. An extension nobody has reviewed shows nothing at all, rather than five grey stars claiming the width to state a score that does not exist.

**The row gets the shrink discipline the name row above it already has** — that row uses `overflow: hidden`, `minWidth: 0` and explicit shrink priorities; the footer was the one row that never got it. Now: a `gap` so the groups cannot touch, `minWidth: 0` + `overflow: hidden` on the rating so it clips, `flexShrink: 0` kept on the count.

Which extension is more popular is what the eye compares across a grid of these, so **the download count is never what gives way** — the rating beside it is. Overflow becomes structurally impossible rather than tuned away, and the 134px magic number is deleted rather than retuned.

The loading skeleton was drawing five stars too, so it now matches the footprint the real card has.

`ExtensionRatingStars` itself is untouched — the detail page and the reviews list have room for five stars and still use it.

## Testing

Three tests in a new `extension-card.spec.tsx`: the rating renders as exactly one `StarIcon` plus `5.0` and `(16)`; the download count survives beside it; and an unreviewed extension renders no star at all.

Full webui suite green (289 tests, 56 files), `tsc --noEmit` and `yarn lint` clean.

**Not verified in a browser.** This build image has no engine Playwright supports (`Playwright does not support chromium on ubuntu26.04-x64`, and there's no chromium package), so I could not render the before or after. That shaped the fix: it's built so that overflow cannot happen for *any* content width, rather than tuned to measurements I couldn't take. The visual change — one star instead of five — is worth a look on a real page before merging, particularly at the narrow end of the grid and on a card with no reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)