### PR TITLE
docs: correct the properties the reference documents but the server does not bind

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -996,38 +996,6 @@ Rate-limiting time to idle duration. Does not apply to Redis cache manager.
 
 Maximum amount of rate-limiting entries to keep in cache. Does not apply to Redis cache manager.
 
-| Property      | `ovsx.caching.extensionquery-ids.ttl`
-|---------------|-------------------------
-| Type          | ISO 8601 duration
-| Default       | `PT1H`
-| Compatibility | Since 0.31.0
-
-VS Code adapter extensionquery public ids time to live duration. Does not apply to Redis cache manager.
-
-| Property      | `ovsx.caching.extensionquery-ids.max-size`
-|---------------|-------------------------
-| Type          | long
-| Default       | `1024`
-| Compatibility | Since 0.31.0
-
-Maximum amount of VS Code adapter extensionquery public ids to keep in cache. Does not apply to Redis cache manager.
-
-| Property      | `ovsx.caching.extensionquery-results.ttl`
-|---------------|-------------------------
-| Type          | ISO 8601 duration
-| Default       | `PT1H`
-| Compatibility | Since 0.31.0
-
-VS Code adapter extensionquery results time to live duration. Does not apply to Redis cache manager.
-
-| Property      | `ovsx.caching.extensionquery-results.max-size`
-|---------------|-------------------------
-| Type          | long
-| Default       | `1024`
-| Compatibility | Since 0.31.0
-
-Maximum amount of VS Code adapter extensionquery results to keep in cache. Does not apply to Redis cache manager.
-
 ## Personal Access Token
 
 | Property      | `ovsx.token-prefix`

--- a/server/scripts/config-properties-baseline.txt
+++ b/server/scripts/config-properties-baseline.txt
@@ -6,25 +6,18 @@
 # The list may only shrink. Documenting a property, or correcting a stale entry in the reference,
 # means deleting its line here; the check fails while a line claims a gap that no longer exists.
 #
-# The ovsx.oauth2.attribute-names entries are the standing exception: the key names a login
-# provider chosen by the operator, so the reference documents the family with a [provider-name]
-# placeholder that no scan of the source can produce. Those lines stay.
+# The remaining "unbound" lines are the standing exception rather than outstanding work: the key
+# names a login provider chosen by the operator, so the reference documents the family with a
+# [provider-name] placeholder that no scan of the source can produce. Those lines stay.
+#
+# A property the reference records as removed in some release needs no line here - the check reads
+# the Compatibility row and does not expect a tombstone to be bound.
 
-unbound ovsx.caching.extensionquery-ids.max-size
-unbound ovsx.caching.extensionquery-ids.ttl
-unbound ovsx.caching.extensionquery-results.max-size
-unbound ovsx.caching.extensionquery-results.ttl
-unbound ovsx.eclipse.publisher-agreement.timezone
-unbound ovsx.elasticsearch.relevance.downloads
-unbound ovsx.elasticsearch.relevance.rating
-unbound ovsx.elasticsearch.relevance.timestamp
-unbound ovsx.elasticsearch.relevance.unverified
 unbound ovsx.oauth2.attribute-names.[provider-name].avatar-url
 unbound ovsx.oauth2.attribute-names.[provider-name].email
 unbound ovsx.oauth2.attribute-names.[provider-name].full-name
 unbound ovsx.oauth2.attribute-names.[provider-name].login-name
 unbound ovsx.oauth2.attribute-names.[provider-name].provider-url
-unbound ovsx.redis.embedded
 
 undocumented ovsx.access-token.token-hash-accept-unpeppered
 undocumented ovsx.access-token.token-hash-algorithm

--- a/server/scripts/config-properties-check.sh
+++ b/server/scripts/config-properties-check.sh
@@ -27,10 +27,23 @@ jbang scripts/src/ConfigPropertiesReport.java --keys | grep '^ovsx\.' | sort -u 
 
 # Each property is introduced by a "| Property | `key`" row; a mention anywhere else in the prose
 # is a cross-reference, not a definition, and must not count as documenting it.
+#
+# A block whose Compatibility row says the property was removed is a tombstone, kept so that
+# someone upgrading from a config file that still sets it can find out what happened to it. It
+# describes a past release rather than this one, so it is not expected to be bound - and if it ever
+# is again, it shows up as undocumented, which is the right complaint.
 # shellcheck disable=SC2016  # the backticks are markdown, not command substitution
-grep -E '^\| Property +\| `' "${REFERENCE}" \
-    | sed -E 's/^\| Property +\| `([^`]+)`.*/\1/' \
-    | sort -u > "${WORK}/documented"
+awk '
+    /^\| Property +\| `/ {
+        if (key != "" && !removed) { print key }
+        match($0, /`[^`]+`/)
+        key = substr($0, RSTART + 1, RLENGTH - 2)
+        removed = 0
+        next
+    }
+    /^\| Compatibility +\|/ && /removed/ { removed = 1 }
+    END { if (key != "" && !removed) { print key } }
+' "${REFERENCE}" | sort -u > "${WORK}/documented"
 
 baseline() {
     { grep -E "^${1} " "${BASELINE}" || true; } | awk '{ print $2 }' | sort -u


### PR DESCRIPTION
Follows #2193. First tranche of the corrections: the 15 entries the check tolerates as documented
but not bound. Working through them showed that only four are actually wrong.

## Six are tombstones, and the check was wrong to flag them

`ovsx.redis.embedded` records its removal in 0.29.0, `ovsx.eclipse.publisher-agreement.timezone` in
0.15.2, and the four `ovsx.elasticsearch.relevance.*` entries in 0.18.0 - each naming the property
that replaced it:

```
| Compatibility | Since 0.1.0, **deprecated** in 0.2.0, **removed** in 0.18.0 (use `ovsx.search.relevance.rating`)
```

They exist so that someone upgrading with a config file that still sets one can find out what
happened to it. Deleting them to satisfy the check would have thrown that away, so the check now
reads the `Compatibility` row and does not expect a property recorded as removed to be bound.

The rule is self-documenting - the intent lives in the reference rather than in a baseline nobody
reads - and it fails in the useful direction: a tombstone for a property the server *does* bind is
reported as undocumented, which is exactly the right complaint. Verified by marking
`ovsx.registry.version` removed and watching the check flag it.

## Four are genuinely wrong and are deleted

`ovsx.caching.extensionquery-{ids,results}.{ttl,max-size}` are documented as present "Since
0.31.0", but `git log -S extensionquery` over `server/src/main/java/org/eclipse/openvsx/cache/`
returns nothing for the whole history: no such cache has ever existed, so nothing has ever read
these and setting them has never done anything.

## Five stay as a standing exception

The `ovsx.oauth2.attribute-names.[provider-name].*` family is documented under a placeholder,
because the operator names the login provider. No scan of the source can produce those keys, so
they keep their baseline lines, and the baseline comment now says why.

## Result

The baseline's unbound section goes from 15 lines to 5. Clean run:

```
203 properties bound, 125 documented, 88 gaps tolerated by the baseline.
```

The 83 undocumented properties are untouched here - 40 `ovsx.scanning.*`, 10 `ovsx.caching.*`, 8
`ovsx.rate-limit.*`, 6 `ovsx.trusted-publishing.*`, 4 `ovsx.access-token.*` and the rest - and come
next, deleting baseline lines as they are written.

Prepared with Claude Code.
