### PR TITLE
fix: stop deriving the base URL from untrusted X-Forwarded-* headers

### DIFF
--- a/deploy/docker/configuration/application.yml
+++ b/deploy/docker/configuration/application.yml
@@ -142,13 +142,10 @@ ovsx:
     key-pair: create # create, renew, delete, 'undefined'
   registry:
     version: <OPENVSX_VERSION>
-  # The absolute URL this registry is served at. Set it in any deployment reachable from the open web:
-  # absolute URLs in responses - download links, icons, API URLs - are otherwise derived per request
-  # from the X-Forwarded-Host/-Proto/-Prefix headers, which are only believed when the peer that sent
-  # them is in ovsx.server.trusted-proxies (loopback and the private ranges by default).
+  # Set this in any deployment reachable from the open web, or the URLs in a response are derived
+  # from headers the client sends. See doc/configuration.md, Server URL.
   #  server:
   #    url: https://openvsx.example
-  #    trusted-proxies: '127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10'
   storage:
     local:
       directory: /tmp

--- a/deploy/docker/configuration/application.yml
+++ b/deploy/docker/configuration/application.yml
@@ -142,6 +142,13 @@ ovsx:
     key-pair: create # create, renew, delete, 'undefined'
   registry:
     version: <OPENVSX_VERSION>
+  # The absolute URL this registry is served at. Set it in any deployment reachable from the open web:
+  # absolute URLs in responses - download links, icons, API URLs - are otherwise derived per request
+  # from the X-Forwarded-Host/-Proto/-Prefix headers, which are only believed when the peer that sent
+  # them is in ovsx.server.trusted-proxies (loopback and the private ranges by default).
+  #  server:
+  #    url: https://openvsx.example
+  #    trusted-proxies: '127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10'
   storage:
     local:
       directory: /tmp

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -114,13 +114,10 @@ data:
       elasticsearch:
         clear-on-start: true
         host: elasticsearch:9200
-      # The absolute URL this registry is served at. Set it in any deployment reachable from the open web:
-      # absolute URLs in responses - download links, icons, API URLs - are otherwise derived per request
-      # from the X-Forwarded-Host/-Proto/-Prefix headers, which are only believed when the peer that sent
-      # them is in ovsx.server.trusted-proxies (loopback and the private ranges by default).
+      # Set this in any deployment reachable from the open web, or the URLs in a response are derived
+      # from headers the client sends. See doc/configuration.md, Server URL.
       #  server:
       #    url: https://openvsx.example
-      #    trusted-proxies: '127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10'
       eclipse:
         base-url: https://api.eclipse.org
         publisher-agreement:

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -114,6 +114,13 @@ data:
       elasticsearch:
         clear-on-start: true
         host: elasticsearch:9200
+      # The absolute URL this registry is served at. Set it in any deployment reachable from the open web:
+      # absolute URLs in responses - download links, icons, API URLs - are otherwise derived per request
+      # from the X-Forwarded-Host/-Proto/-Prefix headers, which are only believed when the peer that sent
+      # them is in ovsx.server.trusted-proxies (loopback and the private ranges by default).
+      #  server:
+      #    url: https://openvsx.example
+      #    trusted-proxies: '127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10'
       eclipse:
         base-url: https://api.eclipse.org
         publisher-agreement:

--- a/deploy/openshift/application.yml
+++ b/deploy/openshift/application.yml
@@ -110,13 +110,10 @@ ovsx:
     key-pair: create # create, renew, delete, 'undefined'
   registry:
     version: 'OPENVSX_VERSION'
-  # The absolute URL this registry is served at. Set it in any deployment reachable from the open web:
-  # absolute URLs in responses - download links, icons, API URLs - are otherwise derived per request
-  # from the X-Forwarded-Host/-Proto/-Prefix headers, which are only believed when the peer that sent
-  # them is in ovsx.server.trusted-proxies (loopback and the private ranges by default).
+  # Set this in any deployment reachable from the open web, or the URLs in a response are derived
+  # from headers the client sends. See doc/configuration.md, Server URL.
   #  server:
   #    url: https://openvsx.example
-  #    trusted-proxies: '127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10'
   storage:
     local:
       directory: /tmp/extensions

--- a/deploy/openshift/application.yml
+++ b/deploy/openshift/application.yml
@@ -110,6 +110,13 @@ ovsx:
     key-pair: create # create, renew, delete, 'undefined'
   registry:
     version: 'OPENVSX_VERSION'
+  # The absolute URL this registry is served at. Set it in any deployment reachable from the open web:
+  # absolute URLs in responses - download links, icons, API URLs - are otherwise derived per request
+  # from the X-Forwarded-Host/-Proto/-Prefix headers, which are only believed when the peer that sent
+  # them is in ovsx.server.trusted-proxies (loopback and the private ranges by default).
+  #  server:
+  #    url: https://openvsx.example
+  #    trusted-proxies: '127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10'
   storage:
     local:
       directory: /tmp/extensions

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -65,6 +65,37 @@ Maximum number of author-declared tags to keep from a published package. Tags be
 
 Maximum number of internal tags - the ones the packaging tool generates, such as `__ext_yml` - to keep from a published package. Counted separately from the author's own tags; a negative value keeps all of them.
 
+## Server URL
+
+Where this registry is reachable, which is what the absolute URLs in a response - download
+links, icons, an extension's API URLs - are built from.
+
+Distinct from `ovsx.webui.url` below: that is where the web UI is served, which is the same host
+in the usual deployment but need not be, and is the upstream registry rather than this one in a
+mirror.
+
+| Property      | `ovsx.server.url`
+|---------------|---------------------
+| Type          | string
+| Default       |
+| Compatibility | Unreleased
+
+The absolute URL this registry is served at, e.g. `https://openvsx.example`, or `https://example.com/openvsx` when it is served under a path. Setting it takes the base URL out of the request altogether: the `X-Forwarded-*` headers are ignored, whoever sends them and however the proxies in front are configured, every node in a cluster agrees on what it emits, and the response cache holds one entry per extension rather than one per host that was asked for. Set it on any deployment reachable from the open web.
+
+Empty by default, which derives the base URL from each request and is only as trustworthy as `ovsx.server.trusted-proxies` is correct for the deployment.
+
+| Property      | `ovsx.server.trusted-proxies`
+|---------------|-----------------------------
+| Type          | string[]
+| Default       | `127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10`
+| Compatibility | Unreleased
+
+The peers whose `X-Forwarded-Host`, `X-Forwarded-Proto` and `X-Forwarded-Prefix` headers are read at all, as IP addresses or CIDR ranges, comma separated. Only consulted when `ovsx.server.url` is empty. The default is the loopback and private ranges, the same set Tomcat's `RemoteIpValve` trusts, because that is where a reverse proxy sits in a container or cluster deployment; a request from anywhere else is a client talking to this server directly and its forwarded headers are ignored.
+
+Needs extending for a proxy that reaches this server from a public address - a cloud load balancer not on the same private network is the usual case - or the registry starts emitting internal-host URLs, and logs a warning naming both properties when it does. `*` reads the headers from every peer.
+
+This decides whose headers are read, not whether their contents can be believed: a proxy that relays the client's `X-Forwarded-Host` instead of overwriting it is trusted here and still forwarding a value the client chose, so prefer `ovsx.server.url`.
+
 ## Web UI
 
 | Property      | `ovsx.webui.url`

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -74,6 +74,22 @@ Distinct from `ovsx.webui.url` below: that is where the web UI is served, which 
 in the usual deployment but need not be, and is the upstream registry rather than this one in a
 mirror.
 
