### PR TITLE
fix(webui): add fixed height to footer rating

### DIFF
--- a/webui/CHANGELOG.md
+++ b/webui/CHANGELOG.md
@@ -25,6 +25,7 @@ This change log covers only the frontend library (webui) of Open VSX.
 - **Breaking:** `elements.claimNamespace` now receives `{ namespace, extension?, sx? }` instead of `{ extension, sx? }`. The namespace settings page offers the same claim action and has no extension to pass, so implementations must read the namespace from `namespace` rather than `extension.namespace`
 - Publishing goes through TanStack Query: `publishExtension` and `createNamespace` are mutation hooks (`usePublishExtension`, `useCreateNamespace`), and both service methods lose their `AbortController` parameter — writes are no longer aborted, and retries are the query client's to own. The user's extension list is a query too (`useUserExtensions`), read by the settings tab and by the publish queue as it follows a package, so a card appears in the list as soon as the registry has the package
 - `ExtensionCard` accepts an `Extension` as well as a `SearchEntry`, and takes optional `to`, `linkState`, `overlay`, `footerStart`, `dimmed`, `tone` and `iconPending` props so other surfaces can reuse it instead of copying it
+- Show an extension card's rating as one star and the score rather than five stars, and no rating at all on an extension nobody has reviewed. Five icons could not shrink, so beside a long download count the count spilled out of the card
 
 ### Added
 

--- a/webui/src/components/extension-card.tsx
+++ b/webui/src/components/extension-card.tsx
@@ -91,6 +91,9 @@ const CardFooterRating: FunctionComponent<{ children?: ReactNode; placeholder?: 
             display: 'flex',
             alignItems: 'center',
             gap: '0.1875rem',
+            // Taller than a star or a line of the score, so the footer's rule sits at the same
+            // height whether the cell has a score in it or not.
+            height: '1.25rem',
             minWidth: 0,
             flexShrink: 1,
             overflow: 'hidden',
@@ -105,8 +108,7 @@ const CardFooterRating: FunctionComponent<{ children?: ReactNode; placeholder?: 
 );
 
 // Only the unknown parts are skeletons. The rating cell keeps a greyed star beside a placeholder
-// bar so the footer reserves the footprint a rated card will need; a card that turns out to have
-// no reviews shows no rating at all, so for those the row does still settle once loaded.
+// bar so the footer shows the shape a rated card will have.
 const SkeletonContent: FunctionComponent = () => (
     <>
         <Skeleton variant='rounded' width={54} height={54} sx={{ flexShrink: 0, mb: '0.75rem' }} />


### PR DESCRIPTION
After the change we introduced to the rating to prevent download counts from overflowing we introduced a visual bug where for extensions for no reviews there will be a different space on the extension card footer 

<img width="1437" height="356" alt="image" src="https://github.com/user-attachments/assets/03cf484f-7cc2-48d0-87ec-40aa002b1360" />

This PR fixes it by fixing that height so that even if the review count is not present the height of the footer will remain the same 

<img width="1372" height="343" alt="image" src="https://github.com/user-attachments/assets/d0d6a308-9c83-454d-ba6f-e7ca8078e7fe" />
