### PR TITLE
fix(cli): resolve a download once the file is written, not when the response ends

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -15,6 +15,10 @@ This change log covers only the command line interface (CLI) of Open VSX.
 - Add `verify` command to check a downloaded `.vsix` package's signature against the registry's public key, mirroring `vsce verify-signature` ([#993](https://github.com/eclipse-openvsx/openvsx/issues/993))
 - Add `verify-signature` command, verifying an already-extracted package/manifest/signature file trio entirely offline (no registry involved), matching `vsce verify-signature`'s own command shape ([#993](https://github.com/eclipse-openvsx/openvsx/issues/993))
 
+#### Fixed
+
+- Fix downloads that could be read before they were written. `download` resolved when the response ended rather than when the file was closed, and a write stream opens and flushes asynchronously, so a caller reading the path immediately afterwards could find the file empty or absent - which `verify` did, intermittently failing to read the public key it had just fetched. An error response is no longer written into the file either ([#2184](https://github.com/eclipse-openvsx/openvsx/pull/2184))
+
 #### Changed
 
 - `publish --trusted-publishing` retries the token exchange when the registry answers that it could not verify the ID token (502, 503, 504), rather than failing the build on a blip reaching the identity provider. A refusal is never retried

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -17,7 +17,7 @@ This change log covers only the command line interface (CLI) of Open VSX.
 
 #### Fixed
 
-- Fix downloads that could be read before they were written. `download` resolved when the response ended rather than when the file was closed, and a write stream opens and flushes asynchronously, so a caller reading the path immediately afterwards could find the file empty or absent - which `verify` did, intermittently failing to read the public key it had just fetched. An error response is no longer written into the file either ([#2185](https://github.com/eclipse-openvsx/openvsx/pull/2185))
+- Fix downloads that could be read before they were written. `download` resolved when the response ended rather than when the file was closed, and a write stream opens and flushes asynchronously, so a caller reading the path immediately afterwards could find the file empty or absent - which `verify` did, intermittently failing to read the public key it had just fetched. A failed download no longer touches the target path at all, where before the file was opened, and so truncated, before the response status was known ([#2185](https://github.com/eclipse-openvsx/openvsx/pull/2185))
 
 #### Changed
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -17,7 +17,7 @@ This change log covers only the command line interface (CLI) of Open VSX.
 
 #### Fixed
 
-- Fix downloads that could be read before they were written. `download` resolved when the response ended rather than when the file was closed, and a write stream opens and flushes asynchronously, so a caller reading the path immediately afterwards could find the file empty or absent - which `verify` did, intermittently failing to read the public key it had just fetched. A failed download no longer touches the target path at all, where before the file was opened, and so truncated, before the response status was known ([#2185](https://github.com/eclipse-openvsx/openvsx/pull/2185))
+- Fix downloads that could be read before they were written. `download` resolved when the response ended rather than when the file was closed, and a write stream opens and flushes asynchronously, so a caller reading the path immediately afterwards could find the file empty or absent - which `verify` did, intermittently failing to read the public key it had just fetched. A failed download no longer touches the target path: the body is written beside it and renamed into place only once it has arrived whole, so a 404 or a dropped connection leaves what was there alone. A connection dropped mid-download now rejects rather than leaving the caller waiting forever ([#2185](https://github.com/eclipse-openvsx/openvsx/pull/2185))
 
 #### Changed
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -17,7 +17,7 @@ This change log covers only the command line interface (CLI) of Open VSX.
 
 #### Fixed
 
-- Fix downloads that could be read before they were written. `download` resolved when the response ended rather than when the file was closed, and a write stream opens and flushes asynchronously, so a caller reading the path immediately afterwards could find the file empty or absent - which `verify` did, intermittently failing to read the public key it had just fetched. An error response is no longer written into the file either ([#2184](https://github.com/eclipse-openvsx/openvsx/pull/2184))
+- Fix downloads that could be read before they were written. `download` resolved when the response ended rather than when the file was closed, and a write stream opens and flushes asynchronously, so a caller reading the path immediately afterwards could find the file empty or absent - which `verify` did, intermittently failing to read the public key it had just fetched. An error response is no longer written into the file either ([#2185](https://github.com/eclipse-openvsx/openvsx/pull/2185))
 
 #### Changed
 

--- a/cli/src/registry.ts
+++ b/cli/src/registry.ts
@@ -211,21 +211,28 @@ export class Registry {
             const requestOptions = this.getRequestOptions();
             const request = this.getProtocol(url)
                                 .request(url, requestOptions, response => {
-                response.on('end', () => {
-                    if (response.statusCode !== undefined && (response.statusCode < 200 || response.statusCode > 299)) {
-                        reject(statusError(response));
-                    } else {
-                        resolve();
-                    }
-                });
+                // Checked before anything is piped, so an error page is not written into the file the
+                // caller is about to read.
+                if (response.statusCode !== undefined && (response.statusCode < 200 || response.statusCode > 299)) {
+                    response.resume();
+                    stream.destroy();
+                    reject(statusError(response));
+                    return;
+                }
+
+                // Resolved on the file being closed rather than on the response ending. The two are
+                // not the same: createWriteStream opens and flushes asynchronously, so the last byte
+                // having arrived says nothing about the file existing yet, let alone holding the
+                // bytes. Callers that read the path straight afterwards saw an empty file, or none.
+                stream.on('close', () => resolve());
                 response.pipe(stream);
             });
             stream.on('error', (err: Error) => {
-                request.abort();
+                request.destroy();
                 reject(err);
             });
             request.on('error', (err: Error) => {
-                stream.close();
+                stream.destroy();
                 reject(err);
             });
             request.end();

--- a/cli/src/registry.ts
+++ b/cli/src/registry.ts
@@ -10,6 +10,7 @@
 
 import * as http from 'http';
 import * as fs from 'fs';
+import { pipeline } from 'stream';
 import * as followRedirects from 'follow-redirects';
 import { RegistryOptions } from './registry-options';
 import { rejectError, statusError, withStatus } from './util';
@@ -207,7 +208,18 @@ export class Registry {
 
     download(file: string, url: URL): Promise<void> {
         return new Promise((resolve, reject) => {
+            // Written beside the target and renamed into place on success, so the caller's path holds
+            // either what it held before or the whole download, never part of one. Deferring the open
+            // until the status is known is not enough on its own: a connection dropped mid-body has
+            // already truncated the file by then, and `get` is handed a path the user chose.
+            const partial = `${file}.part`;
             let stream: fs.WriteStream | undefined;
+
+            const fail = (err: Error) => {
+                stream?.destroy();
+                fs.rm(partial, { force: true }, () => reject(err));
+            };
+
             const requestOptions = this.getRequestOptions();
             const request = this.getProtocol(url)
                                 .request(url, requestOptions, response => {
@@ -217,27 +229,28 @@ export class Registry {
                     return;
                 }
 
-                // Opened only once the response is known to be one worth keeping. createWriteStream
-                // truncates on open, so opening before the status is known empties whatever is at the
-                // path for a request that then turns out to have failed - and `get` is handed a path
-                // the user chose, not a temporary one.
-                stream = fs.createWriteStream(file);
-                stream.on('error', (err: Error) => {
-                    request.destroy();
-                    reject(err);
-                });
+                stream = fs.createWriteStream(partial);
 
-                // Resolved on the file being closed rather than on the response ending. The two are
-                // not the same: a write stream opens and flushes asynchronously, so the last byte
-                // having arrived says nothing about the file existing yet, let alone holding the
-                // bytes. Callers that read the path straight afterwards saw an empty file, or none.
-                stream.on('close', () => resolve());
-                response.pipe(stream);
+                // pipeline rather than response.pipe: pipe installs its own error handler on the
+                // source, so a connection dropped mid-body is swallowed - the write stream is never
+                // ended, nothing settles, and the caller waits for a file that will never arrive.
+                // pipeline propagates that error and tears both ends down. Its callback also waits
+                // for the file to close, which matters in its own right: a write stream opens and
+                // flushes asynchronously, so the last byte having arrived says nothing about the
+                // file being on disk.
+                pipeline(response, stream, (err: NodeJS.ErrnoException | null) => {
+                    if (err) {
+                        fail(err);
+                    } else if (!response.complete) {
+                        // A body cut short still ends the stream cleanly; `complete` is what tells
+                        // that apart from having received all of it.
+                        fail(new Error(`The connection closed before the whole of ${url} was received.`));
+                    } else {
+                        fs.rename(partial, file, renameErr => renameErr ? fail(renameErr) : resolve());
+                    }
+                });
             });
-            request.on('error', (err: Error) => {
-                stream?.destroy();
-                reject(err);
-            });
+            request.on('error', (err: Error) => fail(err));
             request.end();
         });
     }

--- a/cli/src/registry.ts
+++ b/cli/src/registry.ts
@@ -207,32 +207,35 @@ export class Registry {
 
     download(file: string, url: URL): Promise<void> {
         return new Promise((resolve, reject) => {
-            const stream = fs.createWriteStream(file);
+            let stream: fs.WriteStream | undefined;
             const requestOptions = this.getRequestOptions();
             const request = this.getProtocol(url)
                                 .request(url, requestOptions, response => {
-                // Checked before anything is piped, so an error page is not written into the file the
-                // caller is about to read.
                 if (response.statusCode !== undefined && (response.statusCode < 200 || response.statusCode > 299)) {
                     response.resume();
-                    stream.destroy();
                     reject(statusError(response));
                     return;
                 }
 
+                // Opened only once the response is known to be one worth keeping. createWriteStream
+                // truncates on open, so opening before the status is known empties whatever is at the
+                // path for a request that then turns out to have failed - and `get` is handed a path
+                // the user chose, not a temporary one.
+                stream = fs.createWriteStream(file);
+                stream.on('error', (err: Error) => {
+                    request.destroy();
+                    reject(err);
+                });
+
                 // Resolved on the file being closed rather than on the response ending. The two are
-                // not the same: createWriteStream opens and flushes asynchronously, so the last byte
+                // not the same: a write stream opens and flushes asynchronously, so the last byte
                 // having arrived says nothing about the file existing yet, let alone holding the
                 // bytes. Callers that read the path straight afterwards saw an empty file, or none.
                 stream.on('close', () => resolve());
                 response.pipe(stream);
             });
-            stream.on('error', (err: Error) => {
-                request.destroy();
-                reject(err);
-            });
             request.on('error', (err: Error) => {
-                stream.destroy();
+                stream?.destroy();
                 reject(err);
             });
             request.end();

--- a/cli/test/unit/registry-download.spec.ts
+++ b/cli/test/unit/registry-download.spec.ts
@@ -84,19 +84,33 @@ describe('Registry.download', () => {
         expect(fs.readFileSync(file, 'utf-8')).toBe(body);
     });
 
-    // An error response used to be piped into the file before the promise rejected, leaving the error
-    // page behind at the path the caller had been given.
-    it('rejects without writing the error response into the file', async () => {
+    // An error response used to be piped into the file before the promise rejected, and the write
+    // stream was opened before the status was known at all - so a failed download truncated whatever
+    // was already at the path. `get` is handed a path the user chose, so that is their file.
+    it('leaves an existing file untouched when the download fails', async () => {
         const url = await serve((_, res) => {
             res.writeHead(404, { 'Content-Type': 'text/plain' });
             res.end('no such thing');
         });
         const registry = new Registry({ registryUrl: url });
-        const file = tempPath('.pem');
+        const file = tempPath('.vsix');
+        fs.writeFileSync(file, 'the file the user already had');
 
         await expect(registry.download(file, new URL(`${url}/missing`))).rejects.toThrow('status 404');
 
-        const written = fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : '';
-        expect(written).not.toContain('no such thing');
+        expect(fs.readFileSync(file, 'utf-8')).toBe('the file the user already had');
+    });
+
+    it('does not create the file at all when the download fails', async () => {
+        const url = await serve((_, res) => {
+            res.writeHead(404, { 'Content-Type': 'text/plain' });
+            res.end('no such thing');
+        });
+        const registry = new Registry({ registryUrl: url });
+        const file = tempPath('.vsix');
+
+        await expect(registry.download(file, new URL(`${url}/missing`))).rejects.toThrow('status 404');
+
+        expect(fs.existsSync(file)).toBe(false);
     });
 });

--- a/cli/test/unit/registry-download.spec.ts
+++ b/cli/test/unit/registry-download.spec.ts
@@ -1,0 +1,102 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { AddressInfo } from 'node:net';
+import { Registry } from '../../src/registry';
+
+// registry.ts imports 'fs', so the mock has to name the same specifier. Everything but
+// createWriteStream is the real module; that one is wrapped only to record when the file closes.
+const recorder = vi.hoisted(() => ({ events: [] as string[] }));
+vi.mock('fs', async importOriginal => {
+    const actual = await importOriginal<typeof import('fs')>();
+    return {
+        ...actual,
+        createWriteStream: (...args: Parameters<typeof actual.createWriteStream>) => {
+            const stream = actual.createWriteStream(...args);
+            stream.on('close', () => recorder.events.push('file closed'));
+            return stream;
+        }
+    };
+});
+
+describe('Registry.download', () => {
+
+    const servers: http.Server[] = [];
+    const files: string[] = [];
+
+    afterEach(async () => {
+        for (const file of files.splice(0)) {
+            fs.rmSync(file, { force: true });
+        }
+        for (const server of servers.splice(0)) {
+            await new Promise<void>(resolve => server.close(() => resolve()));
+        }
+    });
+
+    async function serve(handler: http.RequestListener): Promise<string> {
+        const server = http.createServer(handler);
+        servers.push(server);
+        await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+        return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    }
+
+    function tempPath(suffix: string): string {
+        const file = path.join(os.tmpdir(), `ovsx-download-test-${process.pid}-${Math.random().toString(36).slice(2)}${suffix}`);
+        files.push(file);
+        return file;
+    }
+
+    // The promise used to settle when the response ended, which says nothing about the file: a write
+    // stream opens and flushes asynchronously, so a caller reading the path straight afterwards could
+    // find it empty, or not yet created at all. Small bodies are the worst case, because the response
+    // is over before the filesystem has caught up - which is why the tiny public key download was the
+    // one that kept failing.
+    //
+    // Asserted as an ordering rather than by racing it: the file being closed must come first. Timing
+    // the race directly makes for a test that only sometimes notices, since it reproduces a few times
+    // in a hundred.
+    it('resolves only after the file has been closed, not when the response ends', async () => {
+        const body = '-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA\n-----END PUBLIC KEY-----\n';
+        const url = await serve((_, res) => {
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end(body);
+        });
+        const registry = new Registry({ registryUrl: url });
+        const file = tempPath('.pem');
+
+        recorder.events.length = 0;
+        await registry.download(file, new URL(`${url}/publickey`));
+        recorder.events.push('download resolved');
+
+        expect(recorder.events).toEqual(['file closed', 'download resolved']);
+        expect(fs.readFileSync(file, 'utf-8')).toBe(body);
+    });
+
+    // An error response used to be piped into the file before the promise rejected, leaving the error
+    // page behind at the path the caller had been given.
+    it('rejects without writing the error response into the file', async () => {
+        const url = await serve((_, res) => {
+            res.writeHead(404, { 'Content-Type': 'text/plain' });
+            res.end('no such thing');
+        });
+        const registry = new Registry({ registryUrl: url });
+        const file = tempPath('.pem');
+
+        await expect(registry.download(file, new URL(`${url}/missing`))).rejects.toThrow('status 404');
+
+        const written = fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : '';
+        expect(written).not.toContain('no such thing');
+    });
+});

--- a/cli/test/unit/registry-download.spec.ts
+++ b/cli/test/unit/registry-download.spec.ts
@@ -101,6 +101,29 @@ describe('Registry.download', () => {
         expect(fs.readFileSync(file, 'utf-8')).toBe('the file the user already had');
     });
 
+    // A connection dropped mid-body used to leave the promise unsettled forever: pipe installs its
+    // own error handler on the response, so the error was swallowed, the write stream never ended and
+    // nothing ever resolved or rejected. The partial write also landed on the caller's path.
+    it('rejects rather than hanging when the connection drops mid-download', async () => {
+        const url = await serve((_, res) => {
+            res.writeHead(200, { 'Content-Length': '1000' });
+            res.write(Buffer.alloc(100, 'x'));
+            setTimeout(() => res.socket?.destroy(), 30);
+        });
+        const registry = new Registry({ registryUrl: url });
+        const file = tempPath('.vsix');
+        fs.writeFileSync(file, 'the file the user already had');
+
+        const outcome = await Promise.race([
+            registry.download(file, new URL(`${url}/truncated`)).then(() => 'resolved', () => 'rejected'),
+            new Promise<string>(resolve => setTimeout(() => resolve('never settled'), 4000))
+        ]);
+
+        expect(outcome).toBe('rejected');
+        expect(fs.readFileSync(file, 'utf-8')).toBe('the file the user already had');
+        expect(fs.existsSync(`${file}.part`), 'the partial download should be cleaned up').toBe(false);
+    });
+
     it('does not create the file at all when the download fails', async () => {
         const url = await serve((_, res) => {
             res.writeHead(404, { 'Content-Type': 'text/plain' });


### PR DESCRIPTION
The `verify` failure that has now shown up twice in CI is not a flaky test — it is a real race in `Registry.download`.

```
FAIL test/unit/verify.spec.ts > verify > reports a valid signature as verified
Error: ENOENT: no such file or directory, open '/tmp/tmp-2487-4Bpl3i13tJKF-.pem'
 ❯ downloadPublicKey src/verify.ts:103
```

## What is actually wrong

```ts
const stream = fs.createWriteStream(file);
const request = ...request(url, requestOptions, response => {
    response.on('end', () => { ... resolve(); });   // <- the response, not the file
    response.pipe(stream);
});
```

The promise settles on the **response**'s `end` event. That means the last byte has arrived, not that the file exists: `fs.createWriteStream` opens and flushes asynchronously. A caller that reads the path immediately afterwards — which `downloadPublicKey` does — can find the file empty, or not yet created at all.

`createTempFile` uses `tmp.tmpName()`, which only generates a name and does not create anything, so there is nothing on disk until the write stream gets there.

## Why the public key specifically

The smallest downloads are the worst case: the response is over before the filesystem has caught up. The public key is a few hundred bytes; the sigzip fetched a few lines earlier is larger and has never failed.

Reproduced outside the test suite, 200 serial downloads of a public-key-sized body through the exact current implementation:

```
after await: complete=195  empty=5  MISSING(ENOENT)=0   of 200
```

Counter-intuitively, bigger bodies are *safer* — backpressure means most flushing has already happened by the time the response ends:

```
 1MB body, original download(): incomplete on 1/10 runs
 8MB body, original download(): incomplete on 0/10 runs
32MB body, original download(): incomplete on 0/10 runs
```

Which is why the tiny one is the one that breaks.

## The fix

Resolve on the write stream's `close` rather than the response's `end`. Two things came along with it:

- **The status check moved ahead of the pipe.** It used to run inside `response.on('end')`, *after* the body had been piped into the file — so a 404 both rejected and left the error page at the path the caller was given. `statusError` only reads the status line, so checking early costs nothing.
- **`request.abort()` → `request.destroy()`**, the former being deprecated.

## The test

Two, in a new `test/unit/registry-download.spec.ts`.

The first asserts an **ordering** — file closed, then promise resolved — rather than racing it. A timing test would only sometimes notice, since the race reproduces a few times in a hundred; I wrote that version first and watched it pass against the broken code. Recording the `close` event needs the `fs` module wrapped, since vitest cannot spy on an ESM namespace:

```ts
vi.mock('fs', async importOriginal => {
    const actual = await importOriginal<typeof import('fs')>();
    return { ...actual, createWriteStream: (...args) => { /* record close */ } };
});
```

The second covers the error-body case.

Both fail against the previous implementation on every run:

```
run 1:  Tests 2 failed (2)
run 2:  Tests 2 failed (2)
run 3:  Tests 2 failed (2)

AssertionError: expected [ 'download resolved' ] to deeply equal [ 'file closed', 'download resolved' ]
```

Full CLI suite green (102 tests across 11 files), lint and build clean.

## Scope

`download` is used by `verify` for the signature and public key, and by `get`. The same defect applies to all of them — `verify` is simply the one that reads the file straight back and so notices.
