### PR TITLE
build: check that doc/configuration.md documents the properties the server binds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,13 @@ repos:
       language: system
       require_serial: true
       files: ^server/src/(main|test)/java/.*\.java$
+    - id: config-properties-check
+      name: server -> configuration properties documented in doc/configuration.md
+      entry: server/scripts/config-properties-check.sh
+      language: system
+      require_serial: true
+      pass_filenames: false
+      files: ^(server/src/main/java/.*\.java|server/scripts/(config-properties-check\.sh|config-properties-baseline\.txt|src/ConfigPropertiesReport\.java)|doc/configuration\.md)$
     - id: formatter-version-check
       name: server -> formatter dependency versions (jdt.core, spotless-lib)
       entry: server/scripts/formatter-version-check.sh

--- a/server/scripts/config-properties-baseline.txt
+++ b/server/scripts/config-properties-baseline.txt
@@ -1,0 +1,111 @@
+# Gaps this check tolerates, one per line as "<kind> <key>":
+#
+#   undocumented  the server binds it, doc/configuration.md does not document it
+#   unbound       doc/configuration.md documents it, the server binds nothing by that name
+#
+# The list may only shrink. Documenting a property, or correcting a stale entry in the reference,
+# means deleting its line here; the check fails while a line claims a gap that no longer exists.
+#
+# The ovsx.oauth2.attribute-names entries are the standing exception: the key names a login
+# provider chosen by the operator, so the reference documents the family with a [provider-name]
+# placeholder that no scan of the source can produce. Those lines stay.
+
+unbound ovsx.caching.extensionquery-ids.max-size
+unbound ovsx.caching.extensionquery-ids.ttl
+unbound ovsx.caching.extensionquery-results.max-size
+unbound ovsx.caching.extensionquery-results.ttl
+unbound ovsx.eclipse.publisher-agreement.timezone
+unbound ovsx.elasticsearch.relevance.downloads
+unbound ovsx.elasticsearch.relevance.rating
+unbound ovsx.elasticsearch.relevance.timestamp
+unbound ovsx.elasticsearch.relevance.unverified
+unbound ovsx.oauth2.attribute-names.[provider-name].avatar-url
+unbound ovsx.oauth2.attribute-names.[provider-name].email
+unbound ovsx.oauth2.attribute-names.[provider-name].full-name
+unbound ovsx.oauth2.attribute-names.[provider-name].login-name
+unbound ovsx.oauth2.attribute-names.[provider-name].provider-url
+unbound ovsx.redis.embedded
+
+undocumented ovsx.access-token.token-hash-accept-unpeppered
+undocumented ovsx.access-token.token-hash-algorithm
+undocumented ovsx.access-token.token-hash-pepper
+undocumented ovsx.access-token.token-hash-previous-peppers
+undocumented ovsx.caching.customer.max-size
+undocumented ovsx.caching.customer.tti
+undocumented ovsx.caching.files-webresource.max-file-size
+undocumented ovsx.caching.files-webresource.max-total-size
+undocumented ovsx.caching.rate-limit-token.max-size
+undocumented ovsx.caching.rate-limit-token.ttl
+undocumented ovsx.caching.setting.ttl
+undocumented ovsx.caching.tier.max-size
+undocumented ovsx.caching.tier.tti
+undocumented ovsx.caching.usage.ttl
+undocumented ovsx.changes-feed.lag
+undocumented ovsx.cors.public-origins
+undocumented ovsx.data.mirror.exclude-extensions
+undocumented ovsx.data.mirror.include-extensions
+undocumented ovsx.extension-control.delete-transitively
+undocumented ovsx.extension-query.max-pre-release-versions
+undocumented ovsx.logs.aws.max-keys
+undocumented ovsx.migrations.batch-size
+undocumented ovsx.migrations.cron
+undocumented ovsx.oauth2.attribute-names
+undocumented ovsx.publishing.max-internal-tags
+undocumented ovsx.publishing.max-tags
+undocumented ovsx.rate-limit.default-http-content-type
+undocumented ovsx.rate-limit.default-http-response-body
+undocumented ovsx.rate-limit.default-http-status-code
+undocumented ovsx.rate-limit.enabled
+undocumented ovsx.rate-limit.filters
+undocumented ovsx.rate-limit.ip-address-function
+undocumented ovsx.rate-limit.token-prefix
+undocumented ovsx.rate-limit.usage-stats
+undocumented ovsx.scanning.blocklist-check.enabled
+undocumented ovsx.scanning.blocklist-check.enforced
+undocumented ovsx.scanning.blocklist-check.required
+undocumented ovsx.scanning.blocklist-check.user-message
+undocumented ovsx.scanning.configured
+undocumented ovsx.scanning.enabled
+undocumented ovsx.scanning.max-archive-size-bytes
+undocumented ovsx.scanning.max-entry-count
+undocumented ovsx.scanning.max-single-file-bytes
+undocumented ovsx.scanning.namespace-ownership-check.check-active-extensions
+undocumented ovsx.scanning.namespace-ownership-check.enabled
+undocumented ovsx.scanning.namespace-ownership-check.enforced
+undocumented ovsx.scanning.namespace-ownership-check.gallery-url
+undocumented ovsx.scanning.namespace-ownership-check.required
+undocumented ovsx.scanning.secret-detection.debug-preview-chars
+undocumented ovsx.scanning.secret-detection.enabled
+undocumented ovsx.scanning.secret-detection.enforced
+undocumented ovsx.scanning.secret-detection.gitleaks.auto-fetch
+undocumented ovsx.scanning.secret-detection.gitleaks.force-refresh
+undocumented ovsx.scanning.secret-detection.gitleaks.output-path
+undocumented ovsx.scanning.secret-detection.gitleaks.refresh-cron
+undocumented ovsx.scanning.secret-detection.gitleaks.scheduled-refresh
+undocumented ovsx.scanning.secret-detection.gitleaks.skip-rule-ids
+undocumented ovsx.scanning.secret-detection.long-line-no-space-threshold
+undocumented ovsx.scanning.secret-detection.max-findings
+undocumented ovsx.scanning.secret-detection.minified-line-threshold
+undocumented ovsx.scanning.secret-detection.regex-context-chars
+undocumented ovsx.scanning.secret-detection.required
+undocumented ovsx.scanning.secret-detection.rules-path
+undocumented ovsx.scanning.secret-detection.suppression-markers
+undocumented ovsx.scanning.secret-detection.timeout-check-interval
+undocumented ovsx.scanning.secret-detection.timeout-seconds
+undocumented ovsx.scanning.similarity.allow-similarity-to-own-names
+undocumented ovsx.scanning.similarity.enabled
+undocumented ovsx.scanning.similarity.enforced
+undocumented ovsx.scanning.similarity.only-check-new-extensions
+undocumented ovsx.scanning.similarity.only-protect-verified-names
+undocumented ovsx.scanning.similarity.required
+undocumented ovsx.scanning.similarity.similarity-threshold
+undocumented ovsx.scanning.similarity.skip-if-publisher-verified
+undocumented ovsx.storage.file-cache-duration
+undocumented ovsx.trusted-publishing.active-providers
+undocumented ovsx.trusted-publishing.audience
+undocumented ovsx.trusted-publishing.enabled
+undocumented ovsx.trusted-publishing.forbidden-jwt-headers
+undocumented ovsx.trusted-publishing.gitlab
+undocumented ovsx.trusted-publishing.token-expiration
+undocumented ovsx.upstream.proxy.enabled
+undocumented ovsx.webui.additional-routes

