### PR TITLE
fix: resolve extension resources for the target platform VS Code asks for

### DIFF
--- a/server/src/main/java/org/eclipse/openvsx/adapter/IVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/IVSCodeService.java
@@ -32,6 +32,7 @@ public interface IVSCodeService {
             String namespaceName,
             String extensionName,
             String version,
+            String targetPlatform,
             String path
     );
 

--- a/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/LocalVSCodeService.java
@@ -510,24 +510,37 @@ public class LocalVSCodeService implements IVSCodeService {
             String namespaceName,
             String extensionName,
             String version,
+            String targetPlatform,
             String path
     ) {
         if (BuiltInExtensionUtil.isBuiltIn(namespaceName)) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(builtinExtensionResponse());
         }
 
-        var extensionDownloadPath = webResources.getExtensionDownload(namespaceName, extensionName, null, version);
+        var extensionDownloadPath = webResources
+                .getExtensionDownload(namespaceName, extensionName, targetPlatform, version);
         if (extensionDownloadPath == null) {
             throw new NotFoundException();
         }
 
-        var file = getWebResource(namespaceName, extensionName, null, version, path, extensionDownloadPath);
+        var file = getWebResource(
+                namespaceName,
+                extensionName,
+                targetPlatform,
+                version,
+                path,
+                extensionDownloadPath);
         if (file != null) {
             return storageUtil.getFileResponse(file);
         }
 
-        var node = webResources
-                .browseExtensionPackage(namespaceName, extensionName, null, version, path, extensionDownloadPath);
+        var node = webResources.browseExtensionPackage(
+                namespaceName,
+                extensionName,
+                targetPlatform,
+                version,
+                path,
+                extensionDownloadPath);
         if (node != null) {
             return storageUtil.getFileResponse(node);
         }

