### PR TITLE
fix: enforce the targetPlatform values the API documents

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/RegistryAPI.java
@@ -28,8 +28,10 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -846,6 +848,10 @@ public class RegistryAPI {
                 example = "Programming Languages"
             ) String category,
             @RequestParam(required = false)
+            @Pattern(
+                regexp = TargetPlatform.NAMES_PARAM_REGEX,
+                message = "parameter must be a supported target platform"
+            )
             @Parameter(
                 description = "Target platform",
                 example = TargetPlatform.NAME_LINUX_ARM64,
@@ -1005,6 +1011,10 @@ public class RegistryAPI {
                 )
             ) String includeAllVersions,
             @RequestParam(required = false)
+            @Pattern(
+                regexp = TargetPlatform.NAMES_PARAM_REGEX,
+                message = "parameter must be a supported target platform"
+            )
             @Parameter(
                 description = "Target platform",
                 example = TargetPlatform.NAME_LINUX_X64,
@@ -1136,6 +1146,10 @@ public class RegistryAPI {
                 description = "Whether to include all versions of an extension, ignored if extensionVersion is specified"
             ) boolean includeAllVersions,
             @RequestParam(required = false)
+            @Pattern(
+                regexp = TargetPlatform.NAMES_PARAM_REGEX,
+                message = "parameter must be a supported target platform"
+            )
             @Parameter(
                 description = "Target platform",
                 example = TargetPlatform.NAME_LINUX_X64,
@@ -1246,6 +1260,7 @@ public class RegistryAPI {
         description = "Returns redirect to GET /api/-/query."
     )
     public ResponseEntity<QueryResultJson> postQuery(
+            @Valid
             @RequestBody
             @Parameter(description = "Parameters of the metadata query") QueryParamJson param
     ) {

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,7 @@ import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
@@ -44,6 +46,7 @@ import static org.eclipse.openvsx.adapter.ExtensionQueryResult.ExtensionFile.*;
 import static org.eclipse.openvsx.util.TargetPlatform.*;
 
 @RestController
+@Validated
 public class VSCodeAPI {
     private static final int DEFAULT_PAGE_SIZE = 20;
     private static final Logger logger = LoggerFactory.getLogger(VSCodeAPI.class);
@@ -219,6 +222,10 @@ public class VSCodeAPI {
                 )
             ) String assetType,
             @RequestParam(defaultValue = TargetPlatform.NAME_UNIVERSAL)
+            @Pattern(
+                regexp = TargetPlatform.NAMES_PARAM_REGEX,
+                message = "parameter must be a supported target platform"
+            )
             @Parameter(
                 description = "Target platform",
                 example = TargetPlatform.NAME_LINUX_X64,
@@ -341,6 +348,10 @@ public class VSCodeAPI {
             @PathVariable
             @Parameter(description = "Extension version", example = "2.11.7") String version,
             @RequestParam(defaultValue = TargetPlatform.NAME_UNIVERSAL)
+            @Pattern(
+                regexp = TargetPlatform.NAMES_PARAM_REGEX,
+                message = "parameter must be a supported target platform"
+            )
             @Parameter(
                 description = "Target platform",
                 example = TargetPlatform.NAME_LINUX_X64,

--- a/server/src/main/java/org/eclipse/openvsx/json/QueryParamJson.java
+++ b/server/src/main/java/org/eclipse/openvsx/json/QueryParamJson.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
 import org.apache.commons.lang3.StringUtils;
 
 import static org.eclipse.openvsx.util.TargetPlatform.*;
@@ -47,6 +48,7 @@ public class QueryParamJson {
     @Schema(description = "Whether to include all versions of an extension, ignored if extensionVersion is specified")
     private boolean includeAllVersions;
 
+    @Pattern(regexp = NAMES_PARAM_REGEX, message = "field must be a supported target platform")
     @Schema(
         description = "Name of the target platform",
         allowableValues = {

--- a/server/src/main/java/org/eclipse/openvsx/util/TargetPlatform.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/TargetPlatform.java
@@ -33,6 +33,13 @@ public class TargetPlatform {
             NAME_DARWIN_X64 + "|" + NAME_DARWIN_ARM64 + "|" +
             NAME_WEB + "|" + NAME_UNIVERSAL;
 
+    /**
+     * Any known platform name, or nothing at all: unlike a path segment, a query parameter can be absent
+     * or empty, and neither is a request for an unknown platform. For validating the parameter forms of
+     * {@code targetPlatform}, whose {@code allowableValues} the path-segment regex above cannot enforce.
+     */
+    public static final String NAMES_PARAM_REGEX = "(" + NAMES_PATH_PARAM_REGEX + ")?";
+
     public static final List<String> TARGET_PLATFORM_NAMES = List.of(
             NAME_WIN32_X64,
             NAME_WIN32_IA32,

--- a/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/RegistryAPITest.java
@@ -167,6 +167,63 @@ class RegistryAPITest {
     @Autowired
     ExtensionService extensionService;
 
+    // targetPlatform documents an `allowableValues` enum on every endpoint that takes it, and until now
+    // enforced it only where it is a path segment. As a query parameter an unknown value was quietly
+    // rewritten to null, so the caller got the whole registry back instead of the slice it asked for -
+    // which answers a question nobody put, and is indistinguishable from success.
+    @Test
+    void testSearchRejectsAnUnknownTargetPlatform() throws Exception {
+        mockMvc.perform(get("/api/-/search").param("targetPlatform", "win32-bogus"))
+                .andExpect(status().isBadRequest())
+                .andExpect(
+                        content()
+                                .json(errorJson("targetPlatform: parameter must be a supported target platform")));
+    }
+
+    @Test
+    void testQueryV2RejectsAnUnknownTargetPlatform() throws Exception {
+        mockMvc.perform(get("/api/v2/-/query").param("targetPlatform", "win32-bogus"))
+                .andExpect(status().isBadRequest())
+                .andExpect(
+                        content()
+                                .json(errorJson("targetPlatform: parameter must be a supported target platform")));
+    }
+
+    @Test
+    void testQueryRejectsAnUnknownTargetPlatform() throws Exception {
+        mockMvc.perform(get("/api/-/query").param("targetPlatform", "win32-bogus"))
+                .andExpect(status().isBadRequest())
+                .andExpect(
+                        content()
+                                .json(errorJson("targetPlatform: parameter must be a supported target platform")));
+    }
+
+    @Test
+    void testPostQueryRejectsAnUnknownTargetPlatform() throws Exception {
+        mockMvc.perform(
+                post("/api/-/query")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"targetPlatform\":\"win32-bogus\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // A platform that is merely no longer publishable is still one that published versions carry, so it
+    // has to keep resolving - see #1074, where win32-ia32 has 983 of them.
+    @Test
+    void testSearchAcceptsEveryDocumentedTargetPlatform() throws Exception {
+        for (var targetPlatform : TargetPlatform.TARGET_PLATFORM_NAMES) {
+            mockMvc.perform(get("/api/-/search").param("targetPlatform", targetPlatform))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    // Absent and empty both mean "do not filter", and neither is a request for an unknown platform.
+    @Test
+    void testSearchAcceptsAnAbsentOrEmptyTargetPlatform() throws Exception {
+        mockMvc.perform(get("/api/-/search")).andExpect(status().isOk());
+        mockMvc.perform(get("/api/-/search").param("targetPlatform", "")).andExpect(status().isOk());
+    }
+
     @Test
     void testPublicNamespace() throws Exception {
         var namespace = mockNamespace();

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -73,6 +73,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @WebMvcTest(VSCodeAPI.class)
 @MockitoBean(
@@ -109,6 +110,39 @@ class VSCodeAPITest {
 
     @Autowired
     MockMvc mockMvc;
+
+    // Both of these take targetPlatform as a query parameter with a documented allowableValues enum, and
+    // neither enforced it: an unknown value fell through to a lookup for a platform that cannot exist.
+    // These return a stream and a redirect rather than a ResultJson, so the rejection is a problem
+    // detail rather than the {"error": ...} body the registry API uses.
+    @Test
+    void testAssetRejectsAnUnknownTargetPlatform() throws Exception {
+        mockMvc.perform(
+                get(
+                        "/vscode/asset/{namespace}/{extension}/{version}/{assetType}",
+                        "redhat",
+                        "java",
+                        "1.0.0",
+                        "Microsoft.VisualStudio.Code.Manifest")
+                        .param("targetPlatform", "win32-bogus"))
+                .andExpect(status().isBadRequest())
+                .andExpect(
+                        jsonPath("$.errors[0]").value("targetPlatform: parameter must be a supported target platform"));
+    }
+
+    @Test
+    void testVspackageRejectsAnUnknownTargetPlatform() throws Exception {
+        mockMvc.perform(
+                get(
+                        "/vscode/gallery/publishers/{namespace}/vsextensions/{extension}/{version}/vspackage",
+                        "redhat",
+                        "java",
+                        "1.0.0")
+                        .param("targetPlatform", "win32-bogus"))
+                .andExpect(status().isBadRequest())
+                .andExpect(
+                        jsonPath("$.errors[0]").value("targetPlatform: parameter must be a supported target platform"));
+    }
 
     @Test
     void testSearch() throws Exception {


### PR DESCRIPTION
Every endpoint taking `targetPlatform` documents an `allowableValues` enum, and it was enforced only where the value is a **path segment** (via `NAMES_PATH_PARAM_REGEX`). As a **query parameter** it was not enforced anywhere: an unknown value failed `TargetPlatform.isValid`, was rewritten to `null`, and the filter was simply dropped.

Live on production today:

```
$ curl -sS "https://open-vsx.org/api/-/search?targetPlatform=win32-ia32&size=3" \
    | jq -c '{totalSize, platforms: [.extensions[].targetPlatform]}'
{"totalSize":22,"platforms":["win32-ia32","win32-ia32","win32-ia32"]}

$ curl -sS "https://open-vsx.org/api/-/search?targetPlatform=win32-bogus&size=3" \
    | jq -c '{totalSize, platforms: [.extensions[].targetPlatform]}'
{"totalSize":17546,"platforms":["universal","universal","universal"]}
```

HTTP 200 both times. The failure mode is not that it is wrong — it is that it is **indistinguishable from success**: a typo returns a large, plausible, entirely unfiltered result set and nothing in the response says the filter was ignored.

## The fix

`@Pattern` against the names the enum already documents, wherever the value arrives as a parameter:

| | needed |
| --- | --- |
| `RegistryAPI` — `/api/-/search`, `/api/-/query`, `/api/v2/-/query` | `@Pattern` (class was already `@Validated`) |
| `VSCodeAPI` — `/vscode/asset/**`, `/vspackage` | `@Pattern` + `@Validated` on the class |
| `QueryParamJson.targetPlatform` (POST `/api/-/query`) | `@Pattern` + `@Valid` on the request body |

The pattern admits an empty value — `NAMES_PARAM_REGEX` is `(<names>)?` — because an empty parameter means "do not filter", not "filter by nothing", and clients that always emit the parameter would otherwise start failing.

This deliberately leaves the six internal callers that use `isValid` to decide *whether to apply a filter* free to keep that meaning: by the time a service sees the value it is either a known platform or absent. Rejecting at the edge is what makes those call sites correct rather than lucky.

## Bearing on #1074

#1074 proposes dropping `win32-ia32` from the list. Doing that today would silently convert every request for it into a request for everything — 22 results becoming 20,008. With this in place such a request is a 400 instead, and the 983 published `win32-ia32` versions keep resolving, because the list they are matched against is untouched. It does not decide #1074 either way; it removes the trap.

## The audit

I looked for the same inconsistency everywhere rather than assuming this was the only instance. Every request-side `allowableValues` in the API layer:

| Parameter | Enforced by | |
| --- | --- | --- |
| `targetPlatform` (path segments) | route regex | ok |
| `targetPlatform` (query/body) | **nothing** | fixed here |
| `sortBy`, `sortOrder` (`/api/-/search`) | `ElasticSearchService.sortResults` throws | ok |
| `includeAllVersions` | throws `Invalid includeAllVersions value` | ok |
| `role` (AdminAPI ×4) | `AdminService.parseRole` throws | ok |
| `enforcement`, `sortBy`, `sortOrder` (ScanAPI) | `parseEnforcementFilter` / `toDbSortField` / `normalizeSortOrder` throw | ok |
| `decision`, `sortBy`, `sortOrder` (FileDecisionAPI) | `@Min`/`@Max`; `toFileSortField` / `normalizeSortOrder` throw | ok |

Two cases I left alone on purpose:

- **`ExtensionQueryParam.sortBy`** (the VS Code gallery POST body) silently defaults to relevance for an unrecognised integer. That mirrors the upstream Marketplace API this adapter imitates, and tightening it risks real clients for no benefit.
- **`assetType`** has a documented enum and no route constraint, but an unknown value ends in a `NotFoundException`. A 404 is a correct answer for an unknown asset, not a silently different one.

So the gap really was `targetPlatform` alone — everything else already validates, just by hand rather than by annotation.

## Tests

Eight, in `RegistryAPITest` and `VSCodeAPITest`: one rejection per affected endpoint, plus two that guard the opposite property — that every documented platform is still accepted (`win32-ia32` included, per #1074), and that an absent or empty parameter still means "no filter".

Confirmed the six rejection tests fail without the change:

```
testSearchRejectsAnUnknownTargetPlatform       FAILED
testQueryRejectsAnUnknownTargetPlatform        FAILED
testQueryV2RejectsAnUnknownTargetPlatform      FAILED
testPostQueryRejectsAnUnknownTargetPlatform    FAILED
testAssetRejectsAnUnknownTargetPlatform        FAILED
testVspackageRejectsAnUnknownTargetPlatform    FAILED
```

The two "accepts" tests pass either way, as they should — they exist to catch over-rejection.

Full server suite green (1211 tests); `spotlessCheck` and `format.sh` clean.

## Note on the error body

The registry endpoints return `ResultJson` subtypes, so a rejection reads `{"error": "targetPlatform: parameter must be a supported target platform"}`. The two VS Code endpoints return a stream and a redirect, so `ValidationExceptionHandler` falls through to an RFC 9457 problem detail there. That asymmetry is pre-existing and orthogonal to this change; worth knowing when reading the tests, which assert both shapes.
