### PR TITLE
fix: make the documented docker compose command work

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -36,6 +36,9 @@ To run the Open VSX registry in a development environment, you can use `docker c
    * `commandline`: Starts a container with the OpenVSX CLI tools.
    * `openvsx`: Combines `backend`, `frontend`, and `commandline` profiles to start all related services.
    * `kibana`: Starts a kibana instance for easier access to the Elasticsearch service.
+   * `minio`: Starts a MinIO instance as S3-compatible object storage, for exercising external file storage locally. A companion container creates the `test` bucket and makes it publicly downloadable on every start, since MinIO here keeps no volume and loses both when the container is recreated.
+   * `valkey`: Starts a six-node Valkey cluster (three primaries and three replicas), for exercising the cache locally. A companion container forms the cluster on first start and leaves it alone afterwards.
+   * `valkey-admin`: Starts the Valkey cluster as above, plus a web UI for inspecting it.
  * In the project root, initiate Docker Compose:
    * With profiles: `docker compose --profile <profile_name> up`. Use multiple `--profile` flags for multiple profiles, e.g., `docker compose --profile openvsx --profile kibana up`.
    * A profile is required: every service in the file belongs to one, so a plain `docker compose up` starts nothing.
@@ -45,6 +48,8 @@ To run the Open VSX registry in a development environment, you can use `docker c
    * registry backend is available at [http://localhost:8080/](http://localhost:8080/) if the `backend` or `openvsx` profile was selected.
    * web ui is available at [http://localhost:3000/](http://localhost:3000/) if the `frontend` or `openvsx` profile was selected.
    * kibana is exposed at [http://localhost:5601/](http://localhost:5601/) if the `kibana` profile was selected.
+   * MinIO is at [http://localhost:9000/](http://localhost:9000/) with its console at [http://localhost:9001/](http://localhost:9001/) (`minioadmin`/`minioadmin`) if the `minio` profile was selected.
+   * the Valkey nodes are on ports 7001-7006 (user `openvsx`, password `openvsx`) if the `valkey` or `valkey-admin` profile was selected, and the Valkey UI is at [http://localhost:8090/](http://localhost:8090/) for `valkey-admin`.
  * Open VSX CLI commands can be run via `docker compose exec cli lib/ovsx` if the `commandline` or `openvsx` profile was selected.
  * To load some extensions from the main registry (openvsx.org), run `docker compose exec cli yarn load-extensions <N>`, where N is the number of extensions you would like to publish in your local registry.
  * For troubleshooting or manual intervention, access a service's interactive shell with `docker compose run --rm <service> /bin/bash`. Service names are listed in the [docker-compose.yml](docker-compose.yml) file.

--- a/doc/development.md
+++ b/doc/development.md
@@ -27,7 +27,7 @@ To execute any of these commands within your workspace, navigate to Terminal -> 
 To run the Open VSX registry in a development environment, you can use `docker compose` by following these steps:
 
  * Verify Docker Compose is installed by running `docker compose version`. If an error occurs, you may need to [install docker compose](https://docs.docker.com/compose/install/) on your machine.
- * Decide which profile(s) to run based on your needs. The [docker-compose.yml] file defines profiles for specific components:
+ * Decide which profile(s) to run based on your needs. The [docker-compose.yml](../docker-compose.yml) file defines profiles for specific components:
    * `db`: Starts the PostgreSQL container.
    * `es`: Starts the Elasticsearch container.
    * `debug`: Starts the PostgreSQL and Elasticsearch containers, which suits running the OpenVSX server and web UI locally for easier debugging.
@@ -52,7 +52,7 @@ To run the Open VSX registry in a development environment, you can use `docker c
    * the Valkey nodes are on ports 7001-7006 (user `openvsx`, password `openvsx`) if the `valkey` or `valkey-admin` profile was selected, and the Valkey UI is at [http://localhost:8090/](http://localhost:8090/) for `valkey-admin`.
  * Open VSX CLI commands can be run via `docker compose exec cli lib/ovsx` if the `commandline` or `openvsx` profile was selected.
  * To load some extensions from the main registry (openvsx.org), run `docker compose exec cli yarn load-extensions <N>`, where N is the number of extensions you would like to publish in your local registry.
- * For troubleshooting or manual intervention, access a service's interactive shell with `docker compose run --rm <service> /bin/bash`. Service names are listed in the [docker-compose.yml](docker-compose.yml) file.
+ * For troubleshooting or manual intervention, access a service's interactive shell with `docker compose run --rm <service> /bin/bash`. Service names are listed in the [docker-compose.yml](../docker-compose.yml) file.
 
 ### Setup locally on WSL
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -31,14 +31,14 @@ To run the Open VSX registry in a development environment, you can use `docker c
    * `db`: Starts the PostgreSQL container.
    * `es`: Starts the Elasticsearch container.
    * `debug`: Starts the PostgreSQL and Elasticsearch containers, which suits running the OpenVSX server and web UI locally for easier debugging.
-   * `backend`: Starts the OpenVSX server container (java).
+   * `backend`: Starts the OpenVSX server container (java), along with the PostgreSQL and Elasticsearch containers it waits on.
    * `frontend`: Starts the web UI container.
    * `commandline`: Starts a container with the OpenVSX CLI tools.
    * `openvsx`: Combines `backend`, `frontend`, and `commandline` profiles to start all related services.
    * `kibana`: Starts a kibana instance for easier access to the Elasticsearch service.
  * In the project root, initiate Docker Compose:
-   * Without profiles: `docker compose up`.
    * With profiles: `docker compose --profile <profile_name> up`. Use multiple `--profile` flags for multiple profiles, e.g., `docker compose --profile openvsx --profile kibana up`.
+   * A profile is required: every service in the file belongs to one, so a plain `docker compose up` starts nothing.
 
  * Depending on which profile(s) you selected, after some seconds, the respective services become available:
    * registry backend is available at [http://localhost:8080/](http://localhost:8080/) if the `backend` or `openvsx` profile was selected.

--- a/doc/development.md
+++ b/doc/development.md
@@ -31,7 +31,7 @@ To run the Open VSX registry in a development environment, you can use `docker c
    * `db`: Starts the PostgreSQL container.
    * `es`: Starts the Elasticsearch container.
    * `debug`: Starts the PostgreSQL and Elasticsearch containers, which suits running the OpenVSX server and web UI locally for easier debugging.
-   * `backend`: Starts the OpenVSX server container (java), along with the PostgreSQL and Elasticsearch containers it waits on.
+   * `backend`: Starts the OpenVSX server container (java).
    * `frontend`: Starts the web UI container.
    * `commandline`: Starts a container with the OpenVSX CLI tools.
    * `openvsx`: Combines `backend`, `frontend`, and `commandline` profiles to start all related services.
@@ -39,6 +39,7 @@ To run the Open VSX registry in a development environment, you can use `docker c
  * In the project root, initiate Docker Compose:
    * With profiles: `docker compose --profile <profile_name> up`. Use multiple `--profile` flags for multiple profiles, e.g., `docker compose --profile openvsx --profile kibana up`.
    * A profile is required: every service in the file belongs to one, so a plain `docker compose up` starts nothing.
+   * Each profile starts only its own services, so pick the infrastructure too: `docker compose --profile openvsx --profile debug up` runs the whole stack, while `--profile openvsx` alone starts the server, web UI and CLI against a database that is not there. The server waits for PostgreSQL and Elasticsearch to report healthy when they are part of the selection.
 
  * Depending on which profile(s) you selected, after some seconds, the respective services become available:
    * registry backend is available at [http://localhost:8080/](http://localhost:8080/) if the `backend` or `openvsx` profile was selected.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,10 +37,6 @@ services:
     profiles:
       - db
       - debug
-      # `server` depends on this, so it has to be selectable by the profile that selects `server`,
-      # or the project does not even validate: "depends on undefined service".
-      - openvsx
-      - backend
 
   elasticsearch:
     image: elasticsearch:9.2.8
@@ -69,8 +65,6 @@ services:
     profiles:
       - es
       - debug
-      - openvsx
-      - backend
 
   kibana:
     image: kibana:8.7.1
@@ -79,7 +73,9 @@ services:
     environment:
       - ELASTICSEARCH_URL=http://elasticsearch:9200
     depends_on:
-      - elasticsearch
+      elasticsearch:
+        condition: service_started
+        required: false
     profiles:
       - kibana
 
@@ -205,11 +201,18 @@ services:
       - ./server:/app
     ports:
       - 8080:8080
+    # `required: false` states the dependency without claiming ownership: postgres and elasticsearch
+    # stay in their own profiles, and are waited on when the selected profiles include them. Without
+    # it, selecting a profile that holds a service but not its dependency is a hard error - "service
+    # X depends on undefined service Y: invalid compose project" - which is what `--profile openvsx`,
+    # `--profile frontend`, `--profile commandline` and `--profile kibana` all used to be.
     depends_on:
       postgres:
         condition: service_healthy
+        required: false
       elasticsearch:
         condition: service_healthy
+        required: false
     healthcheck:
       # eclipse-temurin ships no curl, wget or nc, so the previous curl-based check could only ever
       # exit 127. bash is present, and its /dev/tcp is enough to ask the actuator the same question.
@@ -234,7 +237,9 @@ services:
     ports:
       - 3000:3000
     depends_on:
-      - server
+      server:
+        condition: service_started
+        required: false
     profiles:
       - openvsx
       - frontend
@@ -246,7 +251,9 @@ services:
     volumes:
       - ./cli:/app
     depends_on:
-      - server
+      server:
+        condition: service_started
+        required: false
     environment:
       - OVSX_REGISTRY_URL=http://server:8080
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,18 @@ services:
         max-file: "3"
     ports:
       - '5432:5432'
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U openvsx"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     profiles:
       - db
       - debug
+      # `server` depends on this, so it has to be selectable by the profile that selects `server`,
+      # or the project does not even validate: "depends on undefined service".
+      - openvsx
+      - backend
 
   elasticsearch:
     image: elasticsearch:9.2.8
@@ -50,7 +59,9 @@ services:
         soft: -1
         hard: -1
     healthcheck:
-      test: curl -s http://elasticsearch01:9200 >/dev/null || exit 1
+      # localhost, not the service name: there is no `elasticsearch01` here, so this never resolved
+      # and the container sat "starting" for the full 50 retries while the cluster was green.
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health >/dev/null || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 50
@@ -58,6 +69,8 @@ services:
     profiles:
       - es
       - debug
+      - openvsx
+      - backend
 
   kibana:
     image: kibana:8.7.1
@@ -193,10 +206,16 @@ services:
     ports:
       - 8080:8080
     depends_on:
-      - postgres
-      - elasticsearch
+      postgres:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     healthcheck:
-      test: "curl --fail --silent localhost:8081/actuator/health | grep UP || exit 1"
+      # eclipse-temurin ships no curl, wget or nc, so the previous curl-based check could only ever
+      # exit 127. bash is present, and its /dev/tcp is enough to ask the actuator the same question.
+      # Single-quoted so the \r\n reach bash as escapes for printf, rather than being turned into
+      # real control characters by YAML on the way.
+      test: ['CMD-SHELL', 'exec 3<>/dev/tcp/localhost/8081 && printf "GET /actuator/health HTTP/1.0\r\n\r\n" >&3 && grep -q UP <&3']
       interval: 10s
       timeout: 5s
       retries: 50

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,15 +66,19 @@ services:
       - es
       - debug
 
+  # Kibana has to match the Elasticsearch above: it refuses to talk to a cluster on a different
+  # major version, so the two versions move together.
   kibana:
-    image: kibana:8.7.1
+    image: kibana:9.2.8
     ports:
       - "5601:5601"
     environment:
-      - ELASTICSEARCH_URL=http://elasticsearch:9200
+      # ELASTICSEARCH_HOSTS, not ELASTICSEARCH_URL: `elasticsearch.url` was removed in Kibana 7 and
+      # is not a setting any more, so the old name was quietly doing nothing.
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
     depends_on:
       elasticsearch:
-        condition: service_started
+        condition: service_healthy
         required: false
     profiles:
       - kibana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,9 +216,15 @@ services:
     healthcheck:
       # eclipse-temurin ships no curl, wget or nc, so the previous curl-based check could only ever
       # exit 127. bash is present, and its /dev/tcp is enough to ask the actuator the same question.
+      # bash explicitly, not CMD-SHELL: that runs /bin/sh, which on this image is dash, and dash has
+      # no /dev/tcp - it fails with "cannot create /dev/tcp/...: Directory nonexistent".
       # Single-quoted so the \r\n reach bash as escapes for printf, rather than being turned into
       # real control characters by YAML on the way.
-      test: ['CMD-SHELL', 'exec 3<>/dev/tcp/localhost/8081 && printf "GET /actuator/health HTTP/1.0\r\n\r\n" >&3 && grep -q UP <&3']
+      test:
+        - CMD
+        - bash
+        - -c
+        - 'exec 3<>/dev/tcp/localhost/8081 && printf "GET /actuator/health HTTP/1.0\r\n\r\n" >&3 && grep -q UP <&3'
       interval: 10s
       timeout: 5s
       retries: 50


### PR DESCRIPTION
Picks up the three findings still standing from #1258, which reported them in June 2025 against a very different version of this file.

## The documented command does not work

`doc/development.md` offers this verbatim as the way to start a dev stack:

```
$ docker compose --profile openvsx --profile kibana up
service "server" depends on undefined service "postgres": invalid compose project
```

`server` is in `openvsx`/`backend`; `postgres` is in `db`/`debug`. The project fails to validate before a single container is created, so anyone following our own instructions hits this on their first command. `postgres` and `elasticsearch` now also belong to the profiles that select the service depending on them.

## Two healthchecks could never have passed

Which is presumably why nobody noticed the profiles were broken — nothing downstream ever waited on health.

**elasticsearch** curled `http://elasticsearch01:9200`. There is no such host here; the service is `elasticsearch`. From inside the running container, while the cluster is `status: green`:

```
elasticsearch01 -> exit 6   (couldn't resolve host)
localhost       -> exit 0
```

So it stayed `starting` for the full 50 retries and then reported unhealthy, with a perfectly good cluster behind it.

**server** curled `localhost:8081/actuator/health`, and `eclipse-temurin:25-jdk` has no curl:

```
$ docker run --rm --entrypoint sh eclipse-temurin:25-jdk -c 'command -v curl wget nc python3'
(nothing)
$ docker run --rm --entrypoint sh eclipse-temurin:25-jdk -c 'curl --fail --silent localhost:8081/actuator/health'
sh: 1: curl: not found
```

`bash` *is* present, and its `/dev/tcp` can ask the actuator the same question with nothing to install:

```yaml
test: ['CMD-SHELL', 'exec 3<>/dev/tcp/localhost/8081 && printf "GET /actuator/health HTTP/1.0\r\n\r\n" >&3 && grep -q UP <&3']
```

Single-quoted deliberately: in a double-quoted YAML scalar those `\r\n` become real control characters before bash sees them, which happens to work but only by accident of double interpretation.

The alternative was `apt-get install curl` on every container start, which is what #1258 proposed — reasonable when the base image was `openjdk:17`, but a network round trip on each `up` and no longer necessary.

## Which lets `depends_on` do its job

With both checks working, `depends_on` can wait on readiness instead of only on container creation. That is the ordering problem #1258 originally reported: the server no longer races a Postgres still initialising or an Elasticsearch that has not opened its port. `postgres` gained a `pg_isready` check so it can be waited on at all.

## What I did not take from #1258

Worth recording so the PR can be closed with a clear conscience. Two of its changes have since landed independently — the `ES_JAVA_OPTS` memory settings and the `memlock` ulimits are both in main already. The rest is overtaken or not worth it: the `openjdk:17-bullseye` switch (main is on temurin 25), `SPRING_PROFILES_ACTIVE`/`ELASTICSEARCH_HOST`/`POSTGRES_HOST` env vars (the repo uses `generate-properties.sh --docker`), `/etc/localtime` mounts on every service (cosmetic, and breaks on Docker Desktop hosts), `"0.0.0.0:8080:8080"` (identical to `8080:8080`), removing the `cli` service, and `docs/docker-deployment-fix.md`, which is in Chinese and mostly describes the above.

## Docs

`backend` now brings its dependencies, so its description says so. I also dropped the "Without profiles: `docker compose up`" line — every service in the file has a profile, so that command starts nothing:

```
$ docker compose config --services
(empty)
```

## Verified

- both profile commands resolve to a valid project
- `postgres` healthy in ~12s, `elasticsearch` in ~36s, where elasticsearch previously never reached it
- a cold `up server` creates the server container only once both report healthy — dependencies started 20:15:45, server 20:16:01
- the `/dev/tcp` check exits 0 against a live endpoint and non-zero against a closed port, tested inside `eclipse-temurin:25-jdk` itself

What I did **not** run is a full `--profile openvsx up` through to a healthy server, since that builds the server with Gradle inside the container. The healthcheck command is verified against a real HTTP endpoint in the same image, but the first person to run the whole stack should confirm the server actually flips to healthy.

Closes #1258 — credit to @hbyecoding for the report.