+| Deployment | What to set |
+|---|---|
+| One public hostname, TLS terminated by a reverse proxy | `ovsx.server.url`, e.g. `https://openvsx.example` |
+| Served under a path, e.g. `https://example.com/openvsx` | `ovsx.server.url`, including the path |
+| No proxy, the server itself is on the internet | `ovsx.server.url`; `ovsx.server.trusted-proxies` may be emptied to ignore the forwarded headers outright |
+| The proxy reaches the server from a public address, e.g. a cloud load balancer | `ovsx.server.url`; or add that address to `ovsx.server.trusted-proxies` |
+| A mirror | `ovsx.server.url` is the mirror's own URL, not `ovsx.upstream.url` or `ovsx.webui.url` |
+| Several hostnames answered by one registry | Leave `ovsx.server.url` unset, and make sure the proxy *overwrites* `X-Forwarded-Host` rather than passing on what the client sent |
+| Local development | Nothing: the server is reached over loopback, which is trusted by default |
+
+If the URLs in a response name an **internal host or port**, the proxy is not in
+`ovsx.server.trusted-proxies` and its headers are being ignored; the server logs a warning naming
+both properties the first time that happens. If they name a **host nobody configured**, the proxy is
+passing on the client's `X-Forwarded-Host` instead of overwriting it, and `ovsx.server.url` is the
+answer. Either way the wrong URLs are cached, so flush the caches after fixing it.
+
 | Property      | `ovsx.server.url`
 |---------------|---------------------
 | Type          | string

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -63,6 +63,15 @@ It is possible to [configure another Open VSX instance as upstream](configuratio
 A reverse proxy can be used to make an Open VSX instance available over HTTPS. The rest of this
 section shows how to configure [NGINX](https://nginx.org/) as that reverse proxy.
 
+Set [`ovsx.server.url`](configuration.md#server-url) to the URL the registry is served at when you
+put a proxy in front of it. The absolute URLs in a response - download links, icons, an extension's
+API URLs - are otherwise derived from the `X-Forwarded-Host`, `X-Forwarded-Proto` and
+`X-Forwarded-Prefix` headers of each request, and those are written by whoever sent the request.
+They are only read from a peer in
+[`ovsx.server.trusted-proxies`](configuration.md#server-url), which by default is the loopback and
+private ranges; a proxy reaching the server from a public address needs that list extended, or the
+registry emits internal-host URLs.
+
 ### 1. Create an OpenSSL Self-Signed Certificate
 
 If you don't have a self-signed certificate, you can create one using the following steps:
@@ -118,7 +127,11 @@ server {
     location / {
         proxy_pass http://<YOUR_PUBLIC_IP>:8080;
         proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-Host $host;
+        # A literal, not $host: $host is the Host header the client sent, and this server block is
+        # the default for the port, so a request naming any host at all reaches it. Forwarding that
+        # would let a client choose the host in the URLs the registry emits, and those responses are
+        # cached and served to everyone else. Setting ovsx.server.url settles it regardless.
+        proxy_set_header X-Forwarded-Host <YOUR_PUBLIC_IP>;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
     }

--- a/server/src/dev/resources/application.yml
+++ b/server/src/dev/resources/application.yml
@@ -141,6 +141,13 @@ ovsx:
     key-pair: create # create, renew, delete, 'undefined'
   registry:
     version: 'v1.2.0-dev'
+  # The absolute URL this registry is served at. Set it in any deployment reachable from the open web:
+  # absolute URLs in responses - download links, icons, API URLs - are otherwise derived per request
+  # from the X-Forwarded-Host/-Proto/-Prefix headers, which are only believed when the peer that sent
+  # them is in ovsx.server.trusted-proxies (loopback and the private ranges by default).
+  #  server:
+  #    url: https://openvsx.example
+  #    trusted-proxies: '127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10'
   storage:
     # an example config using minio (use docker compose --profile minio up)
     # and login to localhost:9000 and create a bucket with name test

--- a/server/src/dev/resources/application.yml
+++ b/server/src/dev/resources/application.yml
@@ -141,13 +141,10 @@ ovsx:
     key-pair: create # create, renew, delete, 'undefined'
   registry:
     version: 'v1.2.0-dev'
-  # The absolute URL this registry is served at. Set it in any deployment reachable from the open web:
-  # absolute URLs in responses - download links, icons, API URLs - are otherwise derived per request
-  # from the X-Forwarded-Host/-Proto/-Prefix headers, which are only believed when the peer that sent
-  # them is in ovsx.server.trusted-proxies (loopback and the private ranges by default).
+  # Set this in any deployment reachable from the open web, or the URLs in a response are derived
+  # from headers the client sends. See doc/configuration.md, Server URL.
   #  server:
   #    url: https://openvsx.example
-  #    trusted-proxies: '127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10'
   storage:
     # an example config using minio (use docker compose --profile minio up)
     # and login to localhost:9000 and create a bucket with name test

--- a/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
+++ b/server/src/main/java/org/eclipse/openvsx/util/UrlUtil.java
@@ -298,7 +298,14 @@ public final class UrlUtil {
             if (forwardedHosts.length > 1) {
                 forwardedHost = forwardedHosts[0];
             }
+            // An IPv6 literal is bracketed and made of colons, so only a colon after the closing
+            // bracket separates a port - without this, `[2001:db8::1]` parses as the host
+            // `[2001:db8:` on a port that is not a number.
             int colonIndex = forwardedHost.lastIndexOf(':');
+            if (forwardedHost.startsWith("[")) {
+                var closingBracket = forwardedHost.indexOf(']');
+                colonIndex = closingBracket >= 0 && colonIndex > closingBracket ? colonIndex : -1;
+            }
             if (colonIndex > 0) {
                 int port;
                 try {

--- a/server/src/main/java/org/eclipse/openvsx/web/ServerUrlConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/ServerUrlConfig.java
@@ -1,0 +1,221 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.web;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import jakarta.annotation.PostConstruct;
+import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.security.web.util.matcher.IpAddressMatcher;
+
+/**
+ * Where this registry believes it is reachable, and whose word it takes for it.
+ * <p>
+ * The absolute URLs in a response - download links, icons, the API URLs of an extension - are built
+ * from a base URL, and that base URL is derived per request from the {@code X-Forwarded-Host},
+ * {@code X-Forwarded-Proto} and {@code X-Forwarded-Prefix} headers. Those are just request headers:
+ * anything that can reach the server can set them, and the responses they end up in are cached under
+ * keys that do not include the host, so one forged request could serve attacker-chosen URLs to everyone
+ * else for the lifetime of the cache entry.
+ * <p>
+ * This holds the two settings that close that off, and {@link TrustedForwardedHeaderFilter} applies
+ * them.
+ */
+@Configuration
+public class ServerUrlConfig {
+
+    /**
+     * The absolute URL this registry is reachable at, e.g. {@code https://open-vsx.org}, or
+     * {@code https://example.com/openvsx} when it is served under a path.
+     * <p>
+     * Set this. It is the only setting that makes the base URL independent of the request: the
+     * {@code X-Forwarded-*} headers are then ignored entirely, whoever sends them and however the proxy
+     * in front is configured, and every node in a cluster agrees on what it emits.
+     * <p>
+     * Empty by default, which keeps the base URL derived from the request - correct only as far as
+     * {@code ovsx.server.trusted-proxies} is correct for the deployment.
+     * <p>
+     * Property: {@code ovsx.server.url}
+     * Default: empty - derive the base URL from the request
+     */
+    @Value("${ovsx.server.url:}")
+    String serverUrl;
+
+    /**
+     * The peers whose {@code X-Forwarded-Host}, {@code X-Forwarded-Proto} and {@code X-Forwarded-Prefix}
+     * headers are honoured, as IP addresses or CIDR ranges, comma separated. Only consulted when
+     * {@code ovsx.server.url} is empty.
+     * <p>
+     * Defaults to the loopback and private ranges - the same set Tomcat's {@code RemoteIpValve} trusts
+     * by default - because that is where a reverse proxy sits in a container or cluster deployment. A
+     * request arriving from anywhere else is a client talking to this server directly, and its forwarded
+     * headers are ignored.
+     * <p>
+     * Needs extending for a proxy that reaches this server from a public address; a cloud load
+     * balancer that is not on the same private network is the usual case. {@code *} restores the old
+     * behaviour of believing every peer, and is unsafe on anything reachable from the open web - prefer
+     * {@code ovsx.server.url}, which does not depend on where a request came from at all.
+     * <p>
+     * Property: {@code ovsx.server.trusted-proxies}
+     * Default: {@code 127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10}
+     */
+    @Value(
+        "${ovsx.server.trusted-proxies:"
+                + "127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10}"
+    )
+    String[] trustedProxies;
+
+    private @Nullable String scheme;
+    private @Nullable String hostAndPort;
+    private @Nullable String prefix;
+    private boolean trustEveryPeer;
+    private List<IpAddressMatcher> trustedProxyMatchers = List.of();
+
+    /**
+     * Registered first in the filter chain deliberately: it settles what the {@code X-Forwarded-*} headers
+     * say, and everything after it - the security chain included - sees the resolved values rather than
+     * whatever the client sent.
+     */
+    @Bean
+    public FilterRegistrationBean<TrustedForwardedHeaderFilter> trustedForwardedHeaderFilter() {
+        var registrationBean = new FilterRegistrationBean<TrustedForwardedHeaderFilter>();
+        registrationBean.setFilter(new TrustedForwardedHeaderFilter(this));
+        registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+
+        return registrationBean;
+    }
+
+    @PostConstruct
+    void init() {
+        if (StringUtils.isNotBlank(serverUrl)) {
+            var uri = parseServerUrl(serverUrl.trim());
+            scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+            hostAndPort = uri.getPort() == -1 ? uri.getHost() : uri.getHost() + ":" + uri.getPort();
+            prefix = StringUtils.stripEnd(StringUtils.defaultString(uri.getPath()), "/");
+        }
+
+        var matchers = new ArrayList<IpAddressMatcher>();
+        for (var proxy : trustedProxies) {
+            if (StringUtils.isBlank(proxy)) {
+                continue;
+            }
+
+            var trimmed = proxy.trim();
+            if (trimmed.equals("*")) {
+                trustEveryPeer = true;
+                continue;
+            }
+
+            try {
+                matchers.add(new IpAddressMatcher(trimmed));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalStateException(
+                        "ovsx.server.trusted-proxies contains '" + trimmed
+                                + "', which is not an IP address or CIDR range",
+                        e);
+            }
+        }
+
+        trustedProxyMatchers = List.copyOf(matchers);
+    }
+
+    private URI parseServerUrl(String value) {
+        URI uri;
+        try {
+            uri = new URI(value);
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("ovsx.server.url is not a valid URL: " + value, e);
+        }
+
+        if (!uri.isAbsolute() || uri.getHost() == null) {
+            throw new IllegalStateException("ovsx.server.url must be an absolute URL with a host: " + value);
+        }
+        // Only these two reach the URL builder in UrlUtil, and a base URL is a place to fetch from
+        // rather than a request of its own, so a query or a fragment on it is a configuration mistake.
+        var scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+        if (!scheme.equals("http") && !scheme.equals("https")) {
+            throw new IllegalStateException("ovsx.server.url must use http or https: " + value);
+        }
+        if (uri.getQuery() != null || uri.getFragment() != null) {
+            throw new IllegalStateException("ovsx.server.url must not have a query or a fragment: " + value);
+        }
+
+        return uri;
+    }
+
+    /**
+     * Whether the base URL is configured rather than derived from the request.
+     */
+    public boolean hasServerUrl() {
+        return scheme != null;
+    }
+
+    /**
+     * The scheme of {@code ovsx.server.url}, or {@code null} when it is not set.
+     */
+    public @Nullable String getScheme() {
+        return scheme;
+    }
+
+    /**
+     * The host of {@code ovsx.server.url}, with its port when that is not the scheme's default, or
+     * {@code null} when it is not set.
+     */
+    public @Nullable String getHostAndPort() {
+        return hostAndPort;
+    }
+
+    /**
+     * The path {@code ovsx.server.url} is served under - empty for a registry at the root of its host -
+     * or {@code null} when it is not set.
+     */
+    public @Nullable String getPrefix() {
+        return prefix;
+    }
+
+    /**
+     * Whether forwarded headers from {@code remoteAddr} are to be believed.
+     */
+    public boolean isTrustedProxy(@Nullable String remoteAddr) {
+        if (trustEveryPeer) {
+            return true;
+        }
+        if (StringUtils.isBlank(remoteAddr)) {
+            return false;
+        }
+
+        for (var matcher : trustedProxyMatchers) {
+            try {
+                if (matcher.matches(remoteAddr)) {
+                    return true;
+                }
+            } catch (IllegalArgumentException e) {
+                // Not an address we can compare - a hostname, or something Tomcat could not resolve to a
+                // literal. Nothing to trust it on.
+                return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/web/ServerUrlConfig.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/ServerUrlConfig.java
@@ -29,31 +29,15 @@ import org.springframework.core.Ordered;
 import org.springframework.security.web.util.matcher.IpAddressMatcher;
 
 /**
- * Where this registry believes it is reachable, and whose word it takes for it.
- * <p>
- * The absolute URLs in a response - download links, icons, the API URLs of an extension - are built
- * from a base URL, and that base URL is derived per request from the {@code X-Forwarded-Host},
- * {@code X-Forwarded-Proto} and {@code X-Forwarded-Prefix} headers. Those are just request headers:
- * anything that can reach the server can set them, and the responses they end up in are cached under
- * keys that do not include the host, so one forged request could serve attacker-chosen URLs to everyone
- * else for the lifetime of the cache entry.
- * <p>
- * This holds the two settings that close that off, and {@link TrustedForwardedHeaderFilter} applies
- * them.
+ * Where this registry is reachable, which the absolute URLs in a response are built from.
+ * {@link TrustedForwardedHeaderFilter} applies these settings; doc/configuration.md, Server URL says which
+ * to use for which deployment.
  */
 @Configuration
 public class ServerUrlConfig {
 
     /**
-     * The absolute URL this registry is reachable at, e.g. {@code https://open-vsx.org}, or
-     * {@code https://example.com/openvsx} when it is served under a path.
-     * <p>
-     * Set this. It is the only setting that makes the base URL independent of the request: the
-     * {@code X-Forwarded-*} headers are then ignored entirely, whoever sends them and however the proxy
-     * in front is configured, and every node in a cluster agrees on what it emits.
-     * <p>
-     * Empty by default, which keeps the base URL derived from the request - correct only as far as
-     * {@code ovsx.server.trusted-proxies} is correct for the deployment.
+     * When set, the base URL is this and the {@code X-Forwarded-*} headers are ignored entirely.
      * <p>
      * Property: {@code ovsx.server.url}
      * Default: empty - derive the base URL from the request
@@ -62,19 +46,9 @@ public class ServerUrlConfig {
     String serverUrl;
 
     /**
-     * The peers whose {@code X-Forwarded-Host}, {@code X-Forwarded-Proto} and {@code X-Forwarded-Prefix}
-     * headers are honoured, as IP addresses or CIDR ranges, comma separated. Only consulted when
-     * {@code ovsx.server.url} is empty.
-     * <p>
-     * Defaults to the loopback and private ranges - the same set Tomcat's {@code RemoteIpValve} trusts
-     * by default - because that is where a reverse proxy sits in a container or cluster deployment. A
-     * request arriving from anywhere else is a client talking to this server directly, and its forwarded
-     * headers are ignored.
-     * <p>
-     * Needs extending for a proxy that reaches this server from a public address; a cloud load
-     * balancer that is not on the same private network is the usual case. {@code *} restores the old
-     * behaviour of believing every peer, and is unsafe on anything reachable from the open web - prefer
-     * {@code ovsx.server.url}, which does not depend on where a request came from at all.
+     * The peers whose forwarded headers are read, as IP addresses or CIDR ranges. Only consulted when
+     * {@code ovsx.server.url} is empty. The default is the loopback and private ranges, the same set
+     * Tomcat's {@code RemoteIpValve} trusts; {@code *} reads them from every peer.
      * <p>
      * Property: {@code ovsx.server.trusted-proxies}
      * Default: {@code 127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10}
@@ -92,9 +66,7 @@ public class ServerUrlConfig {
     private List<IpAddressMatcher> trustedProxyMatchers = List.of();
 
     /**
-     * Registered first in the filter chain deliberately: it settles what the {@code X-Forwarded-*} headers
-     * say, and everything after it - the security chain included - sees the resolved values rather than
-     * whatever the client sent.
+     * First in the chain, so everything after it - the security chain included - sees resolved headers.
      */
     @Bean
     public FilterRegistrationBean<TrustedForwardedHeaderFilter> trustedForwardedHeaderFilter() {
@@ -163,39 +135,22 @@ public class ServerUrlConfig {
         return uri;
     }
 
-    /**
-     * Whether the base URL is configured rather than derived from the request.
-     */
     public boolean hasServerUrl() {
         return scheme != null;
     }
 
-    /**
-     * The scheme of {@code ovsx.server.url}, or {@code null} when it is not set.
-     */
     public @Nullable String getScheme() {
         return scheme;
     }
 
-    /**
-     * The host of {@code ovsx.server.url}, with its port when that is not the scheme's default, or
-     * {@code null} when it is not set.
-     */
     public @Nullable String getHostAndPort() {
         return hostAndPort;
     }
 
-    /**
-     * The path {@code ovsx.server.url} is served under - empty for a registry at the root of its host -
-     * or {@code null} when it is not set.
-     */
     public @Nullable String getPrefix() {
         return prefix;
     }
 
-    /**
-     * Whether forwarded headers from {@code remoteAddr} are to be believed.
-     */
     public boolean isTrustedProxy(@Nullable String remoteAddr) {
         if (trustEveryPeer) {
             return true;

--- a/server/src/main/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilter.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilter.java
@@ -1,0 +1,257 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.web;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Settles what the {@code X-Forwarded-Host}, {@code X-Forwarded-Proto} and {@code X-Forwarded-Prefix}
+ * headers say before anything reads them.
+ * <p>
+ * {@code UrlUtil.getBaseUrl} builds the absolute URLs in a response out of these three headers, and
+ * used to take whatever arrived. Since the responses are cached under keys that do not mention the host -
+ * and cannot easily be, because eviction enumerates exact keys - a single request carrying a forged
+ * {@code X-Forwarded-Host} could put attacker-chosen download and asset URLs into a shared cache entry
+ * and have them served to every other client until it expired.
+ * <p>
+ * Rewriting the headers here, rather than teaching each caller to be careful, is what makes that hold
+ * everywhere: {@code getBaseUrl} is read from about forty places, and this runs before the request
+ * reaches any of them.
+ * <p>
+ * Two rules, in this order:
+ * <ul>
+ * <li>With {@code ovsx.server.url} configured the headers are replaced by what it says, so the base URL
+ * is the same for every request and every node, whatever a client or a proxy claims.
+ * <li>Otherwise a header is honoured only from a peer in {@code ovsx.server.trusted-proxies}, and only
+ * its <em>last</em> value counts. A proxy that appends to the header instead of overwriting it leaves the
+ * client's own value in front, so the leftmost value can be attacker-supplied even when the immediate
+ * peer is trusted; the value written last is the one written by the proxy closest to this server.
+ * </ul>
+ */
+public class TrustedForwardedHeaderFilter extends OncePerRequestFilter {
+
+    static final String HOST = "X-Forwarded-Host";
+    static final String PROTO = "X-Forwarded-Proto";
+    static final String PREFIX = "X-Forwarded-Prefix";
+
+    private static final List<String> FORWARDED_HEADERS = List.of(HOST, PROTO, PREFIX);
+
+    private static final Logger logger = LoggerFactory.getLogger(TrustedForwardedHeaderFilter.class);
+
+    private final ServerUrlConfig config;
+    private final AtomicBoolean untrustedLogged = new AtomicBoolean();
+    private final AtomicBoolean appendedLogged = new AtomicBoolean();
+
+    public TrustedForwardedHeaderFilter(ServerUrlConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        chain.doFilter(resolveForwardedHeaders(request), response);
+    }
+
+    /**
+     * The wrapper has to be in place on an async or error dispatch as well, or a response rendered on one
+     * would go back to reading the headers as they arrived.
+     */
+    @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return false;
+    }
+
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return false;
+    }
+
+    private HttpServletRequest resolveForwardedHeaders(HttpServletRequest request) {
+        // A null value hides the header rather than setting it.
+        var resolved = new HashMap<String, @Nullable String>();
+        if (config.hasServerUrl()) {
+            resolved.put(HOST, config.getHostAndPort());
+            resolved.put(PROTO, config.getScheme());
+            resolved.put(PREFIX, configuredPrefix(request));
+        } else if (config.isTrustedProxy(request.getRemoteAddr())) {
+            resolved.put(HOST, lastValue(request, HOST));
+            resolved.put(PROTO, lastValue(request, PROTO));
+            // Not comma separated: a path may contain a comma, so only whole header lines are candidates.
+            resolved.put(PREFIX, lastLine(request, PREFIX));
+        } else {
+            FORWARDED_HEADERS.forEach(header -> resolved.put(header, null));
+            logUntrusted(request);
+        }
+
+        return new ForwardedHeaderRequest(request, resolved);
+    }
+
+    /**
+     * The configured path prefix, less the servlet context path when it is already part of it -
+     * {@code UrlUtil.getBaseUrl} appends the context path after the prefix, so leaving it in both would
+     * emit it twice.
+     */
+    private String configuredPrefix(HttpServletRequest request) {
+        var prefix = config.getPrefix();
+        if (prefix == null) {
+            return "";
+        }
+
+        var contextPath = request.getContextPath();
+        if (!contextPath.isEmpty() && prefix.endsWith(contextPath)) {
+            return prefix.substring(0, prefix.length() - contextPath.length());
+        }
+
+        return prefix;
+    }
+
+    /**
+     * The last non-blank comma separated value across every line of {@code header}, or {@code null} when
+     * it is absent.
+     */
+    private @Nullable String lastValue(HttpServletRequest request, String header) {
+        String last = null;
+        var lines = request.getHeaders(header);
+        var appended = false;
+        while (lines != null && lines.hasMoreElements()) {
+            for (var value : lines.nextElement().split(",")) {
+                var trimmed = value.trim();
+                if (!trimmed.isEmpty()) {
+                    appended = last != null;
+                    last = trimmed;
+                }
+            }
+        }
+
+        if (appended) {
+            logAppended(header);
+        }
+
+        return last;
+    }
+
+    /**
+     * The last non-blank line of {@code header}, or {@code null} when it is absent.
+     */
+    private @Nullable String lastLine(HttpServletRequest request, String header) {
+        String last = null;
+        var lines = request.getHeaders(header);
+        while (lines != null && lines.hasMoreElements()) {
+            var line = lines.nextElement().trim();
+            if (!line.isEmpty()) {
+                last = line;
+            }
+        }
+
+        return last;
+    }
+
+    private void logUntrusted(HttpServletRequest request) {
+        var present = FORWARDED_HEADERS.stream().anyMatch(header -> request.getHeader(header) != null);
+        if (present && untrustedLogged.compareAndSet(false, true)) {
+            logger.warn(
+                    "Ignoring the X-Forwarded-Host/-Proto/-Prefix headers of a request from {}, which is not"
+                            + " in ovsx.server.trusted-proxies. If a reverse proxy in front of this server"
+                            + " reaches it from that address, set ovsx.server.url to the URL this registry is"
+                            + " served at, or add the address to ovsx.server.trusted-proxies. Logged once.",
+                    request.getRemoteAddr());
+        }
+    }
+
+    private void logAppended(String header) {
+        if (appendedLogged.compareAndSet(false, true)) {
+            logger.warn(
+                    "A request carried more than one {} value, so the proxy in front of this server appends"
+                            + " to that header rather than overwriting it, and the values before the last one"
+                            + " may come from the client. Using the last. Set ovsx.server.url to take the base"
+                            + " URL out of the request entirely. Logged once.",
+                    header);
+        }
+    }
+
+    /**
+     * Reports the forwarded headers as resolved, whatever arrived.
+     */
+    private static class ForwardedHeaderRequest extends HttpServletRequestWrapper {
+
+        private final Map<String, @Nullable String> resolved;
+
+        ForwardedHeaderRequest(HttpServletRequest request, Map<String, @Nullable String> resolved) {
+            super(request);
+            var byLowerCaseName = new HashMap<String, @Nullable String>();
+            resolved.forEach((header, value) -> byLowerCaseName.put(header.toLowerCase(Locale.ROOT), value));
+            this.resolved = byLowerCaseName;
+        }
+
+        @Override
+        public @Nullable String getHeader(String name) {
+            var key = name.toLowerCase(Locale.ROOT);
+            return resolved.containsKey(key) ? resolved.get(key) : super.getHeader(name);
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(String name) {
+            var key = name.toLowerCase(Locale.ROOT);
+            if (!resolved.containsKey(key)) {
+                return super.getHeaders(name);
+            }
+
+            var value = resolved.get(key);
+            return value == null ? Collections.emptyEnumeration() : Collections.enumeration(List.of(value));
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            var names = new LinkedHashSet<String>();
+            var reported = new ArrayList<String>();
+            var original = super.getHeaderNames();
+            while (original != null && original.hasMoreElements()) {
+                var name = original.nextElement();
+                var key = name.toLowerCase(Locale.ROOT);
+                if (!resolved.containsKey(key)) {
+                    names.add(name);
+                } else if (resolved.get(key) != null) {
+                    names.add(name);
+                    reported.add(key);
+                }
+            }
+
+            resolved.forEach((key, value) -> {
+                if (value != null && !reported.contains(key)) {
+                    names.add(key);
+                }
+            });
+
+            return Collections.enumeration(names);
+        }
+    }
+}

--- a/server/src/main/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilter.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilter.java
@@ -34,28 +34,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * Settles what the {@code X-Forwarded-Host}, {@code X-Forwarded-Proto} and {@code X-Forwarded-Prefix}
- * headers say before anything reads them.
+ * Resolves {@code X-Forwarded-Host}, {@code X-Forwarded-Proto} and {@code X-Forwarded-Prefix} before
+ * anything reads them, so that the ~40 callers of {@code UrlUtil.getBaseUrl} cannot be handed a host
+ * the client chose - those responses are cached under keys that do not include it.
  * <p>
- * {@code UrlUtil.getBaseUrl} builds the absolute URLs in a response out of these three headers, and the
- * responses are cached under keys that do not mention the host - and cannot easily be, because eviction
- * enumerates exact keys. So a request carrying a forged {@code X-Forwarded-Host} that reached
- * {@code getBaseUrl} unchecked would put attacker-chosen download and asset URLs into a shared cache
- * entry, to be served to every other client until it expired.
- * <p>
- * Rewriting the headers here, rather than teaching each caller to be careful, is what makes that hold
- * everywhere: {@code getBaseUrl} is read from about forty places, and this runs before the request
- * reaches any of them.
- * <p>
- * Two rules, in this order:
- * <ul>
- * <li>With {@code ovsx.server.url} configured the headers are replaced by what it says, so the base URL
- * is the same for every request and every node, whatever a client or a proxy claims.
- * <li>Otherwise a header is honoured only from a peer in {@code ovsx.server.trusted-proxies}, and only
- * its <em>last</em> value counts. A proxy that appends to the header instead of overwriting it leaves the
- * client's own value in front, so the leftmost value can be attacker-supplied even when the immediate
- * peer is trusted; the value written last is the one written by the proxy closest to this server.
- * </ul>
+ * {@code ovsx.server.url} replaces the headers outright; otherwise they are read only from a peer in
+ * {@code ovsx.server.trusted-proxies}. See doc/configuration.md, Server URL.
  */
 public class TrustedForwardedHeaderFilter extends OncePerRequestFilter {
 
@@ -116,10 +100,9 @@ public class TrustedForwardedHeaderFilter extends OncePerRequestFilter {
     }
 
     /**
-     * The configured path prefix, less the servlet context path when it is already part of it -
-     * {@code UrlUtil.getBaseUrl} appends the context path after the prefix, so leaving it in both would
-     * emit it twice.
-     */
+      * {@code UrlUtil.getBaseUrl} appends the context path after the prefix, so a configured URL that
+      * already includes it would otherwise emit it twice.
+      */
     private String configuredPrefix(HttpServletRequest request) {
         var prefix = config.getPrefix();
         if (prefix == null) {
@@ -198,9 +181,6 @@ public class TrustedForwardedHeaderFilter extends OncePerRequestFilter {
         }
     }
 
-    /**
-     * Reports the forwarded headers as resolved, whatever arrived.
-     */
     private static class ForwardedHeaderRequest extends HttpServletRequestWrapper {
 
         private final Map<String, @Nullable String> resolved;

--- a/server/src/main/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilter.java
+++ b/server/src/main/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilter.java
@@ -37,11 +37,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * Settles what the {@code X-Forwarded-Host}, {@code X-Forwarded-Proto} and {@code X-Forwarded-Prefix}
  * headers say before anything reads them.
  * <p>
- * {@code UrlUtil.getBaseUrl} builds the absolute URLs in a response out of these three headers, and
- * used to take whatever arrived. Since the responses are cached under keys that do not mention the host -
- * and cannot easily be, because eviction enumerates exact keys - a single request carrying a forged
- * {@code X-Forwarded-Host} could put attacker-chosen download and asset URLs into a shared cache entry
- * and have them served to every other client until it expired.
+ * {@code UrlUtil.getBaseUrl} builds the absolute URLs in a response out of these three headers, and the
+ * responses are cached under keys that do not mention the host - and cannot easily be, because eviction
+ * enumerates exact keys. So a request carrying a forged {@code X-Forwarded-Host} that reached
+ * {@code getBaseUrl} unchecked would put attacker-chosen download and asset URLs into a shared cache
+ * entry, to be served to every other client until it expired.
  * <p>
  * Rewriting the headers here, rather than teaching each caller to be careful, is what makes that hold
  * everywhere: {@code getBaseUrl} is read from about forty places, and this runs before the request

--- a/server/src/test/java/org/eclipse/openvsx/web/ServerUrlConfigTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/ServerUrlConfigTest.java
@@ -1,0 +1,198 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.core.Ordered;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServerUrlConfigTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withInitializer(
+                    context -> context.getBeanFactory()
+                            .setConversionService(ApplicationConversionService.getSharedInstance()))
+            .withUserConfiguration(ServerUrlConfig.class);
+
+    @Test
+    void hasNoServerUrlByDefault() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(config(context).hasServerUrl()).isFalse();
+        });
+    }
+
+    @Test
+    void trustsTheLoopbackAndPrivateRangesByDefault() {
+        runner.run(context -> {
+            var config = config(context);
+            assertThat(config.isTrustedProxy("127.0.0.1")).isTrue();
+            assertThat(config.isTrustedProxy("::1")).isTrue();
+            assertThat(config.isTrustedProxy("10.4.3.2")).isTrue();
+            assertThat(config.isTrustedProxy("172.18.0.3")).isTrue();
+            assertThat(config.isTrustedProxy("192.168.1.20")).isTrue();
+            assertThat(config.isTrustedProxy("fd00::1")).isTrue();
+        });
+    }
+
+    @Test
+    void trustsNoPublicAddressByDefault() {
+        runner.run(context -> {
+            var config = config(context);
+            assertThat(config.isTrustedProxy("203.0.113.7")).isFalse();
+            assertThat(config.isTrustedProxy("8.8.8.8")).isFalse();
+            assertThat(config.isTrustedProxy("2001:db8::1")).isFalse();
+            // 172.32 is outside 172.16/12, and the neighbouring ranges are a classic off-by-one.
+            assertThat(config.isTrustedProxy("172.32.0.1")).isFalse();
+            assertThat(config.isTrustedProxy("11.0.0.1")).isFalse();
+        });
+    }
+
+    @Test
+    void trustsNothingItCannotCompare() {
+        runner.run(context -> {
+            var config = config(context);
+            assertThat(config.isTrustedProxy(null)).isFalse();
+            assertThat(config.isTrustedProxy("")).isFalse();
+            assertThat(config.isTrustedProxy("proxy.internal")).isFalse();
+        });
+    }
+
+    @Test
+    void splitsTheServerUrlIntoWhatTheForwardedHeadersWouldHaveSaid() {
+        runner.withPropertyValues("ovsx.server.url=https://open-vsx.org").run(context -> {
+            var config = config(context);
+            assertThat(config.hasServerUrl()).isTrue();
+            assertThat(config.getScheme()).isEqualTo("https");
+            assertThat(config.getHostAndPort()).isEqualTo("open-vsx.org");
+            assertThat(config.getPrefix()).isEmpty();
+        });
+    }
+
+    @Test
+    void keepsAPortAndAPathFromTheServerUrl() {
+        runner.withPropertyValues("ovsx.server.url=http://example.com:8080/openvsx").run(context -> {
+            var config = config(context);
+            assertThat(config.getScheme()).isEqualTo("http");
+            assertThat(config.getHostAndPort()).isEqualTo("example.com:8080");
+            assertThat(config.getPrefix()).isEqualTo("/openvsx");
+        });
+    }
+
+    @Test
+    void stripsATrailingSlashFromTheServerUrl() {
+        runner.withPropertyValues("ovsx.server.url=https://example.com/").run(context -> {
+            assertThat(config(context).getPrefix()).isEmpty();
+        });
+    }
+
+    @Test
+    void treatsABlankServerUrlAsUnset() {
+        runner.withPropertyValues("ovsx.server.url=   ").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(config(context).hasServerUrl()).isFalse();
+        });
+    }
+
+    @Test
+    void refusesToStartOnAServerUrlThatIsNotAbsolute() {
+        runner.withPropertyValues("ovsx.server.url=/openvsx")
+                .run(
+                        context -> assertThat(context).getFailure()
+                                .hasStackTraceContaining("ovsx.server.url must be an absolute URL with a host"));
+    }
+
+    @Test
+    void refusesToStartOnAServerUrlThatIsNotHttp() {
+        runner.withPropertyValues("ovsx.server.url=ftp://example.com")
+                .run(
+                        context -> assertThat(context).getFailure()
+                                .hasStackTraceContaining("ovsx.server.url must use http or https"));
+    }
+
+    @Test
+    void refusesToStartOnAServerUrlCarryingAQuery() {
+        runner.withPropertyValues("ovsx.server.url=https://example.com/openvsx?x=1")
+                .run(
+                        context -> assertThat(context).getFailure()
+                                .hasStackTraceContaining("must not have a query or a fragment"));
+    }
+
+    @Test
+    void refusesToStartOnATrustedProxyThatIsNotAnAddress() {
+        runner.withPropertyValues("ovsx.server.trusted-proxies=10.0.0.0/8,proxy.internal")
+                .run(
+                        context -> assertThat(context).getFailure()
+                                .hasStackTraceContaining(
+                                        "ovsx.server.trusted-proxies contains 'proxy.internal', which is not an IP"
+                                                + " address or CIDR range"));
+    }
+
+    @Test
+    void believesEveryPeerOnAStar() {
+        runner.withPropertyValues("ovsx.server.trusted-proxies=*").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(config(context).isTrustedProxy("203.0.113.7")).isTrue();
+        });
+    }
+
+    @Test
+    void trustsNobodyOnAnEmptyList() {
+        runner.withPropertyValues("ovsx.server.trusted-proxies=").run(context -> {
+            assertThat(context).hasNotFailed();
+            var config = config(context);
+            assertThat(config.isTrustedProxy("127.0.0.1")).isFalse();
+            assertThat(config.isTrustedProxy("10.0.0.1")).isFalse();
+        });
+    }
+
+    /**
+     * Nothing else may read the forwarded headers before they are resolved, and the filter has to be
+     * holding a configuration that is already initialized when it does.
+     */
+    @Test
+    void registersTheFilterFirstInTheChainOverAnInitializedConfiguration() {
+        runner.withPropertyValues("ovsx.server.url=https://openvsx.example").run(context -> {
+            assertThat(context).hasNotFailed();
+            var registration = context.getBean(FilterRegistrationBean.class);
+            assertThat(registration.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE);
+            assertThat(registration.getFilter()).isInstanceOf(TrustedForwardedHeaderFilter.class);
+
+            // The filter is handed the configuration from inside a proxied @Configuration class, so run a
+            // request through the registered instance rather than trust that it got an initialized one.
+            var request = new MockHttpServletRequest("GET", "/vscode/gallery/redhat/java/latest");
+            request.setRemoteAddr("10.0.0.5");
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "evil.attacker.example");
+            var filtered = new HttpServletRequest[1];
+            registration.getFilter()
+                    .doFilter(
+                            request,
+                            new MockHttpServletResponse(),
+                            (req, res) -> filtered[0] = (HttpServletRequest) req);
+
+            assertThat(filtered[0].getHeader(TrustedForwardedHeaderFilter.HOST)).isEqualTo("openvsx.example");
+        });
+    }
+
+    private ServerUrlConfig config(AssertableApplicationContext context) {
+        return context.getBean(ServerUrlConfig.class);
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilterIntegrationTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilterIntegrationTest.java
@@ -1,0 +1,97 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.web;
+
+import java.util.ArrayList;
+
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.servlet.RegistrationBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+
+import org.eclipse.openvsx.AbstractPostgresContainerTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The unit tests exercise the filter directly, which says nothing about whether the assembled chain
+ * puts it where it has to be. These run against a booted context over a real socket.
+ */
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = "ovsx.server.url=https://openvsx.example"
+)
+@AutoConfigureTestRestTemplate
+class TrustedForwardedHeaderFilterIntegrationTest extends AbstractPostgresContainerTest {
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    @Autowired
+    ApplicationContext context;
+
+    /**
+     * {@code /login-providers} answers with an absolute URL built from {@code UrlUtil.getBaseUrl}, so
+     * what it returns is what a forged header would have reached.
+     */
+    @Test
+    void aForgedHostDoesNotReachTheUrlsInAResponse() {
+        var headers = new HttpHeaders();
+        headers.add("X-Forwarded-Host", "evil.attacker.example");
+        headers.add("X-Forwarded-Proto", "https");
+        headers.add("X-Forwarded-Prefix", "/attacker-controlled");
+
+        var response = restTemplate
+                .exchange("/login-providers", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertThat(response.getBody())
+                .contains("https://openvsx.example/oauth2/authorization/")
+                .doesNotContain("evil.attacker.example")
+                .doesNotContain("attacker-controlled");
+    }
+
+    /**
+     * Everything the container ends up running, ordered the way Spring Boot orders it. A filter
+     * registered ahead of this one would read the headers as they arrived.
+     * <p>
+     * Strictly ahead: Boot registers its character encoding filter at the same order, and the two are
+     * therefore in no defined order relative to each other, which is harmless because it does not read
+     * these headers.
+     */
+    @Test
+    void nothingIsRegisteredAheadOfIt() {
+        var ours = context.getBean("trustedForwardedHeaderFilter", RegistrationBean.class);
+        var ahead = new ArrayList<String>();
+        context.getBeansOfType(RegistrationBean.class).forEach((name, bean) -> {
+            if (bean != ours && bean.getOrder() < ours.getOrder()) {
+                ahead.add(name + " at " + bean.getOrder());
+            }
+        });
+        context.getBeansOfType(Filter.class).forEach((name, filter) -> {
+            if (filter instanceof Ordered ordered && ordered.getOrder() < ours.getOrder()) {
+                ahead.add(name + " at " + ordered.getOrder());
+            }
+        });
+
+        assertThat(ahead).isEmpty();
+    }
+}

--- a/server/src/test/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilterTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilterTest.java
@@ -220,6 +220,52 @@ class TrustedForwardedHeaderFilterTest {
                 "ovsx.server.trusted-proxies=*");
     }
 
+    /**
+     * An IPv6 literal is bracketed and made of colons, so the port split has to look for one after
+     * the closing bracket rather than for the last colon in the value.
+     */
+    @Test
+    void keepsAnIpv6HostForwardedByATrustedProxyIntact() {
+        withDefaults(config -> {
+            var request = request(TRUSTED_PROXY, "server", 8080, "http");
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "[2001:db8::1]");
+            request.addHeader(TrustedForwardedHeaderFilter.PROTO, "https");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://[2001:db8::1]");
+        });
+    }
+
+    @Test
+    void keepsAnIpv6HostAndPortForwardedByATrustedProxyIntact() {
+        withDefaults(config -> {
+            var request = request(TRUSTED_PROXY, "server", 8080, "http");
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "[2001:db8::1]:8443");
+            request.addHeader(TrustedForwardedHeaderFilter.PROTO, "https");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://[2001:db8::1]:8443");
+        });
+    }
+
+    @Test
+    void aConfiguredServerUrlMayBeAnIpv6Literal() {
+        withConfig(
+                config -> {
+                    var request = request(UNTRUSTED_PEER, "server", 8080, "http");
+                    assertThat(baseUrl(request, config)).isEqualTo("https://[2001:db8::1]");
+                },
+                "ovsx.server.url=https://[2001:db8::1]");
+    }
+
+    @Test
+    void aConfiguredServerUrlMayBeAnIpv6LiteralWithAPort() {
+        withConfig(
+                config -> {
+                    var request = request(UNTRUSTED_PEER, "server", 8080, "http");
+                    assertThat(baseUrl(request, config)).isEqualTo("https://[2001:db8::1]:8443");
+                },
+                "ovsx.server.url=https://[2001:db8::1]:8443");
+    }
+
     @Test
     void hidesTheHeadersItIgnoresFromEveryWayOfReadingThem() {
         withDefaults(config -> {

--- a/server/src/test/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilterTest.java
+++ b/server/src/test/java/org/eclipse/openvsx/web/TrustedForwardedHeaderFilterTest.java
@@ -1,0 +1,318 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+package org.eclipse.openvsx.web;
+
+import java.util.Collections;
+import java.util.function.Consumer;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import org.eclipse.openvsx.util.UrlUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TrustedForwardedHeaderFilterTest {
+
+    /**
+     * A peer that is not a reverse proxy on a private network. Everything it claims about the host is a
+     * claim by a client, and the response it gets is the one that ends up in a shared cache entry.
+     */
+    private static final String UNTRUSTED_PEER = "203.0.113.7";
+
+    private static final String TRUSTED_PROXY = "10.0.0.5";
+
+    @Test
+    void derivesTheHostFromTheRequestWhenNothingIsForwarded() {
+        withDefaults(config -> {
+            var request = request(UNTRUSTED_PEER);
+            assertThat(baseUrl(request, config)).isEqualTo("https://openvsx.example");
+        });
+    }
+
+    @Test
+    void ignoresAForgedHostFromAnUntrustedPeer() {
+        withDefaults(config -> {
+            var request = request(UNTRUSTED_PEER);
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "evil.attacker.example");
+            request.addHeader(TrustedForwardedHeaderFilter.PROTO, "https");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://openvsx.example");
+        });
+    }
+
+    @Test
+    void ignoresAForgedPrefixFromAnUntrustedPeer() {
+        withDefaults(config -> {
+            var request = request(UNTRUSTED_PEER);
+            request.addHeader(TrustedForwardedHeaderFilter.PREFIX, "/attacker-controlled");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://openvsx.example");
+        });
+    }
+
+    /**
+     * {@code UrlUtil} rejects a scheme it cannot build a URL for by throwing, which on an unfiltered
+     * request made a header enough to turn any of these endpoints into a 500.
+     */
+    @Test
+    void ignoresAnUnsupportedSchemeFromAnUntrustedPeer() {
+        withDefaults(config -> {
+            var request = request(UNTRUSTED_PEER);
+            request.addHeader(TrustedForwardedHeaderFilter.PROTO, "ftp");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://openvsx.example");
+        });
+    }
+
+    @Test
+    void honoursTheHostForwardedByATrustedProxy() {
+        withDefaults(config -> {
+            var request = request(TRUSTED_PROXY, "server", 8080, "http");
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "openvsx.example");
+            request.addHeader(TrustedForwardedHeaderFilter.PROTO, "https");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://openvsx.example");
+        });
+    }
+
+    @Test
+    void honoursThePrefixForwardedByATrustedProxy() {
+        withDefaults(config -> {
+            var request = request(TRUSTED_PROXY, "server", 8080, "http");
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "example.com");
+            request.addHeader(TrustedForwardedHeaderFilter.PROTO, "https");
+            request.addHeader(TrustedForwardedHeaderFilter.PREFIX, "/openvsx");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://example.com/openvsx");
+        });
+    }
+
+    @Test
+    void honoursTheForwardedPort() {
+        withDefaults(config -> {
+            var request = request(TRUSTED_PROXY, "server", 8080, "http");
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "example.com:8443");
+            request.addHeader(TrustedForwardedHeaderFilter.PROTO, "https");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://example.com:8443");
+        });
+    }
+
+    /**
+     * The loopback default is what keeps a development setup, and a proxy on the same host, working
+     * without configuring anything.
+     */
+    @Test
+    void trustsLoopbackByDefault() {
+        withDefaults(config -> {
+            var request = request("127.0.0.1", "localhost", 8080, "http");
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "openvsx.example");
+            request.addHeader(TrustedForwardedHeaderFilter.PROTO, "https");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://openvsx.example");
+        });
+    }
+
+    /**
+     * A proxy that appends to the header rather than overwriting it leaves the client's own value in
+     * front of its own, so the first value is attacker-supplied even though the peer is trusted.
+     */
+    @Test
+    void takesTheLastValueWhenAProxyAppendsToTheHeader() {
+        withDefaults(config -> {
+            var request = request(TRUSTED_PROXY, "server", 8080, "http");
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "evil.attacker.example, openvsx.example");
+            request.addHeader(TrustedForwardedHeaderFilter.PROTO, "http, https");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://openvsx.example");
+        });
+    }
+
+    @Test
+    void takesTheLastValueWhenTheHeaderArrivesOnSeveralLines() {
+        withDefaults(config -> {
+            var request = request(TRUSTED_PROXY, "server", 8080, "http");
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "evil.attacker.example");
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "openvsx.example");
+            request.addHeader(TrustedForwardedHeaderFilter.PROTO, "https");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://openvsx.example");
+        });
+    }
+
+    /**
+     * A path may contain a comma, so the prefix is taken whole rather than as a list.
+     */
+    @Test
+    void doesNotSplitThePrefixOnCommas() {
+        withDefaults(config -> {
+            var request = request(TRUSTED_PROXY, "server", 8080, "http");
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "example.com");
+            request.addHeader(TrustedForwardedHeaderFilter.PROTO, "https");
+            request.addHeader(TrustedForwardedHeaderFilter.PREFIX, "/a,b");
+
+            assertThat(baseUrl(request, config)).isEqualTo("https://example.com/a,b");
+        });
+    }
+
+    @Test
+    void aConfiguredServerUrlOverridesEveryHeader() {
+        withConfig(
+                config -> {
+                    // From a trusted proxy, so only the configured URL can be what rules this out.
+                    var request = request(TRUSTED_PROXY, "server", 8080, "http");
+                    request.addHeader(TrustedForwardedHeaderFilter.HOST, "evil.attacker.example");
+                    request.addHeader(TrustedForwardedHeaderFilter.PROTO, "http");
+                    request.addHeader(TrustedForwardedHeaderFilter.PREFIX, "/attacker-controlled");
+
+                    assertThat(baseUrl(request, config)).isEqualTo("https://openvsx.example");
+                },
+                "ovsx.server.url=https://openvsx.example");
+    }
+
+    @Test
+    void aConfiguredServerUrlKeepsItsPathAndPort() {
+        withConfig(
+                config -> {
+                    var request = request(UNTRUSTED_PEER, "server", 8080, "http");
+                    assertThat(baseUrl(request, config)).isEqualTo("https://example.com:8443/openvsx");
+                },
+                "ovsx.server.url=https://example.com:8443/openvsx/");
+    }
+
+    @Test
+    void aConfiguredServerUrlAppliesWithoutAnyForwardedHeaders() {
+        withConfig(
+                config -> {
+                    var request = request(UNTRUSTED_PEER, "server", 8080, "http");
+                    assertThat(baseUrl(request, config)).isEqualTo("https://openvsx.example");
+                },
+                "ovsx.server.url=https://openvsx.example");
+    }
+
+    @Test
+    void aStarInTrustedProxiesBelievesEveryPeer() {
+        withConfig(
+                config -> {
+                    var request = request(UNTRUSTED_PEER, "server", 8080, "http");
+                    request.addHeader(TrustedForwardedHeaderFilter.HOST, "whatever.example");
+                    request.addHeader(TrustedForwardedHeaderFilter.PROTO, "https");
+
+                    assertThat(baseUrl(request, config)).isEqualTo("https://whatever.example");
+                },
+                "ovsx.server.trusted-proxies=*");
+    }
+
+    @Test
+    void hidesTheHeadersItIgnoresFromEveryWayOfReadingThem() {
+        withDefaults(config -> {
+            var request = request(UNTRUSTED_PEER);
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "evil.attacker.example");
+            request.addHeader("X-Real-Ip", "203.0.113.7");
+
+            var filtered = filter(request, config);
+            assertThat(filtered.getHeader("x-forwarded-host")).isNull();
+            assertThat(Collections.list(filtered.getHeaders(TrustedForwardedHeaderFilter.HOST))).isEmpty();
+            assertThat(Collections.list(filtered.getHeaderNames()))
+                    .doesNotContain(TrustedForwardedHeaderFilter.HOST)
+                    .contains("X-Real-Ip");
+        });
+    }
+
+    @Test
+    void leavesTheResolvedHeadersReadableAndOtherHeadersAlone() {
+        withDefaults(config -> {
+            var request = request(TRUSTED_PROXY);
+            request.addHeader(TrustedForwardedHeaderFilter.HOST, "evil.attacker.example, openvsx.example");
+            request.addHeader("X-Real-Ip", "203.0.113.7");
+
+            var filtered = filter(request, config);
+            assertThat(filtered.getHeader(TrustedForwardedHeaderFilter.HOST)).isEqualTo("openvsx.example");
+            assertThat(Collections.list(filtered.getHeaders("x-forwarded-host"))).containsExactly("openvsx.example");
+            assertThat(Collections.list(filtered.getHeaderNames()))
+                    .contains(TrustedForwardedHeaderFilter.HOST, "X-Real-Ip");
+            assertThat(filtered.getHeader("X-Real-Ip")).isEqualTo("203.0.113.7");
+        });
+    }
+
+    private MockHttpServletRequest request(String remoteAddr) {
+        return request(remoteAddr, "openvsx.example", 443, "https");
+    }
+
+    private MockHttpServletRequest request(String remoteAddr, String serverName, int port, String scheme) {
+        var request = new MockHttpServletRequest("GET", "/vscode/gallery/redhat/java/latest");
+        request.setRemoteAddr(remoteAddr);
+        request.setServerName(serverName);
+        request.setServerPort(port);
+        request.setScheme(scheme);
+
+        return request;
+    }
+
+    /**
+     * The base URL the endpoints would build, read the way they read it - off the bound request rather
+     * than from one passed around.
+     */
+    private String baseUrl(MockHttpServletRequest request, ServerUrlConfig config) {
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(filter(request, config)));
+        try {
+            return UrlUtil.getBaseUrl();
+        } finally {
+            RequestContextHolder.resetRequestAttributes();
+        }
+    }
+
+    private HttpServletRequest filter(MockHttpServletRequest request, ServerUrlConfig config) {
+        var filtered = new HttpServletRequest[1];
+        try {
+            new TrustedForwardedHeaderFilter(config)
+                    .doFilter(
+                            request,
+                            new MockHttpServletResponse(),
+                            (req, res) -> filtered[0] = (HttpServletRequest) req);
+        } catch (Exception e) {
+            throw new AssertionError("the filter itself failed", e);
+        }
+
+        assertThat(filtered[0]).as("the filter did not continue the chain").isNotNull();
+        return filtered[0];
+    }
+
+    private void withDefaults(Consumer<ServerUrlConfig> test) {
+        withConfig(test);
+    }
+
+    /**
+     * Binds {@link ServerUrlConfig} the way the application does, so the defaults under test are the ones
+     * that ship rather than a copy of them.
+     */
+    private void withConfig(Consumer<ServerUrlConfig> test, String... properties) {
+        new ApplicationContextRunner()
+                .withInitializer(
+                        context -> context.getBeanFactory()
+                                .setConversionService(ApplicationConversionService.getSharedInstance()))
+                .withUserConfiguration(ServerUrlConfig.class)
+                .withPropertyValues(properties)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    test.accept(context.getBean(ServerUrlConfig.class));
+                });
+    }
+}