--- a/server/scripts/config-properties-check.sh
+++ b/server/scripts/config-properties-check.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Checks that every ovsx.* property the server binds is documented in doc/configuration.md, and
+# that the reference names no property the server does not bind. The bound set comes from
+# scripts/config-properties-report.sh, so there is no second scanner to keep in sync.
+#
+# Known gaps live in scripts/config-properties-baseline.txt and may only shrink: documenting a
+# property means deleting its line there, and this fails until it is deleted.
+#
+# Usage: config-properties-check.sh
+
+set -eu
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SERVER_ROOT=$( dirname "${SCRIPT_DIR}" )
+REPO_ROOT=$( dirname "${SERVER_ROOT}" )
+
+REFERENCE="${REPO_ROOT}/doc/configuration.md"
+BASELINE="${SCRIPT_DIR}/config-properties-baseline.txt"
+
+cd "${SERVER_ROOT}"
+
+WORK=$( mktemp -d )
+trap 'rm -rf "${WORK}"' EXIT
+
+jbang scripts/src/ConfigPropertiesReport.java --keys | grep '^ovsx\.' | sort -u > "${WORK}/bound"
+
+# Each property is introduced by a "| Property | `key`" row; a mention anywhere else in the prose
+# is a cross-reference, not a definition, and must not count as documenting it.
+# shellcheck disable=SC2016  # the backticks are markdown, not command substitution
+grep -E '^\| Property +\| `' "${REFERENCE}" \
+    | sed -E 's/^\| Property +\| `([^`]+)`.*/\1/' \
+    | sort -u > "${WORK}/documented"
+
+baseline() {
+    { grep -E "^${1} " "${BASELINE}" || true; } | awk '{ print $2 }' | sort -u
+}
+baseline undocumented > "${WORK}/baseline-undocumented"
+baseline unbound > "${WORK}/baseline-unbound"
+
+comm -23 "${WORK}/bound" "${WORK}/documented" > "${WORK}/undocumented"
+comm -13 "${WORK}/bound" "${WORK}/documented" > "${WORK}/unbound"
+
+STATUS=0
+
+complain() {
+    local file=$1 heading=$2 remedy=$3
+    if [ -s "${file}" ]; then
+        echo
+        echo "${heading}"
+        sed 's/^/  /' "${file}"
+        echo "${remedy}"
+        STATUS=1
+    fi
+}
+
+comm -23 "${WORK}/undocumented" "${WORK}/baseline-undocumented" > "${WORK}/new-undocumented"
+complain "${WORK}/new-undocumented" \
+    "These properties are read by the server but not documented in doc/configuration.md:" \
+    "Add a section for each, or add 'undocumented <key>' to scripts/config-properties-baseline.txt."
+
+comm -23 "${WORK}/unbound" "${WORK}/baseline-unbound" > "${WORK}/new-unbound"
+complain "${WORK}/new-unbound" \
+    "doc/configuration.md documents these, but the server binds nothing by that name:" \
+    "Remove or rename them in the reference, or add 'unbound <key>' to scripts/config-properties-baseline.txt."
+
+comm -13 "${WORK}/undocumented" "${WORK}/baseline-undocumented" > "${WORK}/fixed-undocumented"
+complain "${WORK}/fixed-undocumented" \
+    "These are listed as undocumented in the baseline but are now documented:" \
+    "Delete their lines from scripts/config-properties-baseline.txt - it may only shrink."
+
+comm -13 "${WORK}/unbound" "${WORK}/baseline-unbound" > "${WORK}/fixed-unbound"
+complain "${WORK}/fixed-unbound" \
+    "These are listed as unbound in the baseline but the reference no longer has that problem:" \
+    "Delete their lines from scripts/config-properties-baseline.txt - it may only shrink."
+
+if [ "${STATUS}" -eq 0 ]; then
+    TOLERATED=$( grep -cE '^(undocumented|unbound) ' "${BASELINE}" || true )
+    echo "$( wc -l < "${WORK}/bound" | tr -d ' ' ) properties bound, $( wc -l < "${WORK}/documented" | tr -d ' ' ) documented, ${TOLERATED} gaps tolerated by the baseline."
+fi
+
+exit "${STATUS}"