--- a/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/UpstreamVSCodeService.java
@@ -148,6 +148,7 @@ public class UpstreamVSCodeService implements IVSCodeService {
             String namespaceName,
             String extensionName,
             String version,
+            String targetPlatform,
             String path
     ) {
         var urlBuilder = new StringBuilder(
@@ -168,6 +169,13 @@ public class UpstreamVSCodeService implements IVSCodeService {
                 urlBuilder.append("/{").append(varName).append("}");
                 uriVariables.put(varName, segments[i]);
             }
+        }
+
+        // As a query parameter rather than the `<version>+<target>` form the client may have used:
+        // both are accepted upstream, and this one needs no escaping decisions.
+        if (StringUtils.isNotBlank(targetPlatform)) {
+            urlBuilder.append("?target={target}");
+            uriVariables.put("target", targetPlatform);
         }
 
         var method = HttpMethod.GET;

--- a/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/VSCodeAPI.java
@@ -433,13 +433,39 @@ public class VSCodeAPI {
             @PathVariable
             @Parameter(description = "Extension name", example = "malloy-vscode") String extensionName,
             @PathVariable
-            @Parameter(description = "Extension version", example = "0.3.1710435722") String version
+            @Parameter(description = "Extension version", example = "0.3.1710435722") String version,
+            @RequestParam(required = false)
+            @Pattern(
+                regexp = TargetPlatform.NAMES_PARAM_REGEX,
+                message = "parameter must be a supported target platform"
+            )
+            @Parameter(
+                description = "Target platform. May also be given as a `+<target>` suffix on the version, "
+                        + "which is the form VS Code uses when resolving an extension's resources.",
+                example = TargetPlatform.NAME_WEB
+            ) String target
     ) {
+        var targetPlatform = StringUtils.isNotEmpty(target) ? target : null;
+        if (targetPlatform == null) {
+            // VS Code appends the target to the version when it resolves an extension's resources, so
+            // that a `web` build and a `universal` build of one version can be told apart. Only strip
+            // the suffix when it names a platform: a version may legitimately carry semver build
+            // metadata (`1.2.3+build.5`), which belongs to the version rather than being a target.
+            var separator = version.lastIndexOf('+');
+            if (separator >= 0 && separator + 1 < version.length()) {
+                var candidate = version.substring(separator + 1);
+                if (TargetPlatform.isValid(candidate)) {
+                    targetPlatform = candidate;
+                    version = version.substring(0, separator);
+                }
+            }
+        }
+
         var path = UrlUtil.extractWildcardPath(request);
         try {
             for (var service : getVSCodeServices()) {
                 try {
-                    return service.browse(namespaceName, extensionName, version, path);
+                    return service.browse(namespaceName, extensionName, version, targetPlatform, path);
                 } catch (NotFoundException exc) {
                     // Try the next registry
                 }

--- a/server/src/main/java/org/eclipse/openvsx/adapter/WebResourceService.java
+++ b/server/src/main/java/org/eclipse/openvsx/adapter/WebResourceService.java
@@ -37,6 +37,7 @@ import org.eclipse.openvsx.util.ErrorResultException;
 import org.eclipse.openvsx.util.FileUtil;
 import org.eclipse.openvsx.util.NamingUtil;
 import org.eclipse.openvsx.util.SizeLimitInputStream;
+import org.eclipse.openvsx.util.TargetPlatform;
 import org.eclipse.openvsx.util.UrlUtil;
 
 import static org.eclipse.openvsx.cache.CacheService.*;
@@ -147,7 +148,12 @@ public class WebResourceService {
                 return null;
             }
 
-            var baseUrl = UrlUtil.createApiUrl("", "vscode", "unpkg", namespace, extension, version);
+            // The listed URLs are followed as-is, so the target has to survive the round trip or
+            // walking into a subdirectory silently drops back to whichever version matches first.
+            var versionSegment = TargetPlatform.isValid(targetPlatform) && !TargetPlatform.isUniversal(targetPlatform)
+                    ? version + "+" + targetPlatform
+                    : version;
+            var baseUrl = UrlUtil.createApiUrl("", "vscode", "unpkg", namespace, extension, versionSegment);
             var node = jsonMapper.createArrayNode();
             for (var entry : dirEntries) {
                 node.add(baseUrl + "/" + entry);

--- a/server/src/test/java/org/eclipse/openvsx/adapter/UpstreamVSCodeServiceTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/UpstreamVSCodeServiceTest.java
@@ -54,7 +54,7 @@ public class UpstreamVSCodeServiceTest {
                 urlConfig,
                 Mockito.mock(ExtensionValidator.class));
 
-        var response = service.browse("foo", "bar", "1.0.0", "extension/readme.md");
+        var response = service.browse("foo", "bar", "1.0.0", null, "extension/readme.md");
 
         assertEquals(
                 "text/plain;charset=UTF-8",
@@ -63,7 +63,7 @@ public class UpstreamVSCodeServiceTest {
                 response.getHeaders().getFirst("Content-Security-Policy"),
                 "proxied files must carry a Content-Security-Policy");
 
-        response = service.browse("foo", "bar", "1.0.0", "extension/readme.html");
+        response = service.browse("foo", "bar", "1.0.0", null, "extension/readme.html");
 
         assertEquals(
                 "text/plain;charset=UTF-8",

--- a/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
+++ b/server/src/test/java/org/eclipse/openvsx/adapter/VSCodeAPITest.java
@@ -753,6 +753,76 @@ class VSCodeAPITest {
                 .andDo(result -> Files.delete(path));
     }
 
+    // VS Code appends the target to the version when it resolves an extension's resources, so that a
+    // web build and a universal build of one version can be told apart - see #744 and #758. Without
+    // this the request 404s, and an extension published for both targets cannot be browsed at all from
+    // a web VS Code.
+    @Test
+    void testBrowseTopDirForATargetPlatformInTheVersion() throws Exception {
+        var namespaceName = "EditorConfig";
+        var extensionName = "EditorConfig";
+        var version = "0.16.6";
+        var path = mockTargetedExtensionBrowse(namespaceName, extensionName, "web", version);
+        mockMvc.perform(
+                get(
+                        "/vscode/unpkg/{namespaceName}/{extensionName}/{version}",
+                        namespaceName,
+                        extensionName,
+                        version + "+web"))
+                .andExpect(request().asyncStarted())
+                .andDo(MvcResult::getAsyncResult)
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                // The listed URLs keep the target, or following one drops back to whichever version
+                // matches first.
+                .andExpect(
+                        content().json(
+                                "["
+                                        + "\"http://localhost/vscode/unpkg/EditorConfig/EditorConfig/0.16.6+web/extension.vsixmanifest\","
+                                        + "\"http://localhost/vscode/unpkg/EditorConfig/EditorConfig/0.16.6+web/extension/\","
+                                        + "\"http://localhost/vscode/unpkg/EditorConfig/EditorConfig/0.16.6+web/[Content_Types].xml\""
+                                        + "]"))
+                .andDo(result -> Files.delete(path));
+    }
+
+    @Test
+    void testBrowseTopDirForATargetPlatformParameter() throws Exception {
+        var namespaceName = "EditorConfig";
+        var extensionName = "EditorConfig";
+        var version = "0.16.6";
+        var path = mockTargetedExtensionBrowse(namespaceName, extensionName, "web", version);
+        mockMvc.perform(
+                get("/vscode/unpkg/{namespaceName}/{extensionName}/{version}", namespaceName, extensionName, version)
+                        .param("target", "web"))
+                .andExpect(request().asyncStarted())
+                .andDo(MvcResult::getAsyncResult)
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(
+                        content().json(
+                                "["
+                                        + "\"http://localhost/vscode/unpkg/EditorConfig/EditorConfig/0.16.6+web/extension.vsixmanifest\","
+                                        + "\"http://localhost/vscode/unpkg/EditorConfig/EditorConfig/0.16.6+web/extension/\","
+                                        + "\"http://localhost/vscode/unpkg/EditorConfig/EditorConfig/0.16.6+web/[Content_Types].xml\""
+                                        + "]"))
+                .andDo(result -> Files.delete(path));
+    }
+
+    // A version may legitimately carry semver build metadata, which is part of the version and not a
+    // target, so the text after the last '+' is only taken when it names a platform.
+    @Test
+    void testBrowseKeepsSemverBuildMetadataInTheVersion() throws Exception {
+        mockMvc.perform(
+                get(
+                        "/vscode/unpkg/{namespaceName}/{extensionName}/{version}",
+                        "EditorConfig",
+                        "EditorConfig",
+                        "1.2.3+build.5"))
+                .andExpect(status().isNotFound());
+
+        Mockito.verify(repositories).findFileByType("EditorConfig", "EditorConfig", null, "1.2.3+build.5", DOWNLOAD);
+    }
+
     @Test
     void testBrowseVsixManifest() throws Exception {
         var namespaceName = "EditorConfig";
@@ -1411,6 +1481,17 @@ class VSCodeAPITest {
 
     private Path mockWebResourceAsset(String namespaceName, String extensionName, String targetPlatform, String version)
             throws IOException {
+        return mockExtensionBrowse(namespaceName, extensionName, targetPlatform, version, false);
+    }
+
+    /** Browse setup for a request that names its target, so the download lookup is keyed by it rather
+     *  than by null the way an untargeted browse is. */
+    private Path mockTargetedExtensionBrowse(
+            String namespaceName,
+            String extensionName,
+            String targetPlatform,
+            String version
+    ) throws IOException {
         return mockExtensionBrowse(namespaceName, extensionName, targetPlatform, version, false);
     }
 


### PR DESCRIPTION
> **Stacked on #2181** — base is `fix/target-platform-validation`, so this diff shows only the unpkg change. #2181 supplies the `@Validated`/`@Pattern` wiring on `VSCodeAPI` that this reuses; without it the two PRs would both add those lines and conflict. Merge that first, or say so and I will retarget this at `main`.

Reimplements #758 (June 2023) on current `main`. Fixes #744.

## What is broken

VS Code encodes the target platform into the version segment when it resolves an extension's resources — `<version>+<target>`, `web` for a web extension (microsoft/vscode#180525, microsoft/vscode#182072). The unpkg endpoint never learned to read it:

```
/vscode/unpkg/BroadcomMFD/hlasm-language-support/1.23.0/extension/package.json       → 200
/vscode/unpkg/BroadcomMFD/hlasm-language-support/1.23.0+web/extension/package.json   → 404
/vscode/unpkg/.../1.23.0%2Bweb/extension/package.json                                → 404
```

That extension really does publish `1.23.0` for both `universal` and `web`, and the second URL is what a web VS Code sends — so its resources do not load at all in vscode.dev or github.dev.

Even without the suffix the endpoint could not have told the two apart: it passed `null` down to the download lookup, which matched whichever version came first.

## The change

Smaller than #758, because the plumbing already takes a target platform — `WebResourceService.getExtensionDownload(namespace, extension, targetPlatform, version)` and `browseExtensionPackage(...)` both have the parameter, and `browseExtensionPackage` was using it *only* to compose an error message. So this is mostly a matter of resolving a target at the edge and passing it down.

**Where the target comes from.** `?target=` if given, otherwise a `+<target>` suffix on the version. The suffix is taken only when it names a platform:

```java
var separator = version.lastIndexOf('+');
if (separator >= 0 && separator + 1 < version.length()) {
    var candidate = version.substring(separator + 1);
    if (TargetPlatform.isValid(candidate)) { ... }
}
```

A version may legitimately carry semver build metadata — `1.2.3+build.5` — which `SemanticVersion.VERSION_PATH_PARAM_REGEX` explicitly permits. "Text after the last `+`" would read `build.5` as a target, so the validation is what makes the heuristic safe rather than merely convenient. There is a test for it.

**Directory listings re-append the target.** `browseExtensionPackage` built its child URLs from the bare version, so without this, walking into a subdirectory silently drops back to whichever version matches first — the same bug one level down. `universal` is left off, since it is the absence of a target rather than a target.

**Upstream forwarding.** `UpstreamVSCodeService` passes the target on as `?target=`, so a mirror forwards it rather than resolving it against its own registry. Query-parameter form rather than the `+` suffix because both are accepted and it needs no escaping decisions.

## Tests

- `testBrowseTopDirForATargetPlatformInTheVersion` — `0.16.6+web` resolves, and the returned listing URLs keep `+web`
- `testBrowseTopDirForATargetPlatformParameter` — the same via `?target=web`
- `testBrowseKeepsSemverBuildMetadataInTheVersion` — `1.2.3+build.5` is looked up whole, with a null target, verified on the repository call

The first two fail without the change. The third passes either way, which is right — it guards against over-eager parsing, so it should hold both before and after.

Full server suite green (1214 tests); `spotlessCheck` and `format.sh` clean.

## On #758

It cannot be rebased: it is written against `ResponseEntity<byte[]>` and a codebase with no `WebResourceService`, across 8 files and 2½ years of drift. Its repository addition is also redundant now — `findFileByType` already resolves a target-specific version. The design is amvanbaren's and this follows it, including the two details easiest to miss: validating the suffix before stripping it, and putting the target back on the listing URLs.

Suggest closing #758 in favour of this.