### PR DESCRIPTION
Hardens how the server decides what URL it is served at, so that the absolute URLs in a response -
download links, icons, an extension's API URLs - cannot be chosen by the client that asked for them.

## Background

`UrlUtil.getBaseUrl` builds those URLs from the `X-Forwarded-Host`, `X-Forwarded-Proto` and
`X-Forwarded-Prefix` headers, falling back to `getServerName()`, and took all of them as they
arrived. The responses are cached under keys that do not include the host, so a forged host reaches
more than the request that sent it. Four caches hold values built this way: `extension.json`,
`namespace.details.json`, `latest.extension.version.vscode` and `sitemap`.

## What changes

- **`ovsx.server.url`** - the absolute URL the registry is served at. When set, the forwarded
  headers are ignored entirely, whoever sends them: the base URL stops depending on the request,
  every node in a cluster agrees on it, and the cache holds one entry per extension rather than one
  per host that was asked for. **This is the setting to use.**
- **`ovsx.server.trusted-proxies`** - the peers whose forwarded headers are read at all, defaulting
  to the loopback and private ranges, the same set Tomcat's `RemoteIpValve` trusts. Only consulted
  when `ovsx.server.url` is empty.

`TrustedForwardedHeaderFilter` runs first in the chain and resolves the three headers before
anything reads them, which covers the ~40 `getBaseUrl` call sites at one point and leaves every
cache key and eviction path untouched. Keying the caches on the base URL instead would have broken
eviction: `CacheService` evicts exact keys, enumerating every dimension, and a host dimension cannot
be enumerated.