--- a/server/scripts/src/ConfigPropertiesReport.java
+++ b/server/scripts/src/ConfigPropertiesReport.java
@@ -52,6 +52,12 @@ void main(String[] args) throws IOException {
         }
     }
 
+    // One key per line, for scripts/config-properties-check.sh - the report below is for reading.
+    if (List.of(args).contains("--keys")) {
+        entries.keySet().forEach(System.out::println);
+        return;
+    }
+
     System.out.println("# Configuration properties");
     System.out.println();
     System.out.println(


### PR DESCRIPTION
Follows #2191 and #2192.

Makes the drift that motivated #2191 impossible to reintroduce quietly.

## The gap it measures

Run against `main` today, using the scanner rather than a hand-rolled grep:

| | count |
|---|---|
| `ovsx.*` properties the server binds | 203 |
| documented in `doc/configuration.md` | 135 |
| bound but undocumented | 83 |
| documented but bound nowhere | 15 |

These supersede the figures in #2191, which I took from a crude `${...}` grep of the working tree.
`config-properties-report.sh` also reads `@ConfigurationProperties` fields and
`@ConditionalOnProperty`, which that grep missed, and my working tree carried two unmerged
properties. The direction of the conclusion is unchanged, the numbers are simply right now.

## How it works

`server/scripts/config-properties-check.sh` compares two sets:

- **Bound**: `config-properties-report.sh --keys`, a new mode on the existing scanner that prints
  the keys alone. No second scanner to keep in sync.
- **Documented**: the `| Property | \`key\`` rows of `doc/configuration.md`. A mention anywhere else
  is a cross-reference rather than a definition and deliberately does not count as documenting it.

Anything in either difference fails the build unless `config-properties-baseline.txt` lists it.

## The baseline is a ratchet

It holds the 98 gaps that exist today and **may only shrink**. Documenting a property means deleting
its line, and the check fails while a line claims a gap that no longer exists. So this lands green,
catches anything new from the first commit, and turns the outstanding work into a list that counts
down to zero rather than a red build nobody can fix in one sitting.

The five `ovsx.oauth2.attribute-names.[provider-name].*` entries are a standing exception rather
than outstanding work: the key names a login provider the operator chooses, so the reference
documents the family under a placeholder that no scan of the source can produce. The baseline says
so in a comment.

## Verified to fail when it should

Each of the three cases it exists for, checked by mutation:

| case | result |
|---|---|
| a newly bound property that is not documented | fails, naming `ovsx.probe.not-documented` |
| the reference documents something nothing binds | fails, naming `ovsx.probe.removed-long-ago` |
| a baseline line whose gap has been closed | fails, asking for the line to be deleted |

Clean run: `203 properties bound, 135 documented, 98 gaps tolerated by the baseline.`

## Wiring

A local pre-commit hook, running when `server/src/main/java/**`, `doc/configuration.md`, the
baseline or the scanner change. CI runs `prek --all-files`, so the `analyse` job runs it on every
pull request regardless. `shellcheck` passes on the new script, with one explicit `SC2016` waiver
where the backticks are markdown rather than command substitution.

## Follow-up

The corrections PR now has an exact worklist: the 83 undocumented properties (40 of them
`ovsx.scanning.*`, 10 `ovsx.caching.*`, 8 `ovsx.rate-limit.*`) and the 15 stale entries, each
deleted from the baseline as it is fixed.

One thing the scanner cannot see, worth its own look: `RateLimitConfig` uses
`@ConditionalOnProperty(prefix = RateLimitProperties.PROPERTY_PREFIX)`, a constant from another
file, so its keys are omitted and the script says so on stderr.

Prepared with Claude Code.
