### PR TITLE
docs: say that a comment should not recount the bug it fixed

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -134,7 +134,11 @@ you touch configuration, diff all four and say which you changed.
 - Read files in full before wide-ranging changes, and before editing files you
   have not inspected. Do not rely on search snippets.
 - Keep code comments short (1–3 lines): state only the non-obvious constraint or
-  rationale, never narrate what the code does.
+  rationale, never narrate what the code does. In particular do not recount the
+  bug a line used to have or how it used to behave: a comment is read by
+  someone looking at the code as it stands, and the history belongs in the
+  commit message and the pull request, where anyone asking why it changed is
+  already looking.
 - Ask before removing functionality or code that appears intentional. Do not
   preserve backward compatibility unless the user asks for it.
 - A configuration property that has never appeared in a release can be renamed


### PR DESCRIPTION
From review feedback on #2174, where gnugomez pointed out that two of my comments were "talking about a previous state of the code" and suggested this belongs in `AGENTS.md`.

The existing rule already covers length and narrating what the code does:

> Keep code comments short (1–3 lines): state only the non-obvious constraint or rationale, never narrate what the code does.

What it does not cover is recounting the bug — and that is the one an agent reaches for most naturally, having just worked out what was wrong and writing it down next to the fix. The result reads as a changelog entry stranded in the source, and goes stale the moment anything else moves.

The comments that prompted it looked like this:

```java
// The weights belong in the field names. `boost` on a multi_match builder is the boost of the
// whole query - there is one of them, inherited from QueryBase - so a chain of `.fields(x)
// .boost(n)` calls does not weight x by n; each call overwrites the previous query boost and the
// fields end up weighted equally. Which is how a match in `description` came to count for as much
// as a match in `name`.
```

against what survives once the history is dropped:

```java
// Weighted so what an extension is called counts for more than what it says about itself. The
// weights belong in the field names: `boost` on a multi_match is the whole query's boost, not a
// per-field one, so `.fields(x).boost(n)` would weight nothing.
```

Kept separate from #2174 so a documentation change is not buried in a search fix.