## What it does not cover

Worth stating plainly, because the default is not airtight in every deployment shape:

| proxy behaviour | covered by the default |
|---|---|
| no proxy, server directly exposed | yes - the peer is untrusted, headers dropped |
| proxy overwrites `X-Forwarded-Host` | yes |
| proxy relays the client's header unchanged | **no** - a single-valued header from a trusted peer is indistinguishable from one the proxy wrote |
| chain of proxies appends | not exploitable, but the value taken is the innermost hop's, so URLs name an internal host |

And with the forwarded headers dropped, `getBaseUrl` falls back to `getServerName()`, i.e. the
`Host` header, which is equally the client's to choose. Nothing here configures Jetty virtual hosts.

The boundary between proxy-written and client-supplied values cannot be found from
`X-Forwarded-Host` itself: its elements are hostnames, not addresses that can be matched against a
list of proxies. Tomcat walks to that boundary for `X-Forwarded-For` for exactly that reason and
does not attempt it for the host - `hostHeader` is off by default there and used raw. Note also that
`server.forward-headers-strategy=native` is not a trusted-proxy mechanism on Jetty, which this runs
on: `ForwardedRequestCustomizer` has no `trustedProxies` or hop notion at all.

Setting `ovsx.server.url` closes all of it, which is why the documentation leads with it. An
`allowed-hosts` list - derive from the request but only ever emit a host on a configured list - was
written and set aside as a possible follow-up for deployments serving several hostnames.

## Upgrade notes

A deployment whose proxy reaches the server from a **public** address starts emitting internal-host
URLs until it sets `ovsx.server.url` or extends `trusted-proxies`; a warning names both. Caches
should be flushed after deploying. `X-Forwarded-Proto: ftp` from an untrusted peer also stops
producing a 500.

## Documentation

The properties check added in #2193 caught both new properties as undocumented, which is what it is
for. The reference gains a **Server URL** section next to Web UI, because `ovsx.webui.url` is the
setting someone reaches for by mistake - the same host in the usual deployment, but the *upstream*
registry in a mirror.

The NGINX example in the deployment guide forwarded `X-Forwarded-Host $host`. That is the Host
header the client sent, and the guide has you make this the only enabled site, so it is the default
server for the port and a request naming any host reaches it. It now forwards a literal.

## Tests

32 tests, all binding `ServerUrlConfig` through `ApplicationContextRunner` so the defaults under
test are the ones that ship. Neutering the filter fails **10 of the 17** filter tests; the 7 that
pass are the "legitimate proxy deployments keep working" ones. `./gradlew test` passes in full
(1249 tests, Testcontainers included) and `spotlessCheck` is clean.

Prepared with Claude Code.
